### PR TITLE
Code review must-fixes: async/sync runtime, serialization, replay, diagnostics

### DIFF
--- a/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
+++ b/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using NxGraph.Authoring;
+using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
 
 namespace NxGraph.Serialization.Tests;
@@ -160,6 +161,26 @@ public class GraphSerializerTestsTextCodec
 
         using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
         Assert.ThrowsAsync<InvalidOperationException>(async () => await _serializer.FromJsonAsync(source));
+    }
+
+    [Test]
+    public void Serializer_rejects_payloads_exceeding_subgraph_depth_cap()
+    {
+        // Build a chain of nested AsyncStateMachines deeper than MaxSubGraphDepth (64).
+        // The cap exists to prevent stack-overflow on untrusted/deeply nested input.
+        AsyncStateMachine current = GraphBuilder
+            .StartWithAsync(new DummyState { Data = "leaf" })
+            .ToAsyncStateMachine();
+        for (int i = 0; i < 100; i++)
+        {
+            current = GraphBuilder
+                .StartWithAsync(current)
+                .ToAsyncStateMachine();
+        }
+
+        using MemoryStream stream = new();
+        Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _serializer.ToBinaryAsync(current.Graph, stream));
     }
 
     [Test]

--- a/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
+++ b/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
@@ -114,6 +114,55 @@ public class GraphSerializerTestsTextCodec
     }
 
     [Test]
+    public void FromJsonAsync_rejects_payload_with_duplicate_node_indices()
+    {
+        // Two nodes both claiming index 0 — would otherwise overwrite a slot and lose routing.
+        // The logic field carries a JSON-encoded DummyState so the codec doesn't throw before
+        // the duplicate-index check fires on the second iteration.
+        const string logic = "\"{\\\"Data\\\":\\\"x\\\"}\"";
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": {{logic}} },
+                { "$type": "txt", "index": 0, "name": "b", "logic": {{logic}} }
+              ],
+              "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+              "subGraphs": [],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _serializer.FromJsonAsync(source));
+        Assert.That(ex!.Message, Does.Contain("duplicated"));
+    }
+
+    [Test]
+    public void FromJsonAsync_rejects_payload_with_out_of_range_node_index()
+    {
+        // Index 5 in a 1-node payload — would have corrupted routing under the old code.
+        const string logic = "\"{\\\"Data\\\":\\\"x\\\"}\"";
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 5, "name": "a", "logic": {{logic}} }
+              ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await _serializer.FromJsonAsync(source));
+    }
+
+    [Test]
     public async Task Streams_are_left_open_after_json_helpers()
     {
         Graph graph = BuildChain("a", "b");

--- a/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
+++ b/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using NxGraph.Authoring;
 using NxGraph.Graphs;
 
@@ -79,6 +80,37 @@ public class GraphSerializerTestsTextCodec
         Assert.ThrowsAsync<ArgumentNullException>(async () =>
             await _serializer.FromBinaryAsync(source: null!));
         // ReSharper restore NullableWarningSuppressionIsUsed
+    }
+
+    [Test]
+    public async Task Json_payload_includes_serialization_version()
+    {
+        Graph graph = BuildChain("only");
+
+        await using MemoryStream stream = new();
+        await _serializer.ToJsonAsync(graph, stream);
+        string json = Encoding.UTF8.GetString(stream.ToArray());
+
+        Assert.That(json, Does.Contain($"\"version\": {SerializationVersion.Version}"));
+    }
+
+    [Test]
+    public void FromJsonAsync_rejects_payload_with_newer_version()
+    {
+        // Hand-rolled JSON with a version one ahead of what the serializer supports.
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version + 1}},
+              "nodes": [],
+              "transitions": [],
+              "subGraphs": [],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await _serializer.FromJsonAsync(source));
     }
 
     [Test]

--- a/NxGraph.Serialization/GraphDto.cs
+++ b/NxGraph.Serialization/GraphDto.cs
@@ -21,7 +21,13 @@ internal sealed class GraphDto
         Index = index;
     }
 
-    public static int Version => SerializationVersion.Version;
+    /// <summary>
+    /// Serialized payload version. Defaults to <see cref="SerializationVersion.Version"/> for
+    /// freshly-constructed DTOs so the JSON/MessagePack writers emit a version on the wire,
+    /// and is overwritten by the deserializer when reading an existing payload so callers can
+    /// detect version mismatches.
+    /// </summary>
+    public int Version { get; set; } = SerializationVersion.Version;
 
     public INodeDto[] Nodes { get; set; }
     public TransitionDto[] Transitions { get; set; }

--- a/NxGraph.Serialization/GraphDtoFormatter.cs
+++ b/NxGraph.Serialization/GraphDtoFormatter.cs
@@ -13,7 +13,7 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
     {
         // [0.Version 1.Index, 2.Name, 3.Nodes[], 4.Transitions[], 5.SubGraphs[]]
         writer.WriteArrayHeader(VersionOneHeaderCount);
-        writer.Write(GraphDto.Version);
+        writer.Write(value.Version);
         writer.Write(value.Index);
         writer.Write(value.Name);
         options.Resolver.GetFormatterWithVerify<INodeDto[]>().Serialize(ref writer, value.Nodes, options);
@@ -44,6 +44,6 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
             options.Resolver.GetFormatterWithVerify<SubGraphDto[]>().Deserialize(ref reader, options);
 
 
-        return new GraphDto(nodes, transitions, subGraphs, index, name);
+        return new GraphDto(nodes, transitions, subGraphs, index, name) { Version = version };
     }
 }

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -194,12 +194,16 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         var textCodec = _codec as ILogicCodec<string>;
 
         INode[] nodes = new INode[nodesLength];
+        bool[] slotFilled = new bool[nodesLength];
         for (int index = 0; index < nodesLength; index++)
         {
             INodeDto nodeDto = dto.Nodes[index];
             if (nodeDto.Index < 0 || nodeDto.Index >= nodesLength)
                 throw new InvalidOperationException(
                     $"Node DTO index {nodeDto.Index} is out of range (0..{nodesLength - 1}).");
+            if (slotFilled[nodeDto.Index])
+                throw new InvalidOperationException(
+                    $"Node DTO index {nodeDto.Index} is duplicated in the payload.");
 
             switch (nodeDto)
             {
@@ -217,7 +221,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
 
                 {
                     IAsyncLogic asyncLogic = textCodec.Deserialize(textDto.Logic);
-                    nodes[nodeDto.Index] = new LogicNode(new NodeId(index, textDto.Name), asyncLogic);
+                    nodes[nodeDto.Index] = new LogicNode(new NodeId(nodeDto.Index, textDto.Name), asyncLogic);
                 }
                     break;
 
@@ -227,13 +231,24 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                             "GraphSerializer has no ILogicCodec<ReadOnlyMemory<byte>> configured, cannot decode binary nodes.");
                 {
                     IAsyncLogic binAsyncLogic = binaryCodec.Deserialize(binaryDto.Logic);
-                    nodes[nodeDto.Index] = new LogicNode(new NodeId(index, binaryDto.Name), binAsyncLogic);
+                    nodes[nodeDto.Index] = new LogicNode(new NodeId(nodeDto.Index, binaryDto.Name), binAsyncLogic);
                 }
                     break;
 
                 default:
                     throw new InvalidOperationException($"Unknown node DTO type: {nodeDto.GetType().FullName}");
             }
+
+            slotFilled[nodeDto.Index] = true;
+        }
+
+        // Reject payloads with gaps. With nodesLength items and no duplicates already
+        // enforced above, a single unfilled slot means the payload skipped an index
+        // — corrupt routing if we proceeded.
+        for (int i = 0; i < nodesLength; i++)
+        {
+            if (!slotFilled[i])
+                throw new InvalidOperationException($"Node DTO payload is missing entry for index {i}.");
         }
 
         Dictionary<int, Graph> ownerToSubGraph = new();

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -12,6 +12,11 @@ namespace NxGraph.Serialization;
 
 public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializer
 {
+    // Limits subgraph recursion in ToDto/FromDto. A deeper nesting in a payload almost
+    // certainly indicates a malicious or corrupt input rather than a real graph; without
+    // the cap an attacker can stack-overflow the deserializer with a deeply nested payload.
+    internal const int MaxSubGraphDepth = 64;
+
     private readonly ILogicCodec _codec;
     private readonly MessagePackSerializerOptions _options;
 
@@ -28,7 +33,12 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             ]
         );
         _codec = codec;
-        _options = MessagePackSerializerOptions.Standard.WithResolver(resolver);
+        // UntrustedData enables MessagePack-CSharp's hardening against pathological inputs
+        // (collection size caps, hash-collision DoS guards, etc.). Required because graph
+        // payloads can come from disk or the network — both are untrusted boundaries.
+        _options = MessagePackSerializerOptions.Standard
+            .WithSecurity(MessagePackSecurity.UntrustedData)
+            .WithResolver(resolver);
         _jsonOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -120,9 +130,16 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         return FromDto(dto);
     }
 
-    private GraphDto ToDto(Graph graph)
+    private GraphDto ToDto(Graph graph) => ToDto(graph, depth: 0);
+
+    private GraphDto ToDto(Graph graph, int depth)
     {
         ArgumentNullException.ThrowIfNull(graph);
+        if (depth > MaxSubGraphDepth)
+        {
+            throw new InvalidOperationException(
+                $"Subgraph nesting exceeded MaxSubGraphDepth ({MaxSubGraphDepth}) while serializing.");
+        }
         if (_codec is NullLogicCodec)
         {
             throw new InvalidOperationException("No ILogicCodec configured in GraphSerializer.");
@@ -149,7 +166,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     if (logicNode.AsyncLogic is AsyncStateMachine stateMachine)
                     {
                         // Serialize state machine as sub-graph
-                        GraphDto childDto = ToDto(stateMachine.Graph);
+                        GraphDto childDto = ToDto(stateMachine.Graph, depth + 1);
                         subGraphs.Add(new SubGraphDto(index, childDto));
                         nodes[index] = new NodeTextDto(index, node.Id.Name, LogicNode.StateMachineMarker.Id.Name);
                         break;
@@ -173,7 +190,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     break;
                 case Graph childGraph:
                 {
-                    GraphDto childDto = ToDto(childGraph);
+                    GraphDto childDto = ToDto(childGraph, depth + 1);
                     subGraphs.Add(new SubGraphDto(index, childDto));
                     break;
                 }
@@ -183,9 +200,16 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         return new GraphDto(nodes, transitions, subGraphs.ToArray(), graph.Id.Index, graph.Id.Name);
     }
 
-    private Graph FromDto(GraphDto dto)
+    private Graph FromDto(GraphDto dto) => FromDto(dto, depth: 0);
+
+    private Graph FromDto(GraphDto dto, int depth)
     {
         ArgumentNullException.ThrowIfNull(dto);
+        if (depth > MaxSubGraphDepth)
+        {
+            throw new InvalidOperationException(
+                $"Subgraph nesting exceeded MaxSubGraphDepth ({MaxSubGraphDepth}) while deserializing.");
+        }
 
         int nodesLength = dto.Nodes.Length;
         if (nodesLength == 0) throw new InvalidOperationException("GraphDto must contain at least one node.");
@@ -261,7 +285,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                 throw new InvalidOperationException(
                     $"Subgraph DTO owner index {subDto.OwnerIndex} is out of range (0..{nodesLength - 1}).");
 
-            Graph childGraph = FromDto(subDto.Graph);
+            Graph childGraph = FromDto(subDto.Graph, depth + 1);
             if (nodes[subDto.OwnerIndex] == LogicNode.StateMachineMarker)
             {
                 ownerToSubGraph[subDto.OwnerIndex] = childGraph;

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -88,6 +88,16 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         GraphDto dto = JsonSerializer.Deserialize<GraphDto>(json, _jsonOptions) ??
                        throw new InvalidOperationException("Failed to parse Graph JSON.");
 
+        // Match the version-check behaviour of GraphDtoFormatter (MessagePack path). Future
+        // versions are rejected; matching versions pass through. Lower versions are accepted
+        // for forward compatibility (older payloads remain readable when the format adds
+        // optional fields), so only the strict-greater check fires here.
+        if (dto.Version > SerializationVersion.Version)
+        {
+            throw new InvalidOperationException(
+                $"GraphDto: JSON payload version {dto.Version} is newer than serializer version {SerializationVersion.Version}.");
+        }
+
         return FromDto(dto);
     }
 

--- a/NxGraph.Serialization/NodeDtoFormatter.cs
+++ b/NxGraph.Serialization/NodeDtoFormatter.cs
@@ -8,13 +8,18 @@ internal sealed class NodeDtoFormatter : GraphEntityFormatter<INodeDto>
 {
     public static readonly NodeDtoFormatter Instance = new();
 
+    // The wire format is a 4-element array: [0.Type, 1.Index, 2.Name, 3.Logic]. Earlier
+    // revisions of this formatter wrote a 3-element header but four elements, which only
+    // round-tripped because the matching reader read past the declared header — a strict
+    // MessagePack reader would have desynchronized the stream after position 2.
+    private const int ArrayElementCount = 4;
+
     public override void Serialize(ref MessagePackWriter writer, INodeDto value, MessagePackSerializerOptions options)
     {
-        // [0.Type, 1.Index, 2.Name, 3.Logic]
         switch (value)
         {
             case NodeTextDto t:
-                writer.WriteArrayHeader(3);
+                writer.WriteArrayHeader(ArrayElementCount);
                 writer.Write(0); // 0.Type discriminator for text node
                 writer.Write(t.Index); //1.Index
                 writer.Write(t.Name); //2.Name
@@ -22,7 +27,7 @@ internal sealed class NodeDtoFormatter : GraphEntityFormatter<INodeDto>
                 break;
 
             case NodeBinaryDto b:
-                writer.WriteArrayHeader(3);
+                writer.WriteArrayHeader(ArrayElementCount);
                 writer.Write(1); // Type discriminator for binary node
                 writer.Write(b.Index);
                 writer.Write(b.Name);
@@ -37,7 +42,8 @@ internal sealed class NodeDtoFormatter : GraphEntityFormatter<INodeDto>
     public override INodeDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
     {
         int count = reader.ReadArrayHeader();
-        if (count != 3) throw new InvalidOperationException($"INodeDto: expected 3, got {count}");
+        if (count != ArrayElementCount)
+            throw new InvalidOperationException($"INodeDto: expected {ArrayElementCount}, got {count}");
 
         int type = reader.ReadInt32(); // 0.Type (0 = text, 1 = binary)
         int index = reader.ReadInt32(); // 1.index

--- a/NxGraph.Tests/AgentPropagationTests.cs
+++ b/NxGraph.Tests/AgentPropagationTests.cs
@@ -42,4 +42,33 @@ public class AgentPropagationTests
 
         Assert.Throws<InvalidOperationException>(() => fsm.SetAgent(agent));
     }
+
+    [Test]
+    public async Task agent_should_propagate_into_nested_non_generic_async_state_machine()
+    {
+        // Regression: a plain (non-generic) AsyncStateMachine embedded as a node previously
+        // did not have its inner graph walked by Graph.SetAgent because it doesn't
+        // implement IAgentSettable<TAgent> directly. The inner IAgentSettable<DummyAgent>
+        // would silently miss the agent and fail at execution time.
+        AsyncRelayState<DummyAgent> innerLeaf = new((a, _) =>
+        {
+            a.Visited = true;
+            return ResultHelpers.Success;
+        });
+
+        AsyncStateMachine innerMachine = GraphBuilder
+            .StartWithAsync(innerLeaf)
+            .ToAsyncStateMachine();
+
+        AsyncStateMachine<DummyAgent> outerMachine = GraphBuilder
+            .StartWithAsync(innerMachine)
+            .ToAsyncStateMachine<DummyAgent>();
+
+        DummyAgent agent = new();
+        outerMachine.SetAgent(agent);
+
+        await outerMachine.ExecuteAsync();
+
+        Assert.That(agent.Visited, Is.True);
+    }
 }

--- a/NxGraph.Tests/GraphValidatorTests.cs
+++ b/NxGraph.Tests/GraphValidatorTests.cs
@@ -140,4 +140,37 @@ public class GraphValidatorTests
             Assert.That(res.HasErrors, Is.False, "Lack of AllNodes should not produce validation errors.");
         });
     }
+
+    [Test]
+    public void Validator_follows_choice_director_branches_for_reachability()
+    {
+        // Regression: the validator previously stopped at director nodes (TryGetTransition
+        // returns Empty), so nodes only reachable via a director branch were flagged
+        // unreachable. EnumerateStaticTargets exposes those branches to the BFS.
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success), isStart: true);
+        NodeId trueBranch = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success));
+        NodeId falseBranch = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success));
+        NodeId choice = builder.AddNode(new ChoiceState(() => true, trueBranch, falseBranch));
+
+        builder.AddTransition(start, choice);
+
+        Graph graph = builder.Build(throwOnError: false);
+
+        GraphValidationResult res = graph.Validate(new GraphValidationOptions
+            { AllNodes = builder.GetAllNodeIds() });
+
+        bool trueBranchFlagged = res.Diagnostics.Any(d =>
+            d.Node.Index == trueBranch.Index &&
+            d.Message.Contains("unreachable", StringComparison.OrdinalIgnoreCase));
+        bool falseBranchFlagged = res.Diagnostics.Any(d =>
+            d.Node.Index == falseBranch.Index &&
+            d.Message.Contains("unreachable", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(trueBranchFlagged, Is.False, "True branch is reachable via director — should not be flagged.");
+            Assert.That(falseBranchFlagged, Is.False, "False branch is reachable via director — should not be flagged.");
+        });
+    }
 }

--- a/NxGraph.Tests/ReplayTests.cs
+++ b/NxGraph.Tests/ReplayTests.cs
@@ -304,4 +304,58 @@ public class ReplayTests
             return Result.Success;
         }
     }
+
+    [Test]
+    public void Deserialize_rejects_payload_without_magic_header()
+    {
+        // Payload starts with the old format (4-byte count = 0, no events). Without the
+        // magic header it must be rejected — silently accepting it would lock in the
+        // unsafe pre-magic format.
+        using MemoryStream ms = new();
+        using BinaryWriter writer = new(ms);
+        writer.Write(0);
+        Assert.Throws<InvalidDataException>(() => StateMachineReplay.Deserialize(ms.ToArray()));
+    }
+
+    [Test]
+    public void Deserialize_rejects_payload_with_unknown_version()
+    {
+        using MemoryStream ms = new();
+        using BinaryWriter writer = new(ms);
+        writer.Write("NXRP"u8.ToArray());
+        writer.Write((byte)99); // version
+        writer.Write(0); // count
+        Assert.Throws<InvalidDataException>(() => StateMachineReplay.Deserialize(ms.ToArray()));
+    }
+
+    [Test]
+    public void Deserialize_rejects_payload_with_implausibly_large_count()
+    {
+        // count = int.MaxValue would cause `new ReplayEvent[count]` to OOM. The bound on
+        // count vs remaining bytes catches this immediately.
+        using MemoryStream ms = new();
+        using BinaryWriter writer = new(ms);
+        writer.Write("NXRP"u8.ToArray());
+        writer.Write((byte)1); // version
+        writer.Write(int.MaxValue); // count
+        // No events follow.
+        Assert.Throws<InvalidDataException>(() => StateMachineReplay.Deserialize(ms.ToArray()));
+    }
+
+    [Test]
+    public void Deserialize_rejects_payload_with_unknown_event_type_byte()
+    {
+        using MemoryStream ms = new();
+        using BinaryWriter writer = new(ms);
+        writer.Write("NXRP"u8.ToArray());
+        writer.Write((byte)1); // version
+        writer.Write(1); // count
+        writer.Write((byte)200); // bogus EventType
+        // Pad to satisfy the min-size bound check (count=1 needs >=15 bytes remaining).
+        writer.Write(0); // source idx
+        writer.Write(false); // has-target
+        writer.Write(0L); // timestamp
+        writer.Write(string.Empty); // message
+        Assert.Throws<InvalidDataException>(() => StateMachineReplay.Deserialize(ms.ToArray()));
+    }
 }

--- a/NxGraph.Tests/ReplayTests.cs
+++ b/NxGraph.Tests/ReplayTests.cs
@@ -306,6 +306,49 @@ public class ReplayTests
     }
 
     [Test]
+    public void Sync_state_machine_records_replay_events_via_recorder()
+    {
+        ReplayRecorder recorder = new();
+        StateMachine fsm = GraphBuilder
+            .StartWith(() => Result.Success)
+            .To(() => Result.Success)
+            .ToStateMachine(recorder);
+
+        // Run to completion — sync machine ticks via Execute().
+        Result r;
+        do { r = fsm.Execute(); } while (r == Result.Continue);
+
+        ReadOnlyMemory<ReplayEvent> events = recorder.GetEvents();
+        Assert.Multiple(() =>
+        {
+            Assert.That(events.Length, Is.GreaterThan(0));
+            Assert.That(events.ToArray().Any(e => e.Type == EventType.StateMachineStarted), Is.True);
+            Assert.That(events.ToArray().Any(e => e.Type == EventType.StateMachineCompleted), Is.True);
+        });
+    }
+
+    [Test]
+    public void Recorder_DroppedCount_increments_when_ring_overflows()
+    {
+        ReplayRecorder recorder = new(capacity: 4);
+        StateMachine fsm = GraphBuilder
+            .StartWith(() => Result.Success)
+            .To(() => Result.Success)
+            .To(() => Result.Success)
+            .To(() => Result.Success)
+            .ToStateMachine(recorder);
+        // Auto-restart is on by default, which would loop forever. Keep deterministic by
+        // disabling auto-reset and only running once.
+        fsm.SetResetPolicy(RestartPolicy.Manual);
+
+        Result r;
+        do { r = fsm.Execute(); } while (r == Result.Continue);
+
+        Assert.That(recorder.DroppedCount, Is.GreaterThan(0),
+            "A four-node sync machine emits more than four events; ring of size 4 must have dropped some.");
+    }
+
+    [Test]
     public void Deserialize_rejects_payload_without_magic_header()
     {
         // Payload starts with the old format (4-byte count = 0, no events). Without the

--- a/NxGraph.Tests/SwitchDefaultCaseTests.cs
+++ b/NxGraph.Tests/SwitchDefaultCaseTests.cs
@@ -25,4 +25,48 @@ public class SwitchDefaultCaseTests
         Result result = await fsm.ExecuteAsync();
         Assert.That(result, Is.EqualTo(Result.Success));
     }
+
+    [Test]
+    public async Task async_switch_without_default_should_terminate_when_no_case_matches()
+    {
+        // Regression: previously AsyncSwitchState defaulted _defaultNode to default(NodeId)
+        // (index 0 = Start) so a no-match case silently looped to Start instead of
+        // exiting cleanly. The fix routes the no-default case through NodeId.Default,
+        // which the async runtime treats as terminal success.
+        const string key = "nope";
+
+        AsyncStateMachine fsm = GraphBuilder
+            .Start()
+            .Switch(() => key)
+            .CaseAsync("a", _ => ResultHelpers.Failure)
+            .CaseAsync("b", _ => ResultHelpers.Failure)
+            .End()
+            .ToAsyncStateMachine();
+
+        Result result = await fsm.ExecuteAsync();
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
+
+    [Test]
+    public void sync_switch_without_default_should_terminate_when_no_case_matches()
+    {
+        // Regression mirror of the async test above for the sync runtime.
+        const string key = "nope";
+
+        StateMachine fsm = GraphBuilder
+            .Start()
+            .Switch(() => key)
+            .Case("a", () => Result.Failure)
+            .Case("b", () => Result.Failure)
+            .End()
+            .ToStateMachine();
+
+        Result result;
+        do
+        {
+            result = fsm.Execute();
+        } while (result == Result.Continue);
+
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
 }

--- a/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
+++ b/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
 
 namespace NxGraph.Diagnostics.Export;
@@ -41,8 +42,12 @@ public sealed class MermaidGraphExporter : IGraphExporter
             string nodeId = NodeVar(i);
             string label = BuildNodeLabel(node.Id, i, opts);
 
-            // Shape: Start node gets a "stadium" shape, if IDirector rhombus {}, others are rectangles
-            if (node is LogicNode ln && (ln.AsyncLogic is IDirector || ln.Logic is IDirector))
+            // Shape: Start node gets a "stadium" shape, director nodes — sync IDirector or
+            // async IAsyncDirector — get a rhombus, others are rectangles. Previously only
+            // the sync IDirector path was checked, so async If/Switch nodes silently
+            // rendered as plain rectangles.
+            if (node is LogicNode ln && (ln.AsyncLogic is IDirector || ln.Logic is IDirector
+                                         || ln.AsyncLogic is IAsyncDirector || ln.Logic is IAsyncDirector))
             {
                 label = $"{{\"{EscapeLabel( label)}\"}}";
                 sb.Append("  ").Append(nodeId).Append(label).AppendLine();
@@ -104,6 +109,33 @@ public sealed class MermaidGraphExporter : IGraphExporter
                 {
                     sb.Append("  ").Append(from).Append(" -. invalid → .- ").Append(TerminalVar).AppendLine();
                 }
+            }
+        }
+
+        // Director edges: directors don't carry a static transition (the runtime calls
+        // SelectNext at execution time), so they're missed by the static-edge loop above.
+        // Emit dashed edges to every statically-known target so the rendered diagram
+        // reflects the actual reachability.
+        for (int i = 0; i < graph.NodeCount; i++)
+        {
+            if (graph.GetNodeByIndex(i) is not LogicNode dn) continue;
+
+            IEnumerable<NodeId>? targets =
+                (dn.AsyncLogic as IDirector)?.EnumerateStaticTargets()
+                ?? (dn.Logic as IDirector)?.EnumerateStaticTargets()
+                ?? (dn.AsyncLogic as IAsyncDirector)?.EnumerateStaticTargets()
+                ?? (dn.Logic as IAsyncDirector)?.EnumerateStaticTargets();
+            if (targets is null) continue;
+
+            string from = NodeVar(i);
+            foreach (NodeId target in targets)
+            {
+                int dstIdx = target.Index;
+                // Skip the NodeId.Default sentinel (terminal exit from a director) — emitting
+                // an edge to a non-existent index would just look like a broken link.
+                if (target.Equals(NodeId.Default)) continue;
+                if ((uint)dstIdx >= (uint)graph.NodeCount) continue;
+                sb.Append("  ").Append(from).Append(" -.-> ").Append(NodeVar(dstIdx)).AppendLine();
             }
         }
 

--- a/NxGraph/Diagnostics/Replay/ReplayRecorder.cs
+++ b/NxGraph/Diagnostics/Replay/ReplayRecorder.cs
@@ -4,12 +4,19 @@ using NxGraph.Graphs;
 
 namespace NxGraph.Diagnostics.Replay;
 
-public sealed class ReplayRecorder(int capacity = 256) : IAsyncStateMachineObserver
+public sealed class ReplayRecorder(int capacity = 256) : IAsyncStateMachineObserver, IStateMachineObserver
 {
     // ReSharper disable UnusedMember.Global
     // ReSharper disable once MemberCanBePrivate.Global
     public int Count { get; private set; }
     public int Capacity => _events.Length;
+
+    /// <summary>
+    /// Number of events the ring buffer has dropped due to capacity overflow. Increments
+    /// every time Record overwrites an existing slot. Useful for callers that need to
+    /// distinguish "complete capture" from "lossy capture" without scanning the buffer.
+    /// </summary>
+    public long DroppedCount { get; private set; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Clear()
@@ -17,6 +24,7 @@ public sealed class ReplayRecorder(int capacity = 256) : IAsyncStateMachineObser
         Count = 0;
         _head = 0;
         _tail = 0;
+        DroppedCount = 0;
     }
 
 
@@ -74,6 +82,7 @@ public sealed class ReplayRecorder(int capacity = 256) : IAsyncStateMachineObser
         if (Count == _events.Length)
         {
             _head = (_head + 1) % _events.Length;
+            DroppedCount++;
         }
         else
         {
@@ -145,4 +154,35 @@ public sealed class ReplayRecorder(int capacity = 256) : IAsyncStateMachineObser
         Record(new ReplayEvent(EventType.Log, nodeId, null, message, CurrentTimestamp));
         return ResultHelpers.CompletedTask;
     }
+
+    // ── Synchronous observer parity ─────────────────────────────────────
+    // Mirrors the async callbacks above. Sync StateMachine instances previously emitted no
+    // replay events because ReplayRecorder only implemented the async observer interface.
+
+    void IStateMachineObserver.OnStateEntered(NodeId id)
+        => Record(new ReplayEvent(EventType.StateEntered, id, timestamp: CurrentTimestamp));
+
+    void IStateMachineObserver.OnStateExited(NodeId id)
+        => Record(new ReplayEvent(EventType.StateExited, id, timestamp: CurrentTimestamp));
+
+    void IStateMachineObserver.OnTransition(NodeId from, NodeId to)
+        => Record(new ReplayEvent(EventType.Transition, from, to, timestamp: CurrentTimestamp));
+
+    void IStateMachineObserver.OnStateFailed(NodeId id, Exception ex)
+        => Record(new ReplayEvent(EventType.StateFailed, id, null, ex.ToString(), CurrentTimestamp));
+
+    void IStateMachineObserver.OnStateMachineReset(NodeId graphId)
+        => Record(new ReplayEvent(EventType.StateMachineReset, graphId, timestamp: CurrentTimestamp));
+
+    void IStateMachineObserver.OnStateMachineStarted(NodeId graphId)
+        => Record(new ReplayEvent(EventType.StateMachineStarted, graphId, timestamp: CurrentTimestamp));
+
+    void IStateMachineObserver.OnStateMachineCompleted(NodeId graphId, Result result)
+        => Record(new ReplayEvent(EventType.StateMachineCompleted, graphId, null, result.ToString(), CurrentTimestamp));
+
+    void IStateMachineObserver.StateMachineStatusChanged(NodeId graphId, ExecutionStatus prev, ExecutionStatus next)
+        => Record(new ReplayEvent(EventType.StatusChanged, graphId, null, $"{prev}->{next}", CurrentTimestamp));
+
+    void IStateMachineObserver.OnLogReport(NodeId nodeId, string message)
+        => Record(new ReplayEvent(EventType.Log, nodeId, null, message, CurrentTimestamp));
 }

--- a/NxGraph/Diagnostics/Replay/StateMachineReplay.cs
+++ b/NxGraph/Diagnostics/Replay/StateMachineReplay.cs
@@ -4,6 +4,16 @@ namespace NxGraph.Diagnostics.Replay;
 
 public class StateMachineReplay(ReadOnlySpan<ReplayEvent> events)
 {
+    // Wire format: [4-byte magic "NXRP"][1-byte version][4-byte count][events...]
+    // Pre-magic payloads (the original format) are rejected — the format was untrusted-input
+    // unsafe (no bounds on count, unchecked enum) so backwards compat would lock the bug in.
+    private static readonly byte[] Magic = "NXRP"u8.ToArray();
+    private const byte FormatVersion = 1;
+
+    // Lower bound for the wire size of one event: 1 (type) + 4 (source idx) + 1 (has-target bool)
+    // + 8 (timestamp) + 1 (empty BinaryWriter string = single 0 length byte).
+    private const int MinEventSize = 15;
+
     private readonly ReplayEvent[] _events = events.ToArray();
 
     public IEnumerable<ReplayEvent> Events => _events;
@@ -24,6 +34,8 @@ public class StateMachineReplay(ReadOnlySpan<ReplayEvent> events)
         using MemoryStream ms = new();
         using BinaryWriter writer = new(ms);
 
+        writer.Write(Magic);
+        writer.Write(FormatVersion);
         writer.Write(_events.Length);
 
         foreach (ReplayEvent evt in _events)
@@ -42,15 +54,58 @@ public class StateMachineReplay(ReadOnlySpan<ReplayEvent> events)
 
     public static ReplayEvent[] Deserialize(byte[] data)
     {
+        if (data is null) throw new ArgumentNullException(nameof(data));
+
         using MemoryStream ms = new(data);
         using BinaryReader reader = new(ms);
 
+        if (data.Length < Magic.Length + sizeof(byte) + sizeof(int))
+        {
+            throw new InvalidDataException("Replay payload is too short to contain a header.");
+        }
+
+        Span<byte> magic = stackalloc byte[Magic.Length];
+        int magicRead = reader.Read(magic);
+        if (magicRead != Magic.Length || !magic.SequenceEqual(Magic))
+        {
+            throw new InvalidDataException("Replay payload magic header does not match 'NXRP'.");
+        }
+
+        byte version = reader.ReadByte();
+        if (version != FormatVersion)
+        {
+            throw new InvalidDataException(
+                $"Replay payload version {version} is not supported (expected {FormatVersion}).");
+        }
+
         int count = reader.ReadInt32();
+        if (count < 0)
+        {
+            throw new InvalidDataException($"Replay payload event count {count} is negative.");
+        }
+
+        // Reject counts that cannot possibly fit in the remaining buffer. The check is a
+        // floor on event size (15 bytes) so this only rejects obviously-too-large counts;
+        // a payload may still be truncated mid-event and fail later, which is fine.
+        long remaining = ms.Length - ms.Position;
+        long maxCount = remaining / MinEventSize;
+        if (count > maxCount)
+        {
+            throw new InvalidDataException(
+                $"Replay payload claims {count} events but only {remaining} bytes remain (max {maxCount}).");
+        }
+
         ReplayEvent[] events = new ReplayEvent[count];
 
         for (int i = 0; i < count; i++)
         {
-            EventType type = (EventType)reader.ReadByte();
+            byte rawType = reader.ReadByte();
+            if (!Enum.IsDefined(typeof(EventType), rawType))
+            {
+                throw new InvalidDataException(
+                    $"Replay payload event {i} has unknown EventType byte {rawType}.");
+            }
+            EventType type = (EventType)rawType;
             NodeId primary = new(reader.ReadInt32());
 
             NodeId? secondary = null;

--- a/NxGraph/Diagnostics/Validations/GraphValidator.cs
+++ b/NxGraph/Diagnostics/Validations/GraphValidator.cs
@@ -1,4 +1,6 @@
 ﻿using NxGraph.Compatibility;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
 namespace NxGraph.Diagnostics.Validations;
 
@@ -37,9 +39,61 @@ public static class GraphValidator
             if (!visited.Add(current.Index))
                 continue;
 
-            if (!graph.TryGetNode(current, out _))
+            if (!graph.TryGetNode(current, out INode? currentNode))
             {
                 result.Add(Severity.Error, "Node referenced during traversal does not exist.", current);
+                continue;
+            }
+
+            // Director nodes route at runtime; their statically-known targets must be walked
+            // explicitly because TryGetTransition returns Empty for them. EnumerateStaticTargets
+            // returns the empty sequence for opaque custom directors — those remain invisible
+            // to reachability but the built-in Choice/Switch states now participate.
+            IEnumerable<NodeId>? directorTargets = null;
+            if (currentNode is LogicNode logicNode)
+            {
+                directorTargets =
+                    (logicNode.AsyncLogic as IDirector)?.EnumerateStaticTargets()
+                    ?? (logicNode.Logic as IDirector)?.EnumerateStaticTargets()
+                    ?? (logicNode.AsyncLogic as IAsyncDirector)?.EnumerateStaticTargets()
+                    ?? (logicNode.Logic as IAsyncDirector)?.EnumerateStaticTargets();
+            }
+
+            if (directorTargets is not null)
+            {
+                bool sawTerminalBranch = false;
+                foreach (NodeId branchDest in directorTargets)
+                {
+                    if (branchDest.Equals(NodeId.Default))
+                    {
+                        // NodeId.Default is the runtime sentinel for "exit successfully" from
+                        // a director — counts as a terminal path, not an error.
+                        sawTerminalBranch = true;
+                        continue;
+                    }
+
+                    if (!graph.TryGetNode(branchDest, out _))
+                    {
+                        result.Add(Severity.Error,
+                            $"Director branch points to non-existent node #{branchDest.Index}.", current);
+                        continue;
+                    }
+
+                    if (options.WarnOnSelfLoop && branchDest.Index == current.Index)
+                    {
+                        result.Add(Severity.Warning, "Self-loop transition detected.", current);
+                    }
+
+                    queue.Enqueue(branchDest);
+                }
+
+                if (sawTerminalBranch)
+                {
+                    sawTerminal = true;
+                }
+
+                // Director nodes do not have a static fall-through transition; skip the
+                // edge check below.
                 continue;
             }
 

--- a/NxGraph/Fsm/Async/AsyncChoiceState.cs
+++ b/NxGraph/Fsm/Async/AsyncChoiceState.cs
@@ -16,4 +16,11 @@ public sealed class AsyncChoiceState(Func<ValueTask<bool>> predicate, NodeId tru
     {
         return ResultHelpers.Success;
     }
+
+    /// <inheritdoc />
+    public IEnumerable<NodeId> EnumerateStaticTargets()
+    {
+        yield return trueNode;
+        yield return falseNode;
+    }
 }

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -65,7 +65,31 @@ public class AsyncStateMachine : AsyncState
     /// Reset to the initial node. Disallowed while Running/Transitioning.
     /// Status moves: (any non-running) -> Resetting -> Ready.
     /// </summary>
+    /// <remarks>
+    /// Public entry point acquires <see cref="_executeGate"/> so an external caller
+    /// cannot race a running machine. Internal auto-restart paths must call
+    /// <see cref="ResetCore"/> directly because the gate is already held by the
+    /// surrounding <see cref="OnEnterAsync"/>/<see cref="OnRunAsync"/>/<see cref="OnExitAsync"/> frame.
+    /// </remarks>
     public async ValueTask<Result> Reset(CancellationToken ct = default)
+    {
+        if (Interlocked.Exchange(ref _executeGate, 1) == 1)
+        {
+            throw new InvalidOperationException(
+                "Cannot reset while the machine is executing. Await completion before calling Reset.");
+        }
+
+        try
+        {
+            return await ResetCore(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            Volatile.Write(ref _executeGate, 0);
+        }
+    }
+
+    private async ValueTask<Result> ResetCore(CancellationToken ct)
     {
         while (true)
         {
@@ -79,10 +103,12 @@ public class AsyncStateMachine : AsyncState
                 case ExecutionStatus.Created:
                 case ExecutionStatus.Ready:
                     return Result.Success;
+                case ExecutionStatus.Resetting:
+                    // Another caller is already resetting — be idempotent rather than firing duplicate notifications.
+                    return Result.Success;
                 case ExecutionStatus.Completed:
                 case ExecutionStatus.Failed:
                 case ExecutionStatus.Cancelled:
-                case ExecutionStatus.Resetting:
                     break;
                 default:
                     throw new IndexOutOfRangeException(nameof(status));
@@ -120,9 +146,9 @@ public class AsyncStateMachine : AsyncState
             {
                 case RestartPolicy.Ignore:
                     // Ignore further execution attempts until a manual Reset() occurs.
-                    // We must release the gate so the current ExecuteAsync call can run OnRunAsync,
-                    // which will return the cached terminal result.
-                    Volatile.Write(ref _executeGate, 0);
+                    // Keep the gate held so a concurrent caller cannot enter while this
+                    // ExecuteAsync is still on its way to OnRunAsync (which returns the
+                    // cached terminal result) and OnExitAsync (which releases the gate).
                     return Result.Continue;
                 case RestartPolicy.Manual:
                     Volatile.Write(ref _executeGate, 0); // Release the gate before throwing.
@@ -130,7 +156,8 @@ public class AsyncStateMachine : AsyncState
                         $"AsyncStateMachine is in terminal state '{status}'. Call Reset() before executing again.");
                 default:
                     // Auto: tolerate unexpected terminal state by resetting on entry.
-                    await Reset(ct).ConfigureAwait(false);
+                    // ResetCore (not Reset) because OnEnterAsync already holds the gate.
+                    await ResetCore(ct).ConfigureAwait(false);
                     break;
             }
         }
@@ -170,7 +197,8 @@ public class AsyncStateMachine : AsyncState
 
             if (_restartPolicy == RestartPolicy.Auto)
             {
-                await Reset(ct).ConfigureAwait(false);
+                // ResetCore (not Reset) because the gate is held by the surrounding ExecuteAsync.
+                await ResetCore(ct).ConfigureAwait(false);
             }
 
             return result;
@@ -184,8 +212,9 @@ public class AsyncStateMachine : AsyncState
 
             if (_restartPolicy == RestartPolicy.Auto)
             {
-                // Use default token — ct is already cancelled at this point.
-                await Reset(ct).ConfigureAwait(false);
+                // CancellationToken.None: ct is already cancelled; passing it would make
+                // any cancellable await inside the reset throw, stranding status at Resetting.
+                await ResetCore(CancellationToken.None).ConfigureAwait(false);
             }
 
             throw;
@@ -203,8 +232,8 @@ public class AsyncStateMachine : AsyncState
 
             if (_restartPolicy == RestartPolicy.Auto)
             {
-                // Use default token — ct may be cancelled or faulted at this point.
-                await Reset(ct).ConfigureAwait(false);
+                // CancellationToken.None: ct may already be cancelled/faulted; reset must complete cleanly.
+                await ResetCore(CancellationToken.None).ConfigureAwait(false);
             }
 
             throw;

--- a/NxGraph/Fsm/Async/AsyncSwitchState.cs
+++ b/NxGraph/Fsm/Async/AsyncSwitchState.cs
@@ -21,7 +21,15 @@ public sealed class AsyncSwitchState<TKey>(
     {
         TKey key = await _selector();
         return _cases.GetValueOrDefault(key, _defaultNode);
-        
+
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<NodeId> EnumerateStaticTargets()
+    {
+        foreach (NodeId target in _cases.Values)
+            yield return target;
+        yield return _defaultNode;
     }
 
     public ValueTask<Result> ExecuteAsync(CancellationToken ct = default)

--- a/NxGraph/Fsm/Async/AsyncSwitchState.cs
+++ b/NxGraph/Fsm/Async/AsyncSwitchState.cs
@@ -11,7 +11,10 @@ public sealed class AsyncSwitchState<TKey>(
 {
     private readonly Func<ValueTask<TKey>> _selector = selector ?? throw new ArgumentNullException(nameof(selector));
     private readonly IReadOnlyDictionary<TKey, NodeId> _cases = cases ?? throw new ArgumentNullException(nameof(cases));
-    private NodeId _defaultNode = defaultNode;
+    // When no explicit default is supplied, fall back to NodeId.Default — the async runtime
+    // (AsyncStateMachine.InternalRunAsync) treats that as a terminal-success exit from the
+    // director. Defaulting to default(NodeId) would silently route to Start (index 0).
+    private NodeId _defaultNode = defaultNode.Equals(default(NodeId)) ? NodeId.Default : defaultNode;
 
 
     public async ValueTask<NodeId> SelectNextAsync(CancellationToken ct = default)

--- a/NxGraph/Fsm/Async/AsyncTimeoutState.cs
+++ b/NxGraph/Fsm/Async/AsyncTimeoutState.cs
@@ -38,7 +38,11 @@ public class AsyncTimeoutState : IAsyncLogic
 #if NET6_0_OR_GREATER
             reg = ct.UnsafeRegister(_cachedCancelCallback, cts);
 #else
-            reg = ct.Register(static s => ((Action)s!).Invoke(), _cachedCancelCallback);
+            // netstandard2.1 has no UnsafeRegister; the Register(Action<object?>, object?) overload
+            // takes the callback and the state directly. The previous version cast the state to
+            // Action and invoked it, which threw InvalidCastException because the cached callback
+            // is Action<object?>, not Action — and would also have lost the CTS state.
+            reg = ct.Register(_cachedCancelCallback, cts);
 #endif
         }
 
@@ -95,10 +99,12 @@ public class AsyncTimeoutState : IAsyncLogic
                 return cts;
             }
 #else
-            // No TryReset in .NET Standard 2.1, so just dispose and create new.
+            // No TryReset in .NET Standard 2.1: reuse the rented CTS when it has not been
+            // cancelled (CancelAfter will reset its timer on next use). Previously this
+            // branch allocated a *new* CTS when the rented one was not cancelled, leaking
+            // the rented one and doubling allocations on every rent.
             if (!cts.IsCancellationRequested)
             {
-                cts = new CancellationTokenSource(); 
                 return cts;
             }
 #endif

--- a/NxGraph/Fsm/ChoiceState.cs
+++ b/NxGraph/Fsm/ChoiceState.cs
@@ -24,4 +24,11 @@ public sealed class ChoiceState(Func<bool> predicate, NodeId trueNode, NodeId fa
     {
         return _predicate() ? trueNode : falseNode;
     }
+
+    /// <inheritdoc />
+    public IEnumerable<NodeId> EnumerateStaticTargets()
+    {
+        yield return trueNode;
+        yield return falseNode;
+    }
 }

--- a/NxGraph/Fsm/IDirector.cs
+++ b/NxGraph/Fsm/IDirector.cs
@@ -12,6 +12,20 @@ public interface IDirector
     /// </summary>
     /// <returns></returns>
     NodeId SelectNext();
+
+    /// <summary>
+    /// Enumerates every <see cref="NodeId"/> this director can statically be routed to
+    /// (i.e. nodes whose existence is known at authoring time, not selected dynamically
+    /// at runtime). Used by diagnostics (Mermaid export, reachability validation) so
+    /// director branches are visible to tooling.
+    /// </summary>
+    /// <remarks>
+    /// The default returns an empty sequence so existing user implementations compile
+    /// unchanged — but those custom directors will be opaque to the validator and the
+    /// exporter. Built-in <see cref="ChoiceState"/> and <see cref="SwitchState"/>
+    /// override this to surface their known targets.
+    /// </remarks>
+    IEnumerable<NodeId> EnumerateStaticTargets() => System.Array.Empty<NodeId>();
 }
 
 public interface IAsyncDirector
@@ -22,4 +36,7 @@ public interface IAsyncDirector
     /// <param name="ct">The cancellation token to observe while selecting the next node.</param>
     /// <returns>A <see cref="ValueTask{NodeId}"/> representing the selected next node.</returns>
     ValueTask<NodeId> SelectNextAsync(CancellationToken ct = default);
+
+    /// <inheritdoc cref="IDirector.EnumerateStaticTargets"/>
+    IEnumerable<NodeId> EnumerateStaticTargets() => System.Array.Empty<NodeId>();
 }

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -54,7 +54,6 @@ public class StateMachine : State
     private RestartPolicy _restartPolicy = RestartPolicy.Auto;
     private Result _terminalResult = Result.Success;
     private bool _executeGate;
-    private bool _reentranceGuard;
     private readonly Action<string> _cachedLogReportCallback;
 
     /// <summary>Public execution status.</summary>
@@ -164,10 +163,6 @@ public class StateMachine : State
             return _terminalResult;
         }
 
-        if (_reentranceGuard)
-            throw new InvalidOperationException("StateMachine is already executing.");
-
-        _reentranceGuard = true;
         try
         {
             Result result = TickInternal();
@@ -182,10 +177,6 @@ public class StateMachine : State
             _observer?.OnStateFailed(_current, ex);
             Finalise(Result.Failure);
             throw;
-        }
-        finally
-        {
-            _reentranceGuard = false;
         }
     }
 
@@ -202,15 +193,32 @@ public class StateMachine : State
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void Finalise(Result result)
     {
-        _terminalResult = result;
-        TransitionTo(result.IsSuccess ? ExecutionStatus.Completed : ExecutionStatus.Failed);
-
-        if (_restartPolicy == RestartPolicy.Auto)
+        try
         {
-            Reset();
-        }
+            // Idempotent: if the first Finalise call partially completed (e.g. an observer
+            // threw inside TransitionTo) the OnRun catch will call Finalise(Failure) again.
+            // Skip the notification cascade in that case so OnStateMachineCompleted is not
+            // fired twice for the same run.
+            ExecutionStatus current = _status;
+            if (current is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+            {
+                return;
+            }
 
-        _executeGate = false;
+            _terminalResult = result;
+            TransitionTo(result.IsSuccess ? ExecutionStatus.Completed : ExecutionStatus.Failed);
+
+            if (_restartPolicy == RestartPolicy.Auto)
+            {
+                Reset();
+            }
+        }
+        finally
+        {
+            // Always release the gate, even if an observer or Reset threw. Without this the
+            // gate stays held and every subsequent Execute() throws "already executing".
+            _executeGate = false;
+        }
     }
 
     /// <summary>

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -54,6 +54,11 @@ public class StateMachine : State
     private RestartPolicy _restartPolicy = RestartPolicy.Auto;
     private Result _terminalResult = Result.Success;
     private bool _executeGate;
+    // Guards OnRun against reentrance from inside node logic that calls Execute() on the
+    // owning machine. _executeGate alone is not sufficient: State.Execute() only invokes
+    // OnEnter once per lifecycle (via its own _hasEntered flag), so a re-entrant Execute()
+    // skips OnEnter entirely and never observes _executeGate.
+    private bool _reentranceGuard;
     private readonly Action<string> _cachedLogReportCallback;
 
     /// <summary>Public execution status.</summary>
@@ -163,6 +168,10 @@ public class StateMachine : State
             return _terminalResult;
         }
 
+        if (_reentranceGuard)
+            throw new InvalidOperationException("StateMachine is already executing.");
+
+        _reentranceGuard = true;
         try
         {
             Result result = TickInternal();
@@ -177,6 +186,10 @@ public class StateMachine : State
             _observer?.OnStateFailed(_current, ex);
             Finalise(Result.Failure);
             throw;
+        }
+        finally
+        {
+            _reentranceGuard = false;
         }
     }
 

--- a/NxGraph/Fsm/SwitchState.cs
+++ b/NxGraph/Fsm/SwitchState.cs
@@ -17,7 +17,10 @@ public sealed class SwitchState<TKey>(
 {
     private readonly Func<TKey> _selector = selector ?? throw new ArgumentNullException(nameof(selector));
     private readonly IReadOnlyDictionary<TKey, NodeId> _cases = cases ?? throw new ArgumentNullException(nameof(cases));
-    private NodeId _defaultNode = defaultNode;
+    // When no explicit default is supplied, fall back to NodeId.Default — both the sync and
+    // the async runtimes treat that as a terminal-success exit from the director. Defaulting
+    // to default(NodeId) would silently route to Start (index 0) instead.
+    private NodeId _defaultNode = defaultNode.Equals(default(NodeId)) ? NodeId.Default : defaultNode;
 
     /// <summary>
     /// Selects the next node based on the selector function.

--- a/NxGraph/Fsm/SwitchState.cs
+++ b/NxGraph/Fsm/SwitchState.cs
@@ -32,6 +32,14 @@ public sealed class SwitchState<TKey>(
         return _cases.GetValueOrDefault(key, _defaultNode);
     }
 
+    /// <inheritdoc />
+    public IEnumerable<NodeId> EnumerateStaticTargets()
+    {
+        foreach (NodeId target in _cases.Values)
+            yield return target;
+        yield return _defaultNode;
+    }
+
 
     /// <inheritdoc />
     public Result Execute() => Result.Success;

--- a/NxGraph/Graphs/Graph.cs
+++ b/NxGraph/Graphs/Graph.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 using NxGraph.Compatibility;
 using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
 
 namespace NxGraph.Graphs;
 
@@ -142,7 +143,14 @@ public sealed class Graph : INode, IGraph
     {
         Guard.NotNull(agent, nameof(agent));
 
+        if (!SetAgentRecursive(agent))
+        {
+            throw new InvalidOperationException($"No nodes in the graph implement {nameof(IAgentSettable<TAgent>)}.");
+        }
+    }
 
+    private bool SetAgentRecursive<TAgent>(TAgent agent)
+    {
         bool found = false;
         for (int i = 0; i < _nodes.Length; i++)
         {
@@ -153,19 +161,30 @@ public sealed class Graph : INode, IGraph
                 logicNode.AsyncLogic as IAgentSettable<TAgent>
                 ?? logicNode.Logic as IAgentSettable<TAgent>;
 
-            if (settable is null)
+            if (settable is not null)
             {
+                settable.SetAgent(agent);
+                found = true;
+                // Generic StateMachine<TAgent>/AsyncStateMachine<TAgent> already re-walk
+                // their inner graph via SetAgent — no additional recursion needed.
                 continue;
             }
 
-            found = true;
-            settable.SetAgent(agent);
+            // Non-generic nested state machines do not implement IAgentSettable<TAgent>, so
+            // the direct match misses them. Walk their inner graph explicitly so
+            // IAgentSettable<TAgent> nodes deeper in the tree still receive the agent.
+            Graph? nested = (logicNode.AsyncLogic as AsyncStateMachine)?.Graph
+                         ?? (logicNode.Logic as StateMachine)?.Graph;
+            if (nested is not null && !ReferenceEquals(nested, this))
+            {
+                if (nested.SetAgentRecursive(agent))
+                {
+                    found = true;
+                }
+            }
         }
 
-        if (!found)
-        {
-            throw new InvalidOperationException($"No nodes in the graph implement {nameof(IAgentSettable<TAgent>)}.");
-        }
+        return found;
     }
 
     public INode GetNodeByIndex(int index)


### PR DESCRIPTION
## Summary
Applies the 🔴 must-fix items from the 2026-05 audit across the async/sync runtime, serialization, replay, and diagnostics surfaces. One logical fix per commit (13 total) so each can be reviewed or reverted independently.

### Runtime correctness
- **AsyncStateMachine** (`f0875aa`): `Reset()` now acquires `_executeGate`; internal auto-restart paths call a new `ResetCore` so the gate isn't double-acquired; cancellation/failure paths pass `CancellationToken.None` to the reset; `Resetting` status short-circuits to idempotent success instead of the no-op CAS race; `RestartPolicy.Ignore` keeps the gate held through `OnRunAsync`.
- **Sync StateMachine** (`0ed78e3`, `a39ad64`): `Finalise` wraps gate cleanup in `finally` and is idempotent in terminal states so an observer throwing during the terminal transition can't double-fire `OnStateMachineCompleted` or leak the gate. (Note: the review's claim that `_reentranceGuard` was dead code was wrong — `State.Execute` only calls `OnEnter` once, so the guard is the real re-entrance protection. The follow-up commit restores it with an explanatory comment.)
- **AsyncTimeoutState** (`65eb9a4`): netstandard2.1 cancellation registration was casting `Action<object?>` to `Action`, throwing `InvalidCastException` on every cancellation. `CtsPool.Rent`'s netstandard branch was allocating a fresh CTS when the rented one was *not* cancelled, leaking the original and doubling allocations.
- **SwitchState / AsyncSwitchState** (`8d66d86`): when no `Default*` is configured, both runtimes now route through `NodeId.Default` (terminal success). Previously they fell back to `default(NodeId)` (index 0 = Start), silently looping.
- **Graph.SetAgent** (`346b527`): now recurses into non-generic nested `StateMachine`/`AsyncStateMachine` graphs so `IAgentSettable<TAgent>` nodes deeper in the tree receive the agent.

### Serialization & replay hardening
- **JSON version** (`5735925`): `GraphDto.Version` is now an instance property emitted to JSON; `FromJsonAsync` rejects payloads with a newer version.
- **NodeDtoFormatter** (`e6ba258`): array header bumped from 3 to 4 to match the actual payload size (the previous mismatch desynchronizes a strict MessagePack reader).
- **FromDto index handling** (`7ab18d4`): `NodeId` is now rebuilt from `nodeDto.Index` (not the loop counter); duplicate and gap indices are rejected.
- **MessagePack untrusted data** (`cf629f6`): `MessagePackSecurity.UntrustedData` enabled; subgraph recursion capped at depth 64 in both `ToDto` and `FromDto`.
- **Replay binary format** (`049c8e7`): 4-byte `NXRP` magic + 1-byte version header; `count` bounded by remaining bytes / minimum event size; `EventType` validated with `Enum.IsDefined`. (Breaking: pre-magic payloads no longer deserialize; the previous format was untrusted-input unsafe.)
- **ReplayRecorder sync observer** (`fd6e642`): now implements `IStateMachineObserver` so sync machines emit replay events; new `DroppedCount` exposes ring-buffer overflow.

### Diagnostics
- **Director branches visible** (`32db861`): `IDirector` and `IAsyncDirector` gained `EnumerateStaticTargets()` with default-empty implementation so custom directors still compile. `Choice`/`Switch` states implement it. The Mermaid exporter now also checks `IAsyncDirector` for the rhombus shape and emits dashed `-.->` edges to each statically-known target. The graph validator enqueues director branches in its BFS, so nodes only reachable through a director are no longer flagged unreachable.

## Test plan
- [x] `dotnet build NxGraph.sln -c Release` — 0 warnings, 0 errors (both `net8.0` and `netstandard2.1` configurations)
- [x] `dotnet test NxGraph.Tests/NxGraph.Tests.csproj -c Release` — **180 passed**, 0 failed (170 pre-existing + 10 new regression tests for switch defaults, nested SetAgent, director branches, replay-format rejection, sync recording, and `DroppedCount`)
- [x] `dotnet test NxGraph.Serialization.Tests/NxGraph.Serialization.Tests.csproj -c Release` — **11 passed**, 0 failed (6 pre-existing + 5 new for JSON version field/rejection, duplicate-index rejection, out-of-range rejection, deep-nesting rejection)
- [ ] CI green on push
- [ ] Spot-check the 🟡 design-tier items deferred to a follow-up branch

## Out of scope
Deferred per scoping decision: 🟡 design concerns (GraphBuilder idempotency, IfBuilder.Else, validation Debugger polarity, NodeId.Default static-readonly, GraphDto init-only setters, TracingObserver lifecycle, stream JSON, cached options, etc.) and 🟢 nice-to-haves (DiagnosticCode enum, DSL TimeSpan namespacing, replay timestamp resolution, missing serialization test coverage). Each is suitable for its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)