### PR TITLE
Unified fault model, typed context, stepped execution, and durable suspend/resume

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,8 +21,6 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Build & Test
-      env:
-        COVERAGE_THRESHOLD: 0
       run: dotnet run --project NxGraph.Build -- ci
     - name: Upload coverage report
       uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ riderModule.iml
 artifacts/
 NxGraph.Serialization.Tests/TestResults
 NxGraph.Tests/TestResults
+coverage.info
+coverage.json
 /BenchmarkDotNet.Artifacts/
 upm/com.enzx.nxgraph/Runtime/**/*.dll
 upm/com.enzx.nxgraph/Runtime/**/*.pdb

--- a/NxFSM.Examples/DungeonCrawler/DungeonCrawlerExample.cs
+++ b/NxFSM.Examples/DungeonCrawler/DungeonCrawlerExample.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using NxGraph;
 using NxGraph.Authoring;
 using NxGraph.Diagnostics.Export;
@@ -144,8 +144,8 @@ public static class DungeonCrawlerExample
         Console.WriteLine();
 
         // Execute() advances one node per call; loop until a terminal result.
-        Result result = Result.Continue;
-        while (result == Result.Continue)
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
             result = fsm.Execute();
 
         Console.WriteLine();

--- a/NxFSM.Examples/DungeonCrawler/States/BossFightState.cs
+++ b/NxFSM.Examples/DungeonCrawler/States/BossFightState.cs
@@ -1,4 +1,4 @@
-﻿using NxGraph;
+using NxGraph;
 using NxGraph.Authoring;
 using NxGraph.Fsm;
 using NxGraph.Graphs;
@@ -52,8 +52,8 @@ public sealed class BossFightState : State<DungeonContext>
             .WithAgent(Agent);
 
         // Loop to completion — Execute() is stepped; a nested FSM must run to a terminal result.
-        Result result = Result.Continue;
-        while (result == Result.Continue)
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
             result = childFsm.Execute();
 
         if (result == Result.Success && Agent.BossHp <= 0)

--- a/NxFSM.Examples/ReadmeExamples/ObserverExample.cs
+++ b/NxFSM.Examples/ReadmeExamples/ObserverExample.cs
@@ -40,8 +40,8 @@ public static class ObserverExample
             .To(() => Result.Success).SetName("Finish")
             .ToStateMachine(new DiagnosticObserver());
 
-        Result result = Result.Continue;
-        while (result == Result.Continue)
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
             result = sm.Execute();
 
         Console.WriteLine($"Result: {result}");

--- a/NxFSM.Examples/ReadmeExamples/QuickStartExample.cs
+++ b/NxFSM.Examples/ReadmeExamples/QuickStartExample.cs
@@ -42,8 +42,8 @@ public static class QuickStartExample
             .ToStateMachine();
 
         // Execute() advances one node per call; loop to run to completion.
-        Result result = Result.Continue;
-        while (result == Result.Continue)
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
             result = fsm.Execute();
 
         Console.WriteLine($"Result: {result}");

--- a/NxGraph.Benchmarks/SyncFsmBenchmarks.cs
+++ b/NxGraph.Benchmarks/SyncFsmBenchmarks.cs
@@ -46,8 +46,8 @@ public class SyncFsmBenchmarks
 
     private static Result Run(StateMachine sm)
     {
-        Result result = Result.Continue;
-        while (result == Result.Continue)
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
             result = sm.Execute();
         return result;
     }

--- a/NxGraph.Build/Program.cs
+++ b/NxGraph.Build/Program.cs
@@ -91,11 +91,15 @@ public static class Program
         Target("test", DependsOn("build"), async () =>
         {
             var config = OptionalEnv("CONFIGURATION") ?? "Release";
-            var threshold = OptionalEnv("COVERAGE_THRESHOLD") ?? "0";
+            // Line-coverage floor per instrumented module (each test project scopes its own
+            // Include filter in its csproj). Raise this as new features land with tests;
+            // never lower it without a recorded decision.
+            var threshold = OptionalEnv("COVERAGE_THRESHOLD") ?? "70";
             await RunDotNet(repoRoot,
                 $"test --no-build --configuration {config} --verbosity normal " +
                 $"--collect:\"XPlat Code Coverage\" " +
-                $"/p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:Threshold={threshold}");
+                $"/p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:Threshold={threshold} " +
+                $"/p:ThresholdType=line /p:ThresholdStat=minimum");
         });
 
         // ci = restore → build → test (via dependency chain)

--- a/NxGraph.Build/README.md
+++ b/NxGraph.Build/README.md
@@ -154,7 +154,7 @@ sensible defaults for local development.
 | Variable | Used by | Default | Description |
 |---|---|---|---|
 | `CONFIGURATION` | `build`, `test` | `Release` | Build configuration |
-| `COVERAGE_THRESHOLD` | `test` | `0` | Minimum coverage % (Coverlet) |
+| `COVERAGE_THRESHOLD` | `test` | `70` | Minimum line coverage % per instrumented module (Coverlet); raise as coverage grows, don't lower it |
 | `TARGET` | `pack` | _(from git tag)_ | Which packages to pack: `all`, `nxgraph`, `serialization`, `serialization-abstraction` |
 | `VERSION` | `pack`, `upm-patch-version`, `upm-tarball` | _(from git tag)_ | SemVer version string (e.g. `1.2.3` or `1.0.0-beta.1`) |
 | `NUGET_API_KEY` | `push` | _(required)_ | NuGet.org API key |

--- a/NxGraph.Serialization.Tests/DurableSuspendResumeTests.cs
+++ b/NxGraph.Serialization.Tests/DurableSuspendResumeTests.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// The full durability loop: serialize the graph structure with NxGraph.Serialization,
+/// suspend a running machine to a snapshot, ship both across a (simulated) process
+/// boundary, rebuild the graph, resume, and run to completion.
+/// </summary>
+[TestFixture]
+[Category("serialization")]
+public class DurableSuspendResumeTests
+{
+    private readonly GraphSerializer _serializer = new(new DummyLogicTextCodec());
+
+    private sealed class RecordingObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> Events = [];
+
+        public ValueTask OnStateEntered(NodeId id, CancellationToken ct = default)
+        {
+            Events.Add($"entered:{id.Index}");
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnStateExited(NodeId id, CancellationToken ct = default)
+        {
+            Events.Add($"exited:{id.Index}");
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnStateFailed(NodeId id, Exception? ex, CancellationToken ct = default)
+        {
+            Events.Add($"failed:{id.Index}");
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnTransition(NodeId from, NodeId to, CancellationToken ct = default)
+        {
+            Events.Add($"transition:{from.Index}->{to.Index}");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Test]
+    public async Task suspend_serialize_deserialize_resume_completes_the_flow()
+    {
+        Graph original = GraphBuilder
+            .StartWithAsync(new DummyState { Data = "one" })
+            .ToAsync(new DummyState { Data = "two" })
+            .ToAsync(new DummyState { Data = "three" })
+            .Build();
+
+        // Run one step, then suspend mid-flow.
+        AsyncStateMachine running = original.ToAsyncStateMachine();
+        Result first = await running.StepAsync();
+        Assert.That(first, Is.EqualTo(Result.InProgress));
+        StateMachineSnapshot snapshot = running.Suspend();
+
+        // Ship graph + snapshot as JSON, as a durable store would.
+        await using MemoryStream graphStream = new();
+        await _serializer.ToJsonAsync(original, graphStream);
+        string snapshotJson = JsonSerializer.Serialize(snapshot);
+
+        // Rebuild everything on the "other side".
+        graphStream.Position = 0;
+        Graph rebuilt = await _serializer.FromJsonAsync(graphStream);
+        StateMachineSnapshot restored = JsonSerializer.Deserialize<StateMachineSnapshot>(snapshotJson)!;
+
+        RecordingObserver observer = new();
+        AsyncStateMachine resumed = rebuilt.ToAsyncStateMachine(observer);
+        resumed.Resume(restored);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await resumed.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(observer.Events, Does.Not.Contain("entered:0"),
+                "Node 0 completed before the suspend; the resumed machine must not re-enter it.");
+            Assert.That(observer.Events, Does.Contain("exited:1"));
+            Assert.That(observer.Events, Does.Contain("exited:2"));
+        });
+    }
+}

--- a/NxGraph.Serialization.Tests/FailureEdgeSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/FailureEdgeSerializationTests.cs
@@ -1,0 +1,110 @@
+using System.Text;
+using NxGraph.Authoring;
+using NxGraph.Graphs;
+
+namespace NxGraph.Serialization.Tests;
+
+[TestFixture]
+[Category("serialization")]
+public class FailureEdgeSerializationTests
+{
+    private readonly GraphSerializer _serializer = new(new DummyLogicTextCodec());
+
+    private static Graph BuildGraphWithFailureEdge()
+    {
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(new DummyState { Data = "work" }, isStart: true);
+        NodeId next = builder.AddNode(new DummyState { Data = "done" });
+        NodeId handler = builder.AddNode(new DummyState { Data = "cleanup" });
+        builder.AddTransition(start, next);
+        builder.AddFailureTransition(start, handler);
+        return builder.Build(throwOnError: false);
+    }
+
+    [Test]
+    public async Task json_roundtrip_preserves_failure_edges()
+    {
+        Graph graph = BuildGraphWithFailureEdge();
+
+        await using MemoryStream stream = new();
+        await _serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+        Graph roundTripped = await _serializer.FromJsonAsync(stream);
+
+        Transition edge = roundTripped.GetTransitionByIndex(0);
+        Assert.Multiple(() =>
+        {
+            Assert.That(edge.Destination.Index, Is.EqualTo(1));
+            Assert.That(edge.HasFailureDestination, Is.True);
+            Assert.That(edge.FailureDestination.Index, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public async Task binary_roundtrip_preserves_failure_edges()
+    {
+        Graph graph = BuildGraphWithFailureEdge();
+
+        await using MemoryStream stream = new();
+        await _serializer.ToBinaryAsync(graph, stream);
+        stream.Position = 0;
+        Graph roundTripped = await _serializer.FromBinaryAsync(stream);
+
+        Transition edge = roundTripped.GetTransitionByIndex(0);
+        Assert.Multiple(() =>
+        {
+            Assert.That(edge.HasFailureDestination, Is.True);
+            Assert.That(edge.FailureDestination.Index, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public async Task version1_json_without_failure_destination_still_loads()
+    {
+        const string logic = "\"{\\\"Data\\\":\\\"x\\\"}\"";
+        string json = $$"""
+            {
+              "version": 1,
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": {{logic}} },
+                { "$type": "txt", "index": 1, "name": "b", "logic": {{logic}} }
+              ],
+              "transitions": [ { "destination": 1 }, { "destination": -1 } ],
+              "subGraphs": [],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        Graph graph = await _serializer.FromJsonAsync(source);
+
+        Transition edge = graph.GetTransitionByIndex(0);
+        Assert.Multiple(() =>
+        {
+            Assert.That(edge.Destination.Index, Is.EqualTo(1));
+            Assert.That(edge.HasFailureDestination, Is.False);
+        });
+    }
+
+    [Test]
+    public void out_of_range_failure_destination_is_rejected()
+    {
+        const string logic = "\"{\\\"Data\\\":\\\"x\\\"}\"";
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": {{logic}} }
+              ],
+              "transitions": [ { "destination": -1, "failureDestination": 9 } ],
+              "subGraphs": [],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await _serializer.FromJsonAsync(source));
+    }
+}

--- a/NxGraph.Serialization.Tests/NxGraph.Serialization.Tests.csproj
+++ b/NxGraph.Serialization.Tests/NxGraph.Serialization.Tests.csproj
@@ -7,10 +7,18 @@
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+
+        <!-- Coverage instrumentation scope: serialization packages only; the core library
+             is covered by NxGraph.Tests. -->
+        <Include>[NxGraph.Serialization]*,[NxGraph.Serialization.Abstraction]*</Include>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="8.0.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.msbuild" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/NxGraph.Serialization.Tests/RetryPolicySerializationTests.cs
+++ b/NxGraph.Serialization.Tests/RetryPolicySerializationTests.cs
@@ -1,0 +1,103 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Serialization.Tests;
+
+[TestFixture]
+[Category("serialization")]
+public class RetryPolicySerializationTests
+{
+    private readonly GraphSerializer _serializer = new(new DummyLogicTextCodec());
+
+    private static Graph BuildGraphWithRetry()
+    {
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(new DummyState { Data = "flaky" }, isStart: true);
+        NodeId next = builder.AddNode(new DummyState { Data = "done" });
+        builder.AddTransition(start, next);
+        builder.SetRetryPolicy(start,
+            new RetryPolicy(3, TimeSpan.FromMilliseconds(250), BackoffKind.Exponential));
+        return builder.Build(throwOnError: false);
+    }
+
+    [Test]
+    public async Task json_roundtrip_preserves_retry_policies()
+    {
+        Graph graph = BuildGraphWithRetry();
+
+        await using MemoryStream stream = new();
+        await _serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+        Graph roundTripped = await _serializer.FromJsonAsync(stream);
+
+        RetryPolicy[]? policies = roundTripped.RetryPolicies;
+        Assert.That(policies, Is.Not.Null);
+        RetryPolicy policy = policies![0];
+        Assert.Multiple(() =>
+        {
+            Assert.That(policy.MaxAttempts, Is.EqualTo(3));
+            Assert.That(policy.Backoff, Is.EqualTo(TimeSpan.FromMilliseconds(250)));
+            Assert.That(policy.BackoffKind, Is.EqualTo(BackoffKind.Exponential));
+            Assert.That(policies[1].MaxAttempts, Is.Zero, "Node without a policy stays policy-free.");
+        });
+    }
+
+    [Test]
+    public async Task binary_roundtrip_preserves_retry_policies()
+    {
+        Graph graph = BuildGraphWithRetry();
+
+        await using MemoryStream stream = new();
+        await _serializer.ToBinaryAsync(graph, stream);
+        stream.Position = 0;
+        Graph roundTripped = await _serializer.FromBinaryAsync(stream);
+
+        RetryPolicy[]? policies = roundTripped.RetryPolicies;
+        Assert.That(policies, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(policies![0].MaxAttempts, Is.EqualTo(3));
+            Assert.That(policies[0].BackoffKind, Is.EqualTo(BackoffKind.Exponential));
+        });
+    }
+
+    [Test]
+    public async Task json_roundtrip_preserves_outcome_codes_and_names()
+    {
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(new DummyState { Data = "start" }, isStart: true);
+        NodeId done = builder.AddNode(new DummyState { Data = "done" });
+        builder.AddTransition(start, done);
+        builder.SetOutcome(done, 7, "Approved");
+        Graph graph = builder.Build(throwOnError: false);
+
+        await using MemoryStream stream = new();
+        await _serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+        Graph roundTripped = await _serializer.FromJsonAsync(stream);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(roundTripped.OutcomeCodes, Is.Not.Null);
+            Assert.That(roundTripped.OutcomeCodes![1], Is.EqualTo(7));
+            Assert.That(roundTripped.OutcomeNames, Is.Not.Null);
+            Assert.That(roundTripped.OutcomeNames![7], Is.EqualTo("Approved"));
+        });
+    }
+
+    [Test]
+    public async Task graph_without_retry_policies_roundtrips_with_none()
+    {
+        GraphBuilder builder = new();
+        builder.AddNode(new DummyState { Data = "only" }, isStart: true);
+        Graph graph = builder.Build(throwOnError: false);
+
+        await using MemoryStream stream = new();
+        await _serializer.ToBinaryAsync(graph, stream);
+        stream.Position = 0;
+        Graph roundTripped = await _serializer.FromBinaryAsync(stream);
+
+        Assert.That(roundTripped.RetryPolicies, Is.Null);
+    }
+}

--- a/NxGraph.Serialization/GraphDto.cs
+++ b/NxGraph.Serialization/GraphDto.cs
@@ -10,7 +10,9 @@ internal sealed class GraphDto
     /// Minimal DTO for a graph that can be serialized/deserialized.
     /// Keeps indices stable and captures names and edges.
     /// </summary>
-    public GraphDto(INodeDto[] nodes, TransitionDto[] transitions,SubGraphDto[]? subGraphs = null, int index = -1, string? name = null)
+    public GraphDto(INodeDto[] nodes, TransitionDto[] transitions, SubGraphDto[]? subGraphs = null, int index = -1,
+        string? name = null, RetryPolicyDto[]? retryPolicies = null, OutcomeCodeDto[]? outcomeCodes = null,
+        OutcomeNameDto[]? outcomeNames = null)
     {
         if (nodes.Length != transitions.Length)
             throw new ArgumentException("Nodes and transitions must have the same length.", nameof(transitions));
@@ -19,6 +21,9 @@ internal sealed class GraphDto
         SubGraphs =   subGraphs ?? [];
         Name = name;
         Index = index;
+        RetryPolicies = retryPolicies ?? [];
+        OutcomeCodes = outcomeCodes ?? [];
+        OutcomeNames = outcomeNames ?? [];
     }
 
     /// <summary>
@@ -34,5 +39,8 @@ internal sealed class GraphDto
     public SubGraphDto[] SubGraphs { get; set; }
     public string? Name { get; set; }
     public int Index { get; set; }
+    public RetryPolicyDto[] RetryPolicies { get; set; }
+    public OutcomeCodeDto[] OutcomeCodes { get; set; }
+    public OutcomeNameDto[] OutcomeNames { get; set; }
 
 }

--- a/NxGraph.Serialization/GraphDtoFormatter.cs
+++ b/NxGraph.Serialization/GraphDtoFormatter.cs
@@ -8,17 +8,25 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
     internal static readonly GraphDtoFormatter Instance = new();
 
     private const int VersionOneHeaderCount = 6;
+    private const int VersionTwoHeaderCount = 9;
 
     public override void Serialize(ref MessagePackWriter writer, GraphDto value, MessagePackSerializerOptions options)
     {
-        // [0.Version 1.Index, 2.Name, 3.Nodes[], 4.Transitions[], 5.SubGraphs[]]
-        writer.WriteArrayHeader(VersionOneHeaderCount);
+        // [0.Version 1.Index, 2.Name, 3.Nodes[], 4.Transitions[], 5.SubGraphs[],
+        //  6.RetryPolicies[], 7.OutcomeCodes[], 8.OutcomeNames[]]
+        writer.WriteArrayHeader(VersionTwoHeaderCount);
         writer.Write(value.Version);
         writer.Write(value.Index);
         writer.Write(value.Name);
         options.Resolver.GetFormatterWithVerify<INodeDto[]>().Serialize(ref writer, value.Nodes, options);
         options.Resolver.GetFormatterWithVerify<TransitionDto[]>().Serialize(ref writer, value.Transitions, options);
         options.Resolver.GetFormatterWithVerify<SubGraphDto[]>().Serialize(ref writer, value.SubGraphs, options);
+        options.Resolver.GetFormatterWithVerify<RetryPolicyDto[]>()
+            .Serialize(ref writer, value.RetryPolicies, options);
+        options.Resolver.GetFormatterWithVerify<OutcomeCodeDto[]>()
+            .Serialize(ref writer, value.OutcomeCodes, options);
+        options.Resolver.GetFormatterWithVerify<OutcomeNameDto[]>()
+            .Serialize(ref writer, value.OutcomeNames, options);
     }
 
     public override GraphDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
@@ -33,6 +41,9 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
             case 1 when count < VersionOneHeaderCount:
                 throw new InvalidOperationException(
                     $"GraphDto: expected at least {VersionOneHeaderCount} elements, got {count}");
+            case 2 when count < VersionTwoHeaderCount:
+                throw new InvalidOperationException(
+                    $"GraphDto: expected at least {VersionTwoHeaderCount} elements, got {count}");
         }
 
         int index = reader.ReadInt32();
@@ -43,7 +54,21 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
         SubGraphDto[] subGraphs =
             options.Resolver.GetFormatterWithVerify<SubGraphDto[]>().Deserialize(ref reader, options);
 
+        // Version-1 payloads end after SubGraphs; retry policies and outcomes arrived with version 2.
+        RetryPolicyDto[] retryPolicies = [];
+        OutcomeCodeDto[] outcomeCodes = [];
+        OutcomeNameDto[] outcomeNames = [];
+        if (count >= VersionTwoHeaderCount)
+        {
+            retryPolicies = options.Resolver.GetFormatterWithVerify<RetryPolicyDto[]>()
+                .Deserialize(ref reader, options);
+            outcomeCodes = options.Resolver.GetFormatterWithVerify<OutcomeCodeDto[]>()
+                .Deserialize(ref reader, options);
+            outcomeNames = options.Resolver.GetFormatterWithVerify<OutcomeNameDto[]>()
+                .Deserialize(ref reader, options);
+        }
 
-        return new GraphDto(nodes, transitions, subGraphs, index, name) { Version = version };
+        return new GraphDto(nodes, transitions, subGraphs, index, name, retryPolicies, outcomeCodes, outcomeNames)
+            { Version = version };
     }
 }

--- a/NxGraph.Serialization/GraphFormatterResolver.cs
+++ b/NxGraph.Serialization/GraphFormatterResolver.cs
@@ -49,6 +49,42 @@ internal sealed class GraphFormatterResolver : IFormatterResolver
                 return;
             }
 
+            if (typeof(T) == typeof(RetryPolicyDto))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)RetryPolicyDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(RetryPolicyDto[]))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)RetryPolicyArrayDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(OutcomeCodeDto))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)OutcomeCodeDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(OutcomeCodeDto[]))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)OutcomeCodeArrayDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(OutcomeNameDto))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)OutcomeNameDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(OutcomeNameDto[]))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)OutcomeNameArrayDtoFormatter.Instance;
+                return;
+            }
+
             if (typeof(T) == typeof(SubGraphDto))
             {
                 Formatter = (IMessagePackFormatter<T>)(object)SubGraphDtoFormatter.Instance;

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -151,7 +151,8 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         {
             Transition tr = graph.GetTransitionByIndex(index);
             int dest = tr.IsEmpty ? -1 : tr.Destination.Index;
-            transitions[index] = new TransitionDto(dest);
+            int failureDest = tr.HasFailureDestination ? tr.FailureDestination.Index : -1;
+            transitions[index] = new TransitionDto(dest, failureDest);
         }
 
         int nodeCount = graph.NodeCount;
@@ -197,7 +198,54 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             }
         }
 
-        return new GraphDto(nodes, transitions, subGraphs.ToArray(), graph.Id.Index, graph.Id.Name);
+        RetryPolicyDto[]? retryPolicies = null;
+        if (graph.RetryPolicies is { } policies)
+        {
+            List<RetryPolicyDto> entries = [];
+            for (int index = 0; index < policies.Length; index++)
+            {
+                RetryPolicy policy = policies[index];
+                if (policy.MaxAttempts == 0)
+                {
+                    continue;
+                }
+
+                entries.Add(new RetryPolicyDto(index, policy.MaxAttempts, policy.Backoff.Ticks,
+                    (byte)policy.BackoffKind));
+            }
+
+            retryPolicies = entries.ToArray();
+        }
+
+        OutcomeCodeDto[]? outcomeCodes = null;
+        if (graph.OutcomeCodes is { } codes)
+        {
+            List<OutcomeCodeDto> entries = [];
+            for (int index = 0; index < codes.Length; index++)
+            {
+                if (codes[index] != 0)
+                {
+                    entries.Add(new OutcomeCodeDto(index, codes[index]));
+                }
+            }
+
+            outcomeCodes = entries.ToArray();
+        }
+
+        OutcomeNameDto[]? outcomeNames = null;
+        if (graph.OutcomeNames is { Count: > 0 } names)
+        {
+            List<OutcomeNameDto> entries = [];
+            foreach ((int code, string outcomeName) in names)
+            {
+                entries.Add(new OutcomeNameDto(code, outcomeName));
+            }
+
+            outcomeNames = entries.ToArray();
+        }
+
+        return new GraphDto(nodes, transitions, subGraphs.ToArray(), graph.Id.Index, graph.Id.Name, retryPolicies,
+            outcomeCodes, outcomeNames);
     }
 
     private Graph FromDto(GraphDto dto) => FromDto(dto, depth: 0);
@@ -324,14 +372,65 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             if (trDto.Destination < -1 || trDto.Destination >= nodesLength)
                 throw new InvalidOperationException(
                     $"Transition DTO destination index {trDto.Destination} is out of range (-1..{nodesLength - 1}).");
+            if (trDto.FailureDestination < -1 || trDto.FailureDestination >= nodesLength)
+                throw new InvalidOperationException(
+                    $"Transition DTO failure destination index {trDto.FailureDestination} is out of range (-1..{nodesLength - 1}).");
 
-            transitions[i] = trDto.Destination == Transition.Empty.Destination.Index
-                ? Transition.Empty
-                : new Transition(nodes[trDto.Destination].Id);
+            NodeId dest = trDto.Destination == -1 ? NodeId.Default : nodes[trDto.Destination].Id;
+            NodeId failureDest = trDto.FailureDestination == -1 ? NodeId.Default : nodes[trDto.FailureDestination].Id;
+            transitions[i] = new Transition(dest, failureDest);
+        }
+
+        RetryPolicy[]? retryPolicies = null;
+        if (dto.RetryPolicies is { Length: > 0 })
+        {
+            retryPolicies = new RetryPolicy[nodesLength];
+            foreach (RetryPolicyDto entry in dto.RetryPolicies)
+            {
+                if (entry.Index < 0 || entry.Index >= nodesLength)
+                    throw new InvalidOperationException(
+                        $"Retry policy DTO index {entry.Index} is out of range (0..{nodesLength - 1}).");
+                if (entry.MaxAttempts == 0)
+                    throw new InvalidOperationException(
+                        $"Retry policy DTO for node {entry.Index} must allow at least one attempt.");
+                if (entry.BackoffTicks < 0)
+                    throw new InvalidOperationException(
+                        $"Retry policy DTO for node {entry.Index} has a negative backoff.");
+                if (entry.BackoffKind > (byte)BackoffKind.Exponential)
+                    throw new InvalidOperationException(
+                        $"Retry policy DTO for node {entry.Index} has unknown backoff kind {entry.BackoffKind}.");
+
+                retryPolicies[entry.Index] = new RetryPolicy(entry.MaxAttempts,
+                    TimeSpan.FromTicks(entry.BackoffTicks), (BackoffKind)entry.BackoffKind);
+            }
+        }
+
+        int[]? outcomeCodes = null;
+        if (dto.OutcomeCodes is { Length: > 0 })
+        {
+            outcomeCodes = new int[nodesLength];
+            foreach (OutcomeCodeDto entry in dto.OutcomeCodes)
+            {
+                if (entry.NodeIndex < 0 || entry.NodeIndex >= nodesLength)
+                    throw new InvalidOperationException(
+                        $"Outcome code DTO index {entry.NodeIndex} is out of range (0..{nodesLength - 1}).");
+
+                outcomeCodes[entry.NodeIndex] = entry.Code;
+            }
+        }
+
+        Dictionary<int, string>? outcomeNames = null;
+        if (dto.OutcomeNames is { Length: > 0 })
+        {
+            outcomeNames = new Dictionary<int, string>(dto.OutcomeNames.Length);
+            foreach (OutcomeNameDto entry in dto.OutcomeNames)
+            {
+                outcomeNames[entry.Code] = entry.Name;
+            }
         }
 
         NodeId graphId = new(dto.Index, dto.Name);
-        return new Graph(graphId, nodes, transitions);
+        return new Graph(graphId, nodes, transitions, logic: null, retryPolicies, outcomeCodes, outcomeNames);
     }
 
 

--- a/NxGraph.Serialization/OutcomeDtos.cs
+++ b/NxGraph.Serialization/OutcomeDtos.cs
@@ -1,0 +1,111 @@
+using MessagePack;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization;
+
+/// <summary>Sparse per-node terminal outcome code entry.</summary>
+internal sealed record OutcomeCodeDto(int NodeIndex, int Code);
+
+/// <summary>Display name for an outcome code.</summary>
+internal sealed record OutcomeNameDto(int Code, string Name);
+
+internal sealed class OutcomeCodeDtoFormatter : GraphEntityFormatter<OutcomeCodeDto>
+{
+    public static readonly OutcomeCodeDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, OutcomeCodeDto value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(2);
+        writer.Write(value.NodeIndex);
+        writer.Write(value.Code);
+    }
+
+    public override OutcomeCodeDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        if (count != 2) throw new InvalidOperationException($"OutcomeCodeDto: expected 2 elements, got {count}");
+
+        int nodeIndex = reader.ReadInt32();
+        int code = reader.ReadInt32();
+        return new OutcomeCodeDto(nodeIndex, code);
+    }
+}
+
+internal sealed class OutcomeCodeArrayDtoFormatter : GraphEntityFormatter<OutcomeCodeDto[]>
+{
+    public static readonly OutcomeCodeArrayDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, OutcomeCodeDto[] value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(value.Length);
+        for (int index = 0; index < value.Length; index++)
+        {
+            options.Resolver.GetFormatterWithVerify<OutcomeCodeDto>().Serialize(ref writer, value[index], options);
+        }
+    }
+
+    public override OutcomeCodeDto[] Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        OutcomeCodeDto[] codes = new OutcomeCodeDto[count];
+        for (int i = 0; i < count; i++)
+        {
+            codes[i] = options.Resolver.GetFormatterWithVerify<OutcomeCodeDto>().Deserialize(ref reader, options);
+        }
+
+        return codes;
+    }
+}
+
+internal sealed class OutcomeNameDtoFormatter : GraphEntityFormatter<OutcomeNameDto>
+{
+    public static readonly OutcomeNameDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, OutcomeNameDto value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(2);
+        writer.Write(value.Code);
+        writer.Write(value.Name);
+    }
+
+    public override OutcomeNameDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        if (count != 2) throw new InvalidOperationException($"OutcomeNameDto: expected 2 elements, got {count}");
+
+        int code = reader.ReadInt32();
+        string name = reader.ReadString() ??
+                      throw new InvalidOperationException("OutcomeNameDto: name cannot be null.");
+        return new OutcomeNameDto(code, name);
+    }
+}
+
+internal sealed class OutcomeNameArrayDtoFormatter : GraphEntityFormatter<OutcomeNameDto[]>
+{
+    public static readonly OutcomeNameArrayDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, OutcomeNameDto[] value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(value.Length);
+        for (int index = 0; index < value.Length; index++)
+        {
+            options.Resolver.GetFormatterWithVerify<OutcomeNameDto>().Serialize(ref writer, value[index], options);
+        }
+    }
+
+    public override OutcomeNameDto[] Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        OutcomeNameDto[] names = new OutcomeNameDto[count];
+        for (int i = 0; i < count; i++)
+        {
+            names[i] = options.Resolver.GetFormatterWithVerify<OutcomeNameDto>().Deserialize(ref reader, options);
+        }
+
+        return names;
+    }
+}

--- a/NxGraph.Serialization/RetryPolicyDto.cs
+++ b/NxGraph.Serialization/RetryPolicyDto.cs
@@ -1,0 +1,6 @@
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// Sparse per-node retry policy entry: only nodes that declare a policy are serialized.
+/// </summary>
+internal sealed record RetryPolicyDto(int Index, byte MaxAttempts, long BackoffTicks, byte BackoffKind);

--- a/NxGraph.Serialization/RetryPolicyDtoFormatter.cs
+++ b/NxGraph.Serialization/RetryPolicyDtoFormatter.cs
@@ -1,0 +1,60 @@
+using MessagePack;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization;
+
+internal sealed class RetryPolicyDtoFormatter : GraphEntityFormatter<RetryPolicyDto>
+{
+    public static readonly RetryPolicyDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, RetryPolicyDto value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(4);
+        writer.Write(value.Index);
+        writer.Write(value.MaxAttempts);
+        writer.Write(value.BackoffTicks);
+        writer.Write(value.BackoffKind);
+    }
+
+    public override RetryPolicyDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        if (count != 4) throw new InvalidOperationException($"RetryPolicyDto: expected 4 elements, got {count}");
+
+        int index = reader.ReadInt32();
+        byte maxAttempts = reader.ReadByte();
+        long backoffTicks = reader.ReadInt64();
+        byte backoffKind = reader.ReadByte();
+        return new RetryPolicyDto(index, maxAttempts, backoffTicks, backoffKind);
+    }
+}
+
+internal sealed class RetryPolicyArrayDtoFormatter : GraphEntityFormatter<RetryPolicyDto[]>
+{
+    public static readonly RetryPolicyArrayDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, RetryPolicyDto[] value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(value.Length);
+        for (int index = 0; index < value.Length; index++)
+        {
+            options.Resolver.GetFormatterWithVerify<RetryPolicyDto>()
+                .Serialize(ref writer, value[index], options);
+        }
+    }
+
+    public override RetryPolicyDto[] Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        RetryPolicyDto[] policies = new RetryPolicyDto[count];
+        for (int i = 0; i < count; i++)
+        {
+            policies[i] = options.Resolver.GetFormatterWithVerify<RetryPolicyDto>()
+                .Deserialize(ref reader, options);
+        }
+
+        return policies;
+    }
+}

--- a/NxGraph.Serialization/SerializationVersion.cs
+++ b/NxGraph.Serialization/SerializationVersion.cs
@@ -2,7 +2,7 @@
 
 public static class SerializationVersion
 {
-    public const int Version = 1;
+    public const int Version = 2;
     
 }
 

--- a/NxGraph.Serialization/TransitionDto.cs
+++ b/NxGraph.Serialization/TransitionDto.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace NxGraph.Serialization;
 
-internal sealed record TransitionDto(int Destination);
+internal sealed record TransitionDto(int Destination, int FailureDestination = -1);

--- a/NxGraph.Serialization/TransitionDtoFormatter.cs
+++ b/NxGraph.Serialization/TransitionDtoFormatter.cs
@@ -1,4 +1,4 @@
-﻿using MessagePack;
+using MessagePack;
 using NxGraph.Serialization.Abstraction;
 
 namespace NxGraph.Serialization;
@@ -10,17 +10,29 @@ internal sealed class TransitionDtoFormatter : GraphEntityFormatter<TransitionDt
     public override void Serialize(ref MessagePackWriter writer, TransitionDto value,
         MessagePackSerializerOptions options)
     {
-        // [Destination] ; slot index is the "from"
-        writer.WriteArrayHeader(1);
+        // [Destination, FailureDestination] ; slot index is the "from"
+        writer.WriteArrayHeader(2);
         writer.Write(value.Destination);
+        writer.Write(value.FailureDestination);
     }
 
     public override TransitionDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
     {
         int count = reader.ReadArrayHeader();
-        if (count != 1) throw new InvalidOperationException($"TransitionDto: expected 1, got {count}");
-
-        int dest = reader.ReadInt32();
-        return new TransitionDto(dest); // from ignored; array slot determines it
+        // Version-1 payloads carried only the success destination; accept them with no
+        // failure edge so old graphs stay readable.
+        switch (count)
+        {
+            case 1:
+                return new TransitionDto(reader.ReadInt32());
+            case 2:
+            {
+                int dest = reader.ReadInt32();
+                int failureDest = reader.ReadInt32();
+                return new TransitionDto(dest, failureDest);
+            }
+            default:
+                throw new InvalidOperationException($"TransitionDto: expected 1 or 2 elements, got {count}");
+        }
     }
 }

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -1,0 +1,264 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Asserting allocation gate for the two run loops. Unlike the BenchmarkDotNet report
+/// (which is human-read), these tests fail CI when a change allocates on the hot path.
+/// Every hot-path feature should add a case here exercising it end to end.
+/// <para>
+/// Measurements use <see cref="GC.GetAllocatedBytesForCurrentThread"/>; all node logic
+/// completes synchronously, so awaits never leave the measuring thread. The gate only
+/// holds for Release builds (Debug async methods heap-allocate their state machines),
+/// so the fixture self-ignores in Debug.
+/// </para>
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class AllocationGateTests
+{
+    private const int Iterations = 200;
+
+    private sealed class NoopAsyncObserver : IAsyncStateMachineObserver
+    {
+        public ValueTask OnStateEntered(NodeId id, CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask OnStateExited(NodeId id, CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask OnStateFailed(NodeId id, Exception? ex, CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask OnTransition(NodeId from, NodeId to, CancellationToken ct = default) => ValueTask.CompletedTask;
+    }
+
+    private sealed class NoopSyncObserver : IStateMachineObserver;
+
+    [SetUp]
+    public void RequireReleaseBuild()
+    {
+#if DEBUG
+        Assert.Ignore("The allocation gate is only meaningful for Release builds.");
+#endif
+    }
+
+    private static async Task AssertZeroAllocAsync(AsyncStateMachine machine)
+    {
+        for (int i = 0; i < 50; i++)
+        {
+            await machine.ExecuteAsync();
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < Iterations; i++)
+        {
+            await machine.ExecuteAsync();
+        }
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.That(allocated, Is.Zero,
+            $"Async hot path allocated {allocated} B over {Iterations} runs.");
+    }
+
+    private static void AssertZeroAlloc(StateMachine machine)
+    {
+        for (int i = 0; i < 50; i++)
+        {
+            RunToCompletion(machine);
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < Iterations; i++)
+        {
+            RunToCompletion(machine);
+        }
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.That(allocated, Is.Zero,
+            $"Sync hot path allocated {allocated} B over {Iterations} runs.");
+    }
+
+    private static void RunToCompletion(StateMachine machine)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+    }
+
+    private static StateToken AsyncChain(int length)
+    {
+        StateToken token = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success);
+        for (int i = 1; i < length; i++)
+        {
+            token = token.ToAsync(_ => ResultHelpers.Success);
+        }
+
+        return token;
+    }
+
+    [Test]
+    public async Task async_single_node_is_allocation_free()
+    {
+        await AssertZeroAllocAsync(AsyncChain(1).ToAsyncStateMachine());
+    }
+
+    [Test]
+    public async Task async_chain_of_10_is_allocation_free()
+    {
+        await AssertZeroAllocAsync(AsyncChain(10).ToAsyncStateMachine());
+    }
+
+    [Test]
+    public async Task async_chain_with_observer_is_allocation_free()
+    {
+        await AssertZeroAllocAsync(AsyncChain(10).ToAsyncStateMachine(new NoopAsyncObserver()));
+    }
+
+    [Test]
+    public async Task async_goto_loop_is_allocation_free()
+    {
+        int laps = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success).SetName("Top")
+            .ToAsync(_ => ++laps % 3 != 0 ? ResultHelpers.Success : ResultHelpers.Failure)
+            .Goto("Top")
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        for (int i = 0; i < 50; i++)
+        {
+            await machine.ExecuteAsync();
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < Iterations; i++)
+        {
+            await machine.ExecuteAsync();
+        }
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.That(allocated, Is.Zero, $"Goto loop allocated {allocated} B over {Iterations} runs.");
+    }
+
+    [Test]
+    public async Task async_failure_routing_is_allocation_free()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Failure)
+            .OnErrorAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine());
+    }
+
+    [Test]
+    public async Task async_no_backoff_retry_is_allocation_free()
+    {
+        int calls = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ++calls % 3 == 0 ? ResultHelpers.Success : ResultHelpers.Failure)
+            .Retry(maxAttempts: 3)
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine());
+    }
+
+    [Test]
+    public async Task async_stepped_execution_is_allocation_free()
+    {
+        AsyncStateMachine machine = AsyncChain(10).ToAsyncStateMachine();
+
+        for (int i = 0; i < 50; i++)
+        {
+            while ((await machine.StepAsync()) == Result.InProgress)
+            {
+            }
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < Iterations; i++)
+        {
+            while ((await machine.StepAsync()) == Result.InProgress)
+            {
+            }
+        }
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.That(allocated, Is.Zero, $"Stepped execution allocated {allocated} B over {Iterations} runs.");
+    }
+
+    [Test]
+    public async Task async_entry_exit_actions_are_allocation_free()
+    {
+        int counter = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .OnEnter(() => counter++)
+            .OnExit(() => counter++)
+            .ToAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine());
+    }
+
+    [Test]
+    public async Task async_subgraph_composite_is_allocation_free()
+    {
+        Graph child = AsyncChain(3).Build();
+        Graph parent = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .SubGraph(child)
+            .ToAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        await AssertZeroAllocAsync(parent.ToAsyncStateMachine());
+    }
+
+    [Test]
+    public async Task async_history_composite_happy_path_is_allocation_free()
+    {
+        Graph child = AsyncChain(3).Build();
+        Graph parent = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .SubGraph(child, history: true)
+            .Build();
+
+        await AssertZeroAllocAsync(parent.ToAsyncStateMachine());
+    }
+
+    [Test]
+    public async Task async_parallel_regions_are_allocation_free()
+    {
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(AsyncChain(3).Build(), AsyncChain(2).Build())
+            .Build();
+
+        await AssertZeroAllocAsync(parent.ToAsyncStateMachine());
+    }
+
+    [Test]
+    public void sync_chain_of_10_is_allocation_free()
+    {
+        StateToken token = GraphBuilder.StartWith(() => Result.Success);
+        for (int i = 0; i < 9; i++)
+        {
+            token = token.To(() => Result.Success);
+        }
+
+        AssertZeroAlloc(token.ToStateMachine());
+    }
+
+    [Test]
+    public void sync_chain_with_observer_is_allocation_free()
+    {
+        StateToken token = GraphBuilder.StartWith(() => Result.Success);
+        for (int i = 0; i < 9; i++)
+        {
+            token = token.To(() => Result.Success);
+        }
+
+        AssertZeroAlloc(token.ToStateMachine(new NoopSyncObserver()));
+    }
+}

--- a/NxGraph.Tests/AsyncRelayStateLifecycleTests.cs
+++ b/NxGraph.Tests/AsyncRelayStateLifecycleTests.cs
@@ -15,7 +15,7 @@ public class AsyncRelayStateLifecycleTests
         AsyncStateMachine fsm = GraphBuilder
             .StartWithAsync(new AsyncRelayState(
                 run: _ => ResultHelpers.Success,
-                onEnter: _ => { entered = true; return ResultHelpers.Continue; },
+                onEnter: _ => { entered = true; return ResultHelpers.InProgress; },
                 onExit: _ => { exited = true; return default; }))
             .ToAsyncStateMachine();
 
@@ -50,7 +50,7 @@ public class AsyncRelayStateLifecycleTests
         AsyncStateMachine fsm = GraphBuilder
             .StartWithAsync(new AsyncRelayState(
                 run: _ => { log.Add("run"); return ResultHelpers.Success; },
-                onEnter: _ => { log.Add("enter"); return ResultHelpers.Continue; },
+                onEnter: _ => { log.Add("enter"); return ResultHelpers.InProgress; },
                 onExit: _ => { log.Add("exit"); return default; }))
             .ToAsyncStateMachine();
 

--- a/NxGraph.Tests/ContextInjectionTests.cs
+++ b/NxGraph.Tests/ContextInjectionTests.cs
@@ -1,0 +1,139 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// The agent (typed context) is bound per machine and re-stamped onto the graph at the
+/// start of every run, so one immutable <see cref="Graph"/> can be shared by several
+/// machines with distinct contexts — provided their executions don't overlap.
+/// </summary>
+[TestFixture]
+public class ContextInjectionTests
+{
+    private sealed class Blackboard
+    {
+        public string Name = "";
+        public readonly List<string> Log = [];
+    }
+
+    private static Graph BuildGraph()
+    {
+        return GraphBuilder
+            .StartWithAsync(new AsyncRelayState<Blackboard>((bb, _) =>
+            {
+                bb.Log.Add(bb.Name);
+                return ResultHelpers.Success;
+            }))
+            .Build();
+    }
+
+    [Test]
+    public async Task two_async_machines_share_a_graph_with_distinct_contexts()
+    {
+        Graph graph = BuildGraph();
+
+        Blackboard first = new() { Name = "first" };
+        Blackboard second = new() { Name = "second" };
+
+        AsyncStateMachine<Blackboard> machineA = graph.ToAsyncStateMachine<Blackboard>().Add(first);
+        AsyncStateMachine<Blackboard> machineB = graph.ToAsyncStateMachine<Blackboard>().Add(second);
+
+        await machineA.ExecuteAsync();
+        await machineB.ExecuteAsync();
+        await machineA.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Log, Is.EqualTo(new[] { "first", "first" }),
+                "Machine A must see its own context on every run, even after B ran in between.");
+            Assert.That(second.Log, Is.EqualTo(new[] { "second" }));
+        });
+    }
+
+    [Test]
+    public void two_sync_machines_share_a_graph_with_distinct_contexts()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(new RelayState<Blackboard>(bb =>
+            {
+                bb.Log.Add(bb.Name);
+                return Result.Success;
+            }))
+            .Build();
+
+        Blackboard first = new() { Name = "first" };
+        Blackboard second = new() { Name = "second" };
+
+        StateMachine<Blackboard> machineA = graph.ToStateMachine<Blackboard>().Add(first);
+        StateMachine<Blackboard> machineB = graph.ToStateMachine<Blackboard>().Add(second);
+
+        RunToCompletion(machineA);
+        RunToCompletion(machineB);
+        RunToCompletion(machineA);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Log, Is.EqualTo(new[] { "first", "first" }));
+            Assert.That(second.Log, Is.EqualTo(new[] { "second" }));
+        });
+    }
+
+    [Test]
+    public void set_agent_still_applies_immediately()
+    {
+        Graph graph = BuildGraph();
+        Blackboard context = new() { Name = "eager" };
+
+        // Immediate propagation is preserved for callers that inspect node state before running.
+        Assert.DoesNotThrow(() => graph.ToAsyncStateMachine<Blackboard>().Add(context));
+    }
+
+    private sealed class CustomComposite(Graph child) : IAsyncLogic, ISubGraphProvider
+    {
+        private readonly AsyncStateMachine _machine = new(child);
+
+        public IEnumerable<Graph> SubGraphs => [_machine.Graph];
+
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => _machine.ExecuteAsync(ct);
+    }
+
+    [Test]
+    public async Task user_defined_composite_receives_the_agent_via_subgraph_provider()
+    {
+        Blackboard context = new() { Name = "nested" };
+        Graph inner = BuildGraph();
+
+        Graph outer = GraphBuilder
+            .StartWithAsync(new CustomComposite(inner))
+            .Build();
+
+        AsyncStateMachine<Blackboard> machine = outer.ToAsyncStateMachine<Blackboard>().Add(context);
+        await machine.ExecuteAsync();
+
+        Assert.That(context.Log, Is.EqualTo(new[] { "nested" }),
+            "Graph.SetAgent must reach nodes inside a composite it has no compile-time knowledge of.");
+    }
+
+    [Test]
+    public void set_agent_with_no_accepting_node_still_throws()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        AsyncStateMachine<Blackboard> machine = graph.ToAsyncStateMachine<Blackboard>();
+        Assert.Throws<InvalidOperationException>(() => machine.SetAgent(new Blackboard()));
+    }
+
+    private static void RunToCompletion(StateMachine machine)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+    }
+}

--- a/NxGraph.Tests/EntryExitActionTests.cs
+++ b/NxGraph.Tests/EntryExitActionTests.cs
@@ -1,0 +1,142 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class EntryExitActionTests
+{
+    [Test]
+    public async Task entry_and_exit_fire_in_order_around_each_node()
+    {
+        List<string> log = [];
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                log.Add("run:A");
+                return ResultHelpers.Success;
+            })
+            .OnEnter(() => log.Add("enter:A"))
+            .OnExit(() => log.Add("exit:A"))
+            .ToAsync(_ =>
+            {
+                log.Add("run:B");
+                return ResultHelpers.Success;
+            })
+            .OnEnter(() => log.Add("enter:B"))
+            .OnExit(() => log.Add("exit:B"))
+            .Build();
+
+        await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.That(log, Is.EqualTo(new[]
+        {
+            "enter:A", "run:A", "exit:A",
+            "enter:B", "run:B", "exit:B",
+        }));
+    }
+
+    [Test]
+    public void sync_entry_and_exit_fire_in_order_around_each_node()
+    {
+        List<string> log = [];
+        Graph graph = GraphBuilder
+            .StartWith(() =>
+            {
+                log.Add("run:A");
+                return Result.Success;
+            })
+            .OnEnter(() => log.Add("enter:A"))
+            .OnExit(() => log.Add("exit:A"))
+            .To(() =>
+            {
+                log.Add("run:B");
+                return Result.Success;
+            })
+            .OnEnter(() => log.Add("enter:B"))
+            .OnExit(() => log.Add("exit:B"))
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.That(log, Is.EqualTo(new[]
+        {
+            "enter:A", "run:A", "exit:A",
+            "enter:B", "run:B", "exit:B",
+        }));
+    }
+
+    [Test]
+    public async Task retries_do_not_refire_the_entry_action()
+    {
+        int enters = 0;
+        int exits = 0;
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ++executions < 3 ? ResultHelpers.Failure : ResultHelpers.Success)
+            .OnEnter(() => enters++)
+            .OnExit(() => exits++)
+            .Retry(maxAttempts: 3)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executions, Is.EqualTo(3));
+            Assert.That(enters, Is.EqualTo(1), "Entry fires once per visit, not per attempt.");
+            Assert.That(exits, Is.EqualTo(1), "Exit fires once per visit, after the final attempt.");
+        });
+    }
+
+    [Test]
+    public async Task exit_fires_even_when_the_node_fails_terminally()
+    {
+        bool exited = false;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Failure)
+            .OnExit(() => exited = true)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(exited, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task entry_fires_again_on_revisits_via_goto()
+    {
+        int enters = 0;
+        int laps = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success).SetName("Top")
+            .OnEnter(() => enters++)
+            .ToAsync(_ => ++laps < 3 ? ResultHelpers.Success : ResultHelpers.Failure)
+            .Goto("Top")
+            .Build();
+
+        await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.That(enters, Is.EqualTo(3), "Each loop lap is a fresh visit.");
+    }
+
+    [Test]
+    public void action_on_unknown_node_throws()
+    {
+        GraphBuilder builder = new();
+        builder.AddNode(new RelayState(() => Result.Success), isStart: true);
+
+        Assert.Throws<InvalidOperationException>(() => builder.SetEnterAction(new NodeId(9), () => { }));
+    }
+}

--- a/NxGraph.Tests/FailureRoutingTests.cs
+++ b/NxGraph.Tests/FailureRoutingTests.cs
@@ -1,0 +1,226 @@
+using NxGraph.Authoring;
+using NxGraph.Diagnostics.Export;
+using NxGraph.Diagnostics.Validations;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class FailureRoutingTests
+{
+    private sealed class RecordingAsyncObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> Events = [];
+
+        public ValueTask OnStateEntered(NodeId id, CancellationToken ct = default)
+        {
+            Events.Add($"entered:{id.Index}");
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnStateExited(NodeId id, CancellationToken ct = default)
+        {
+            Events.Add($"exited:{id.Index}");
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnStateFailed(NodeId id, Exception? ex, CancellationToken ct = default)
+        {
+            Events.Add($"failed:{id.Index}:{(ex is null ? "null" : ex.GetType().Name)}");
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnTransition(NodeId from, NodeId to, CancellationToken ct = default)
+        {
+            Events.Add($"transition:{from.Index}->{to.Index}");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingSyncObserver : IStateMachineObserver
+    {
+        public readonly List<string> Events = [];
+
+        public void OnStateEntered(NodeId id) => Events.Add($"entered:{id.Index}");
+        public void OnStateExited(NodeId id) => Events.Add($"exited:{id.Index}");
+        public void OnStateFailed(NodeId id, Exception? ex) => Events.Add($"failed:{id.Index}");
+        public void OnTransition(NodeId from, NodeId to) => Events.Add($"transition:{from.Index}->{to.Index}");
+    }
+
+    [Test]
+    public async Task async_failure_routes_to_handler_and_machine_succeeds()
+    {
+        bool cleanupRan = false;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Failure)
+            .OnErrorAsync(_ =>
+            {
+                cleanupRan = true;
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(cleanupRan, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task async_failure_routing_fires_failed_transition_entered_in_order()
+    {
+        RecordingAsyncObserver observer = new();
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Failure)
+            .OnErrorAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        await graph.ToAsyncStateMachine(observer).ExecuteAsync();
+
+        Assert.That(observer.Events, Is.EqualTo(new[]
+        {
+            "entered:0",
+            "failed:0:null",
+            "transition:0->1",
+            "entered:1",
+            "exited:1",
+        }));
+    }
+
+    [Test]
+    public async Task async_failure_without_error_edge_still_terminates_with_failure()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Failure)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+        Assert.That(result, Is.EqualTo(Result.Failure));
+    }
+
+    [Test]
+    public void sync_failure_routes_to_handler_and_machine_succeeds()
+    {
+        bool cleanupRan = false;
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Failure)
+            .OnError(() =>
+            {
+                cleanupRan = true;
+                return Result.Success;
+            })
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(cleanupRan, Is.True);
+        });
+    }
+
+    [Test]
+    public void sync_failure_routing_fires_failed_transition_entered_in_order()
+    {
+        RecordingSyncObserver observer = new();
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Failure)
+            .OnError(() => Result.Success)
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine(observer);
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.That(observer.Events, Is.EqualTo(new[]
+        {
+            "entered:0",
+            "failed:0",
+            "transition:0->1",
+            "entered:1",
+            "exited:1",
+        }));
+    }
+
+    [Test]
+    public async Task failure_handler_can_continue_the_success_chain()
+    {
+        bool recovered = false;
+        StateToken start = GraphBuilder.StartWithAsync(_ => ResultHelpers.Failure);
+        StateToken handler = start.Builder.TokenFor(
+            start.Builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success)));
+        handler.ToAsync(_ =>
+        {
+            recovered = true;
+            return ResultHelpers.Success;
+        });
+
+        Graph graph = start.OnError(handler).Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(recovered, Is.True);
+        });
+    }
+
+    [Test]
+    public void duplicate_failure_edge_throws()
+    {
+        StateToken start = GraphBuilder.StartWith(() => Result.Failure)
+            .OnError(() => Result.Success);
+
+        Assert.Throws<InvalidOperationException>(() => start.OnError(() => Result.Success));
+    }
+
+    [Test]
+    public void validator_walks_failure_edges_for_reachability()
+    {
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(new RelayState(() => Result.Failure), isStart: true);
+        NodeId handler = builder.AddNode(new RelayState(() => Result.Success));
+        builder.AddFailureTransition(start, handler);
+        Graph graph = builder.Build(throwOnError: false);
+
+        GraphValidationResult result = graph.Validate(new GraphValidationOptions
+        {
+            AllNodes = builder.GetAllNodeIds(),
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.HasErrors, Is.False);
+            Assert.That(result.Diagnostics.Any(d =>
+                d.Message.Contains("unreachable", StringComparison.OrdinalIgnoreCase)), Is.False,
+                "The failure handler is reachable via the failure edge and must not be flagged.");
+        });
+    }
+
+    [Test]
+    public void mermaid_export_emits_dashed_fail_edge()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Failure).SetName("Work")
+            .OnError(() => Result.Success)
+            .Build();
+
+        string mermaid = graph.ToMermaid();
+        Assert.That(mermaid, Does.Contain("-. fail .->"));
+    }
+}

--- a/NxGraph.Tests/GotoTests.cs
+++ b/NxGraph.Tests/GotoTests.cs
@@ -1,0 +1,112 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class GotoTests
+{
+    [Test]
+    public void goto_wires_a_back_edge_to_the_named_node()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("A")
+            .To(() => Result.Success).SetName("B")
+            .Goto("A")
+            .Build();
+
+        Transition backEdge = graph.GetTransitionByIndex(1);
+        Assert.Multiple(() =>
+        {
+            Assert.That(backEdge.IsEmpty, Is.False);
+            Assert.That(backEdge.Destination.Index, Is.Zero);
+            Assert.That(backEdge.Destination.Name, Is.EqualTo("A"));
+        });
+    }
+
+    [Test]
+    public void goto_loop_executes_until_a_node_breaks_it()
+    {
+        int visits = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("A")
+            .To(() => ++visits < 3 ? Result.Success : Result.Fail("done"))
+            .Goto("A")
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(visits, Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void goto_target_may_be_named_after_the_goto_is_declared()
+    {
+        StateToken start = GraphBuilder.StartWith(() => Result.Success);
+        GotoToken chain = start.To(() => Result.Fail()).Goto("Late");
+        _ = start.SetName("Late");
+
+        Graph graph = chain.Build();
+        Assert.That(graph.GetTransitionByIndex(1).Destination.Index, Is.Zero);
+    }
+
+    [Test]
+    public void goto_with_unknown_name_fails_the_build()
+    {
+        GotoToken chain = GraphBuilder
+            .StartWith(() => Result.Success).SetName("A")
+            .To(() => Result.Success)
+            .Goto("Missing");
+
+        Assert.Throws<InvalidOperationException>(() => chain.Build());
+    }
+
+    [Test]
+    public void goto_with_ambiguous_name_fails_the_build()
+    {
+        GotoToken chain = GraphBuilder
+            .StartWith(() => Result.Success).SetName("X")
+            .To(() => Result.Success).SetName("X")
+            .To(() => Result.Success)
+            .Goto("X");
+
+        Assert.Throws<InvalidOperationException>(() => chain.Build());
+    }
+
+    [Test]
+    public void goto_conflicts_with_an_existing_transition()
+    {
+        StateToken start = GraphBuilder.StartWith(() => Result.Success).SetName("A");
+        StateToken next = start.To(() => Result.Success);
+
+        Assert.Throws<InvalidOperationException>(() => start.Goto("A"));
+        Assert.DoesNotThrow(() => next.Goto("A"));
+    }
+
+    [Test]
+    public void transition_after_goto_from_same_node_throws()
+    {
+        StateToken start = GraphBuilder.StartWith(() => Result.Success).SetName("A");
+        StateToken second = start.To(() => Result.Success);
+        second.Goto("A");
+
+        Assert.Throws<InvalidOperationException>(() => second.ToAsync(_ => ResultHelpers.Success));
+    }
+
+    [Test]
+    public void goto_with_blank_name_throws_immediately()
+    {
+        StateToken start = GraphBuilder.StartWith(() => Result.Success);
+        Assert.Throws<ArgumentException>(() => start.Goto(" "));
+    }
+}

--- a/NxGraph.Tests/HierarchicalFsmsTests.cs
+++ b/NxGraph.Tests/HierarchicalFsmsTests.cs
@@ -100,8 +100,8 @@ public class HierarchicalFsmTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(r1, Is.EqualTo(Result.Continue));
-            Assert.That(r2, Is.EqualTo(Result.Continue));
+            Assert.That(r1, Is.EqualTo(Result.InProgress));
+            Assert.That(r2, Is.EqualTo(Result.InProgress));
             Assert.That(r3, Is.EqualTo(Result.Success));
             Assert.That(log, Is.EqualTo(["child-1", "child-2", "child-exit", "parent-end", "parent-exit"]));
         }
@@ -129,8 +129,8 @@ public class HierarchicalFsmTests
         // Tick 1: grandchild's only node
         // Tick 2: child's second node  (grandchild finished → child transitions)
         // Tick 3: parent's second node (child finished → parent transitions)
-        Assert.That(parentFsm.Execute(), Is.EqualTo(Result.Continue));
-        Assert.That(parentFsm.Execute(), Is.EqualTo(Result.Continue));
+        Assert.That(parentFsm.Execute(), Is.EqualTo(Result.InProgress));
+        Assert.That(parentFsm.Execute(), Is.EqualTo(Result.InProgress));
         Assert.That(parentFsm.Execute(), Is.EqualTo(Result.Success));
     }
 

--- a/NxGraph.Tests/NxGraph.Tests.csproj
+++ b/NxGraph.Tests/NxGraph.Tests.csproj
@@ -7,10 +7,18 @@
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+
+        <!-- Coverage instrumentation scope: this project is the behavior spec for the core
+             library only; serialization assemblies are covered by NxGraph.Serialization.Tests. -->
+        <Include>[NxGraph]*</Include>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="8.0.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.msbuild" Version="6.0.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/NxGraph.Tests/OpaqueDirectorValidationTests.cs
+++ b/NxGraph.Tests/OpaqueDirectorValidationTests.cs
@@ -1,0 +1,80 @@
+using NxGraph.Authoring;
+using NxGraph.Diagnostics.Validations;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class OpaqueDirectorValidationTests
+{
+    private sealed class OpaqueDirector : AsyncState, IDirector
+    {
+        public NodeId SelectNext() => NodeId.Default;
+
+        protected override ValueTask<Result> OnRunAsync(CancellationToken ct) => ResultHelpers.Success;
+    }
+
+    private sealed class TransparentDirector : AsyncState, IDirector
+    {
+        private readonly NodeId _target;
+
+        public TransparentDirector(NodeId target) => _target = target;
+
+        public NodeId SelectNext() => _target;
+
+        public IEnumerable<NodeId> EnumerateStaticTargets() => [_target, NodeId.Default];
+
+        protected override ValueTask<Result> OnRunAsync(CancellationToken ct) => ResultHelpers.Success;
+    }
+
+    [Test]
+    public void bare_custom_director_emits_opacity_warning()
+    {
+        GraphBuilder builder = new();
+        builder.AddNode(new OpaqueDirector(), isStart: true);
+        Graph graph = builder.Build(throwOnError: false);
+
+        GraphValidationResult result = graph.Validate();
+
+        Assert.That(result.Diagnostics.Any(d =>
+                d.Severity == Severity.Warning &&
+                d.Message.Contains("no static targets", StringComparison.OrdinalIgnoreCase)),
+            Is.True, "Expected an opacity warning for a director with no static targets.");
+    }
+
+    [Test]
+    public void director_with_static_targets_stays_clean()
+    {
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success), isStart: true);
+        NodeId sink = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success));
+        NodeId director = builder.AddNode(new TransparentDirector(sink));
+        builder.AddTransition(start, director);
+        Graph graph = builder.Build(throwOnError: false);
+
+        GraphValidationResult result = graph.Validate();
+
+        Assert.That(result.Diagnostics.Any(d =>
+                d.Message.Contains("no static targets", StringComparison.OrdinalIgnoreCase)),
+            Is.False, "A director that surfaces its targets must not be flagged.");
+    }
+
+    [Test]
+    public void builtin_choice_state_stays_clean()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .If(() => true)
+            .ThenAsync(_ => ResultHelpers.Success)
+            .ElseAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        GraphValidationResult result = graph.Validate();
+
+        Assert.That(result.Diagnostics.Any(d =>
+                d.Message.Contains("no static targets", StringComparison.OrdinalIgnoreCase)),
+            Is.False, "Built-in ChoiceState surfaces its branches and must not be flagged.");
+    }
+}

--- a/NxGraph.Tests/ParallelRegionsTests.cs
+++ b/NxGraph.Tests/ParallelRegionsTests.cs
@@ -1,0 +1,148 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class ParallelRegionsTests
+{
+    private static Graph LoggingChain(List<string> log, string prefix, int length)
+    {
+        StateToken token = GraphBuilder.StartWithAsync(_ =>
+        {
+            log.Add($"{prefix}0");
+            return ResultHelpers.Success;
+        });
+
+        for (int i = 1; i < length; i++)
+        {
+            int step = i;
+            token = token.ToAsync(_ =>
+            {
+                log.Add($"{prefix}{step}");
+                return ResultHelpers.Success;
+            });
+        }
+
+        return token.Build();
+    }
+
+    [Test]
+    public async Task regions_progress_in_interleaved_round_robin_order()
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(LoggingChain(log, "a", 3), LoggingChain(log, "b", 2))
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "a0", "b0", "a1", "b1", "a2" }),
+                "One node per region per round; the shorter region joins early.");
+        });
+    }
+
+    [Test]
+    public async Task join_fails_when_any_region_fails_but_others_still_finish()
+    {
+        List<string> log = [];
+        Graph failing = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                log.Add("f0");
+                return ResultHelpers.Failure;
+            })
+            .Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(LoggingChain(log, "a", 3), failing)
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(log, Does.Contain("a2"), "The healthy region ran to completion before the join.");
+        });
+    }
+
+    [Test]
+    public async Task failed_join_routes_through_the_parent_failure_edge()
+    {
+        bool recovered = false;
+        Graph failing = GraphBuilder.StartWithAsync(_ => ResultHelpers.Failure).Build();
+        Graph healthy = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(healthy, failing)
+            .OnErrorAsync(_ =>
+            {
+                recovered = true;
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(recovered, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task composite_can_run_repeatedly()
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(LoggingChain(log, "a", 2), LoggingChain(log, "b", 2))
+            .Build();
+
+        AsyncStateMachine machine = parent.ToAsyncStateMachine();
+        await machine.ExecuteAsync();
+        await machine.ExecuteAsync();
+
+        Assert.That(log, Has.Count.EqualTo(8), "Both regions restart cleanly on the next run.");
+    }
+
+    [Test]
+    public void empty_region_list_is_rejected()
+    {
+        Assert.Throws<ArgumentException>(() => _ = new AsyncParallelState());
+    }
+
+    [Test]
+    public async Task agent_injection_reaches_region_graphs()
+    {
+        List<string> log = [];
+        Graph region = GraphBuilder
+            .StartWithAsync(new AsyncRelayState<List<string>>((agent, _) =>
+            {
+                agent.Add("region-saw-agent");
+                return ResultHelpers.Success;
+            }))
+            .Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(region)
+            .Build();
+
+        AsyncStateMachine<List<string>> machine = parent.ToAsyncStateMachine<List<string>>();
+        machine.SetAgent(log);
+        await machine.ExecuteAsync();
+
+        Assert.That(log, Is.EqualTo(new[] { "region-saw-agent" }));
+    }
+}

--- a/NxGraph.Tests/PublicApi/NxGraph.Serialization.Abstraction.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.Serialization.Abstraction.approved.txt
@@ -1,0 +1,11 @@
+interface NxGraph.Serialization.Abstraction.IGraphBinarySerializer : NxGraph.Serialization.Abstraction.IGraphSerializer
+  method System.Threading.Tasks.ValueTask ToBinaryAsync(NxGraph.Graphs.Graph, System.IO.Stream, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.Graph] FromBinaryAsync(System.IO.Stream, System.Threading.CancellationToken)
+interface NxGraph.Serialization.Abstraction.IGraphJsonSerializer : NxGraph.Serialization.Abstraction.IGraphSerializer
+  method System.Threading.Tasks.ValueTask ToJsonAsync(NxGraph.Graphs.Graph, System.IO.Stream, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.Graph] FromJsonAsync(System.IO.Stream, System.Threading.CancellationToken)
+interface NxGraph.Serialization.Abstraction.IGraphSerializer
+interface NxGraph.Serialization.Abstraction.ILogicCodec
+interface NxGraph.Serialization.Abstraction.ILogicCodec`1 : NxGraph.Serialization.Abstraction.ILogicCodec
+  method NxGraph.Graphs.IAsyncLogic Deserialize(TWire)
+  method TWire Serialize(NxGraph.Graphs.IAsyncLogic)

--- a/NxGraph.Tests/PublicApi/NxGraph.Serialization.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.Serialization.approved.txt
@@ -1,0 +1,12 @@
+sealed class NxGraph.Serialization.GraphSerializer : NxGraph.Serialization.Abstraction.IGraphBinarySerializer, NxGraph.Serialization.Abstraction.IGraphJsonSerializer, NxGraph.Serialization.Abstraction.IGraphSerializer
+  ctor Void .ctor(NxGraph.Serialization.Abstraction.ILogicCodec)
+  method NxGraph.Serialization.Abstraction.IGraphBinarySerializer AsBinarySerializer()
+  method NxGraph.Serialization.Abstraction.IGraphJsonSerializer AsJsonSerializer()
+  method System.Threading.Tasks.ValueTask ToBinaryAsync(NxGraph.Graphs.Graph, System.IO.Stream, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask ToJsonAsync(NxGraph.Graphs.Graph, System.IO.Stream, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.Graph] FromBinaryAsync(System.IO.Stream, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.Graph] FromJsonAsync(System.IO.Stream, System.Threading.CancellationToken)
+interface NxGraph.Serialization.ILogicBinaryCodec : NxGraph.Serialization.Abstraction.ILogicCodec, NxGraph.Serialization.Abstraction.ILogicCodec`1[[System.ReadOnlyMemory`1[[System.Byte, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
+interface NxGraph.Serialization.ILogicTextCodec : NxGraph.Serialization.Abstraction.ILogicCodec, NxGraph.Serialization.Abstraction.ILogicCodec`1[[System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
+static class NxGraph.Serialization.SerializationVersion
+  field static System.Int32 Version

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -1,0 +1,585 @@
+static class NxGraph.Authoring.Dsl
+  method AsyncSwitchBuilder`1 CaseAsync[TKey](AsyncSwitchBuilder`1, TKey, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method AsyncSwitchBuilder`1 Case[TKey](AsyncSwitchBuilder`1, TKey, System.Func`1[NxGraph.Result])
+  method AsyncSwitchBuilder`1 DefaultAsync[TKey](AsyncSwitchBuilder`1, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method AsyncSwitchBuilder`1 Default[TKey](AsyncSwitchBuilder`1, System.Func`1[NxGraph.Result])
+  method AsyncSwitchBuilder`1 SwitchAsync[TKey](NxGraph.Authoring.StateToken, System.Func`1[System.Threading.Tasks.ValueTask`1[TKey]])
+  method BranchBuilder SetName(BranchBuilder, System.String)
+  method BranchBuilder Then(IfBuilder, System.Func`1[NxGraph.Result])
+  method BranchBuilder ThenAsync(IfBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method BranchBuilder To(BranchBuilder, System.Func`1[NxGraph.Result])
+  method BranchBuilder ToAsync(BranchBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method BranchEnd Else(BranchBuilder, System.Func`1[NxGraph.Result])
+  method BranchEnd ElseAsync(BranchBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method BranchEnd SetName(BranchEnd, System.String)
+  method IfBuilder If(NxGraph.Authoring.StateToken, System.Func`1[System.Boolean])
+  method NxGraph.Authoring.StateToken OnError(NxGraph.Authoring.StateToken, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken OnErrorAsync(NxGraph.Authoring.StateToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken SetName(NxGraph.Authoring.StateToken, System.String)
+  method NxGraph.Authoring.StateToken StartWithTimeoutAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StartToken, NxGraph.Graphs.Graph, Boolean)
+  method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StateToken, NxGraph.Graphs.Graph, Boolean)
+  method NxGraph.Authoring.StateToken To(BranchEnd, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StartToken, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken ToAsync(BranchEnd, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StateToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken WaitForAsync(NxGraph.Authoring.StartToken, System.TimeSpan)
+  method NxGraph.Authoring.StateToken WaitForAsync(NxGraph.Authoring.StateToken, System.TimeSpan)
+  method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(BranchBuilder, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Authoring.StartToken, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Authoring.StateToken, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] ToAsyncStateMachine[TAgent](BranchBuilder, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] ToAsyncStateMachine[TAgent](NxGraph.Authoring.StartToken, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] ToAsyncStateMachine[TAgent](NxGraph.Authoring.StateToken, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] WithAgent[TAgent](NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent], TAgent)
+  method NxGraph.Fsm.StateMachine ToStateMachine(BranchBuilder, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine ToStateMachine(BranchEnd, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine ToStateMachine(NxGraph.Authoring.StartToken, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine ToStateMachine(NxGraph.Authoring.StateToken, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] ToStateMachine[TAgent](BranchBuilder, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] ToStateMachine[TAgent](BranchEnd, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] ToStateMachine[TAgent](NxGraph.Authoring.StartToken, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] ToStateMachine[TAgent](NxGraph.Authoring.StateToken, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] WithAgent[TAgent](NxGraph.Fsm.StateMachine`1[TAgent], TAgent)
+  method NxGraph.Graphs.Graph Build(BranchBuilder)
+  method NxGraph.Graphs.Graph SetName(NxGraph.Graphs.Graph, System.String)
+  method SwitchBuilder`1 CaseAsync[TKey](SwitchBuilder`1, TKey, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method SwitchBuilder`1 Case[TKey](SwitchBuilder`1, TKey, System.Func`1[NxGraph.Result])
+  method SwitchBuilder`1 DefaultAsync[TKey](SwitchBuilder`1, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method SwitchBuilder`1 Default[TKey](SwitchBuilder`1, System.Func`1[NxGraph.Result])
+  method SwitchBuilder`1 Switch[TKey](NxGraph.Authoring.StateToken, System.Func`1[TKey])
+  method System.TimeSpan Days(Double)
+  method System.TimeSpan Days(Int32)
+  method System.TimeSpan Hours(Double)
+  method System.TimeSpan Hours(Int32)
+  method System.TimeSpan Milliseconds(Double)
+  method System.TimeSpan Milliseconds(Int32)
+  method System.TimeSpan Minutes(Double)
+  method System.TimeSpan Minutes(Int32)
+  method System.TimeSpan Seconds(Double)
+  method System.TimeSpan Seconds(Int32)
+struct NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1
+  method AsyncSwitchBuilder`1 Case(TKey, NxGraph.Graphs.ILogic)
+  method AsyncSwitchBuilder`1 CaseAsync(TKey, NxGraph.Graphs.IAsyncLogic)
+  method AsyncSwitchBuilder`1 Default(NxGraph.Graphs.ILogic)
+  method AsyncSwitchBuilder`1 DefaultAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken End()
+struct NxGraph.Authoring.Dsl+BranchBuilder
+  method BranchBuilder To(NxGraph.Graphs.ILogic)
+  method BranchBuilder ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method BranchBuilder WaitForAsync(System.TimeSpan)
+  method BranchEnd Else(NxGraph.Graphs.ILogic)
+  method BranchEnd ElseAsync(NxGraph.Graphs.IAsyncLogic)
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+  property NxGraph.Graphs.NodeId Tip { get; }
+struct NxGraph.Authoring.Dsl+BranchEnd
+  method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken WaitForAsync(System.TimeSpan)
+  method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[T] ToAsyncStateMachine[T](NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Graphs.Graph Build(Boolean)
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+  property NxGraph.Graphs.NodeId Tip { get; }
+struct NxGraph.Authoring.Dsl+IfBuilder
+  method BranchBuilder Then(NxGraph.Graphs.ILogic)
+  method BranchBuilder ThenAsync(NxGraph.Graphs.IAsyncLogic)
+struct NxGraph.Authoring.Dsl+SwitchBuilder`1
+  method NxGraph.Authoring.StateToken End()
+  method SwitchBuilder`1 Case(TKey, NxGraph.Graphs.ILogic)
+  method SwitchBuilder`1 CaseAsync(TKey, NxGraph.Graphs.IAsyncLogic)
+  method SwitchBuilder`1 Default(NxGraph.Graphs.ILogic)
+  method SwitchBuilder`1 DefaultAsync(NxGraph.Graphs.IAsyncLogic)
+struct NxGraph.Authoring.GotoToken
+  method NxGraph.Graphs.Graph Build()
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+sealed class NxGraph.Authoring.GraphBuilder
+  ctor Void .ctor()
+  method NxGraph.Authoring.GraphBuilder AddFailureTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method NxGraph.Authoring.GraphBuilder AddGoto(NxGraph.Graphs.NodeId, System.String)
+  method NxGraph.Authoring.GraphBuilder AddTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method NxGraph.Authoring.GraphBuilder SetEnterAction(NxGraph.Graphs.NodeId, System.Action)
+  method NxGraph.Authoring.GraphBuilder SetExitAction(NxGraph.Graphs.NodeId, System.Action)
+  method NxGraph.Authoring.GraphBuilder SetOutcome(NxGraph.Graphs.NodeId, Int32, System.String)
+  method NxGraph.Authoring.GraphBuilder SetRetryPolicy(NxGraph.Graphs.NodeId, NxGraph.Fsm.RetryPolicy)
+  method NxGraph.Authoring.StartToken Start()
+  method NxGraph.Authoring.StateToken StartWith(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken StartWith(System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken StartWithAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken StartWithAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken TokenFor(NxGraph.Graphs.NodeId)
+  method NxGraph.Diagnostics.Validations.GraphValidationResult Validate(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Validations.GraphValidationOptions)
+  method NxGraph.Graphs.Graph Build(Boolean)
+  method NxGraph.Graphs.NodeId AddNode(NxGraph.Graphs.IAsyncLogic, Boolean)
+  method NxGraph.Graphs.NodeId AddNode(NxGraph.Graphs.ILogic, Boolean)
+  method System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId] GetAllNodeIds()
+  method Void SetName(NxGraph.Graphs.Graph, System.String)
+  method Void SetName(NxGraph.Graphs.NodeId, System.String)
+static class NxGraph.Authoring.GraphBuilderExtensions
+  method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] Add[TAgent](NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent], TAgent)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] ToAsyncStateMachine[TAgent](NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.StateMachine ToStateMachine(NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] Add[TAgent](NxGraph.Fsm.StateMachine`1[TAgent], TAgent)
+  method NxGraph.Fsm.StateMachine`1[TAgent] ToStateMachine[TAgent](NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
+sealed class NxGraph.Authoring.GraphValidationException : System.Exception, System.Runtime.Serialization.ISerializable
+  ctor Void .ctor(NxGraph.Diagnostics.Validations.GraphValidationResult)
+  property NxGraph.Diagnostics.Validations.GraphValidationResult Result { get; }
+struct NxGraph.Authoring.StartToken
+  method AsyncSwitchBuilder`1 SwitchAsync[TKey](System.Func`1[System.Threading.Tasks.ValueTask`1[TKey]])
+  method IfBuilder If(System.Func`1[System.Boolean])
+  method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken To(System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken ToAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Graphs.Graph Build()
+  method SwitchBuilder`1 Switch[TKey](System.Func`1[TKey])
+struct NxGraph.Authoring.StateToken
+  method NxGraph.Authoring.GotoToken Goto(System.String)
+  method NxGraph.Authoring.StateToken OnEnter(System.Action)
+  method NxGraph.Authoring.StateToken OnError(NxGraph.Authoring.StateToken)
+  method NxGraph.Authoring.StateToken OnError(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken OnErrorAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken OnExit(System.Action)
+  method NxGraph.Authoring.StateToken Retry(Byte, System.TimeSpan, NxGraph.Fsm.BackoffKind)
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken)
+  method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken WithOutcome(Int32, System.String)
+  method NxGraph.Graphs.Graph Build()
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+class NxGraph.Diagnostics.Export.ExportOptions
+  ctor Void .ctor()
+enum NxGraph.Diagnostics.Export.FlowDirection : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  BottomToTop = 3
+  LeftToRight = 1
+  RightToLeft = 2
+  TopToBottom = 0
+static class NxGraph.Diagnostics.Export.GraphExportExtensions
+  method System.String ExportWith(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Export.IGraphExporter, NxGraph.Diagnostics.Export.ExportOptions)
+  method System.String ToMermaid(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Export.MermaidExportOptions)
+interface NxGraph.Diagnostics.Export.IGraphExporter
+  method System.String Export(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Export.ExportOptions)
+  property System.String ContentType { get; }
+  property System.String FileExtension { get; }
+  property System.String Format { get; }
+sealed class NxGraph.Diagnostics.Export.MermaidExportOptions : NxGraph.Diagnostics.Export.ExportOptions
+  ctor Void .ctor()
+  property Boolean AddTerminalNode { get; set; }
+  property Boolean ShowNodeIndices { get; set; }
+  property Boolean UseNodeNames { get; set; }
+  property NxGraph.Diagnostics.Export.FlowDirection Direction { get; set; }
+  property System.String TerminalLabel { get; set; }
+  property System.String Title { get; set; }
+sealed class NxGraph.Diagnostics.Export.MermaidGraphExporter : NxGraph.Diagnostics.Export.IGraphExporter
+  ctor Void .ctor()
+  method System.String Export(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Export.ExportOptions)
+  property System.String ContentType { get; }
+  property System.String FileExtension { get; }
+  property System.String Format { get; }
+enum NxGraph.Diagnostics.Replay.EventType : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Log = 9
+  StateEntered = 0
+  StateExited = 1
+  StateFailed = 3
+  StateMachineCancelled = 7
+  StateMachineCompleted = 6
+  StateMachineReset = 4
+  StateMachineStarted = 5
+  StatusChanged = 8
+  Transition = 2
+interface NxGraph.Diagnostics.Replay.ILogReporter
+  property System.Func`3[System.String,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask] LogReport { get; set; }
+struct NxGraph.Diagnostics.Replay.ReplayEvent
+  ctor Void .ctor(NxGraph.Diagnostics.Replay.EventType, NxGraph.Graphs.NodeId, System.Nullable`1[NxGraph.Graphs.NodeId], System.String, Int64)
+  property Int64 Timestamp { get; }
+  property NxGraph.Diagnostics.Replay.EventType Type { get; }
+  property NxGraph.Graphs.NodeId SourceId { get; }
+  property System.Nullable`1[NxGraph.Graphs.NodeId] TargetId { get; }
+  property System.String Message { get; }
+sealed class NxGraph.Diagnostics.Replay.ReplayRecorder : NxGraph.Fsm.IAsyncStateMachineObserver, NxGraph.Fsm.IStateMachineObserver
+  ctor Void .ctor(Int32)
+  method System.ReadOnlyMemory`1[NxGraph.Diagnostics.Replay.ReplayEvent] GetEvents()
+  method System.Threading.Tasks.ValueTask OnLogReport(NxGraph.Graphs.NodeId, System.String, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateEntered(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineCancelled(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineReset(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineStarted(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask StateMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus, System.Threading.CancellationToken)
+  method Void Clear()
+  property Int32 Capacity { get; }
+  property Int32 Count { get; }
+  property Int64 DroppedCount { get; }
+  property NxGraph.Diagnostics.Replay.ReplayEvent Item [Int32] { get; }
+class NxGraph.Diagnostics.Replay.StateMachineReplay
+  ctor Void .ctor(System.ReadOnlySpan`1[NxGraph.Diagnostics.Replay.ReplayEvent])
+  method Byte[] Serialize()
+  method NxGraph.Diagnostics.Replay.ReplayEvent[] Deserialize(Byte[])
+  method Void ReplayAll(System.Action`1[NxGraph.Diagnostics.Replay.ReplayEvent])
+  property System.Collections.Generic.IEnumerable`1[NxGraph.Diagnostics.Replay.ReplayEvent] Events { get; }
+sealed class NxGraph.Diagnostics.Validations.GraphDiagnostic
+  ctor Void .ctor(NxGraph.Diagnostics.Validations.Severity, System.String, NxGraph.Graphs.NodeId)
+  method System.String ToString()
+  property NxGraph.Diagnostics.Validations.Severity Severity { get; }
+  property NxGraph.Graphs.NodeId Node { get; }
+  property System.String Message { get; }
+static class NxGraph.Diagnostics.Validations.GraphValidationExtensions
+  method NxGraph.Diagnostics.Validations.GraphValidationResult ValidateAndThrowIfErrorsDebug(NxGraph.Graphs.Graph, System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId])
+sealed class NxGraph.Diagnostics.Validations.GraphValidationOptions
+  ctor Void .ctor(System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId])
+  property Boolean StrictNoTerminalPath { get; set; }
+  property Boolean StrictSyncOnly { get; set; }
+  property Boolean WarnOnSelfLoop { get; set; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId] AllNodes { get; set; }
+sealed class NxGraph.Diagnostics.Validations.GraphValidationResult
+  ctor Void .ctor()
+  method System.String ToString()
+  property Boolean HasErrors { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Diagnostics.Validations.GraphDiagnostic] Diagnostics { get; }
+static class NxGraph.Diagnostics.Validations.GraphValidator
+  method NxGraph.Diagnostics.Validations.GraphValidationResult Validate(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Validations.GraphValidationOptions)
+enum NxGraph.Diagnostics.Validations.Severity : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Error = 2
+  Info = 0
+  Warning = 1
+sealed class NxGraph.Fsm.Async.AsyncChoiceState : NxGraph.Fsm.IAsyncDirector, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(System.Func`1[System.Threading.Tasks.ValueTask`1[System.Boolean]], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+class NxGraph.Fsm.Async.AsyncCompositeState : NxGraph.Fsm.Async.AsyncState, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(NxGraph.Graphs.IAsyncLogic)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.Async.AsyncHistoryState : NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  property NxGraph.Fsm.Async.AsyncStateMachine Child { get; }
+sealed class NxGraph.Fsm.Async.AsyncParallelState : NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.Async.AsyncStateMachine] Regions { get; }
+sealed class NxGraph.Fsm.Async.AsyncRelayState : NxGraph.Fsm.Async.AsyncState, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.Async.AsyncRelayState`1 : AsyncState`1, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(System.Func`3[TAgent,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[TAgent,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[TAgent,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+abstract class NxGraph.Fsm.Async.AsyncState : NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor()
+  method System.Threading.Tasks.ValueTask LogAsync(System.String, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  property System.Func`3[System.String,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask] LogReport { get; set; }
+class NxGraph.Fsm.Async.AsyncStateMachine : NxGraph.Fsm.Async.AsyncState, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
+  field readonly NxGraph.Graphs.Graph Graph
+  method NxGraph.Fsm.StateMachineSnapshot Suspend()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] Reset(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] StepAsync(System.Threading.CancellationToken)
+  method Void Resume(NxGraph.Fsm.StateMachineSnapshot)
+  method Void SetAutoReset(Boolean)
+  method Void SetRestartPolicy(NxGraph.Fsm.RestartPolicy)
+  property Int32 LastOutcome { get; }
+  property NxGraph.Fsm.ExecutionStatus Status { get; }
+  property System.String LastOutcomeName { get; }
+class NxGraph.Fsm.Async.AsyncStateMachine`1 : NxGraph.Fsm.Async.AsyncStateMachine, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method Void SetAgent(TAgent)
+abstract class NxGraph.Fsm.Async.AsyncState`1 : NxGraph.Fsm.Async.AsyncState, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor()
+  field TAgent Agent
+  method Void SetAgent(TAgent)
+sealed class NxGraph.Fsm.Async.AsyncSwitchState`1 : NxGraph.Fsm.IAsyncDirector, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(System.Func`1[System.Threading.Tasks.ValueTask`1[TKey]], System.Collections.Generic.IReadOnlyDictionary`2[TKey,NxGraph.Graphs.NodeId], NxGraph.Graphs.NodeId)
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+class NxGraph.Fsm.Async.AsyncTimeoutState : NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+static class NxGraph.Fsm.Async.AsyncWait
+  method NxGraph.Fsm.Async.AsyncState For(System.TimeSpan)
+static class NxGraph.Fsm.Async.Timeout
+  method NxGraph.Graphs.IAsyncLogic For(System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Graphs.IAsyncLogic Wrap(NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+enum NxGraph.Fsm.BackoffKind : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Exponential = 2
+  Fixed = 0
+  Linear = 1
+sealed class NxGraph.Fsm.ChoiceState : NxGraph.Fsm.IDirector, NxGraph.Graphs.ILogic
+  ctor Void .ctor(System.Func`1[System.Boolean], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method NxGraph.Graphs.NodeId SelectNext()
+  method NxGraph.Result Execute()
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+enum NxGraph.Fsm.ExecutionStatus : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Cancelled = 6
+  Completed = 4
+  Created = 0
+  Failed = 5
+  Ready = 8
+  Resetting = 7
+  Running = 2
+  Starting = 1
+  Transitioning = 3
+interface NxGraph.Fsm.IAgentSettable`1
+  method Void SetAgent(TAgent)
+interface NxGraph.Fsm.IAsyncDirector
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
+interface NxGraph.Fsm.IAsyncStateMachineObserver
+  method System.Threading.Tasks.ValueTask OnLogReport(NxGraph.Graphs.NodeId, System.String, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateEntered(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineCancelled(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineReset(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineStarted(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask StateMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus, System.Threading.CancellationToken)
+interface NxGraph.Fsm.IDirector
+  method NxGraph.Graphs.NodeId SelectNext()
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+interface NxGraph.Fsm.IStateMachineObserver
+  method Void OnLogReport(NxGraph.Graphs.NodeId, System.String)
+  method Void OnStateEntered(NxGraph.Graphs.NodeId)
+  method Void OnStateExited(NxGraph.Graphs.NodeId)
+  method Void OnStateFailed(NxGraph.Graphs.NodeId, System.Exception)
+  method Void OnStateMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result)
+  method Void OnStateMachineReset(NxGraph.Graphs.NodeId)
+  method Void OnStateMachineStarted(NxGraph.Graphs.NodeId)
+  method Void OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method Void StateMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus)
+sealed class NxGraph.Fsm.NodeStatusTracker
+  ctor Void .ctor()
+  method NxGraph.Fsm.ExecutionStatus Get(NxGraph.Graphs.NodeId)
+  method System.TimeSpan GetDuration(NxGraph.Graphs.NodeId)
+  method Void Initialize(NxGraph.Graphs.Graph)
+  method Void MarkCancelled(NxGraph.Graphs.NodeId)
+  method Void MarkEntered(NxGraph.Graphs.NodeId)
+  method Void MarkExited(NxGraph.Graphs.NodeId, Boolean)
+  method Void MarkTransitioned(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method Void Reset()
+  property Boolean IsInitialized { get; }
+  property Int32 Length { get; }
+sealed class NxGraph.Fsm.NodeStatusTrackingObserver : NxGraph.Fsm.IAsyncStateMachineObserver
+  ctor Void .ctor(NxGraph.Fsm.NodeStatusTracker)
+  method System.Threading.Tasks.ValueTask OnStateEntered(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.RelayState : NxGraph.Fsm.State, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor Void .ctor(System.Func`1[NxGraph.Result], System.Action, System.Action)
+  method NxGraph.Result OnRun()
+  method Void OnEnter()
+  method Void OnExit()
+sealed class NxGraph.Fsm.RelayState`1 : State`1, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor Void .ctor(System.Func`2[TAgent,NxGraph.Result], System.Action`1[TAgent], System.Action`1[TAgent])
+  method NxGraph.Result OnRun()
+  method Void OnEnter()
+  method Void OnExit()
+enum NxGraph.Fsm.RestartPolicy : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Auto = 0
+  Ignore = 2
+  Manual = 1
+struct NxGraph.Fsm.RetryPolicy
+  ctor Void .ctor(Byte, System.TimeSpan, NxGraph.Fsm.BackoffKind)
+  field static readonly NxGraph.Fsm.RetryPolicy None
+  method System.TimeSpan DelayForAttempt(Int32)
+  property Byte MaxAttempts { get; }
+  property NxGraph.Fsm.BackoffKind BackoffKind { get; }
+  property System.TimeSpan Backoff { get; }
+abstract class NxGraph.Fsm.State : NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor Void .ctor()
+  method NxGraph.Result Execute()
+  method NxGraph.Result OnRun()
+  method Void Log(System.String)
+  method Void OnEnter()
+  method Void OnExit()
+  property System.Action`1[System.String] SyncLogReport { get; set; }
+class NxGraph.Fsm.StateMachine : NxGraph.Fsm.State, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
+  field readonly NxGraph.Graphs.Graph Graph
+  method NxGraph.Fsm.StateMachineSnapshot Suspend()
+  method NxGraph.Result OnRun()
+  method NxGraph.Result Reset()
+  method Void OnEnter()
+  method Void OnExit()
+  method Void Resume(NxGraph.Fsm.StateMachineSnapshot)
+  method Void SetAutoReset(Boolean)
+  method Void SetResetPolicy(NxGraph.Fsm.RestartPolicy)
+  property Int32 LastOutcome { get; }
+  property NxGraph.Fsm.ExecutionStatus Status { get; }
+  property System.String LastOutcomeName { get; }
+sealed class NxGraph.Fsm.StateMachineSnapshot : System.IEquatable`1[[NxGraph.Fsm.StateMachineSnapshot, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+  ctor Void .ctor(Int32, NxGraph.Fsm.ExecutionStatus, Int32, Boolean, Boolean, Int32)
+  method Boolean Equals(NxGraph.Fsm.StateMachineSnapshot)
+  method Boolean Equals(System.Object)
+  method Int32 GetHashCode()
+  method NxGraph.Fsm.StateMachineSnapshot <Clone>$()
+  method System.String ToString()
+  method Void Deconstruct(Int32 ByRef, NxGraph.Fsm.ExecutionStatus ByRef, Int32 ByRef, Boolean ByRef, Boolean ByRef, Int32 ByRef)
+  operator Boolean op_Equality(NxGraph.Fsm.StateMachineSnapshot, NxGraph.Fsm.StateMachineSnapshot)
+  operator Boolean op_Inequality(NxGraph.Fsm.StateMachineSnapshot, NxGraph.Fsm.StateMachineSnapshot)
+  property Boolean MidRun { get; set; }
+  property Boolean NodeEntered { get; set; }
+  property Int32 Attempts { get; set; }
+  property Int32 CurrentNodeIndex { get; set; }
+  property Int32 LastOutcome { get; set; }
+  property NxGraph.Fsm.ExecutionStatus Status { get; set; }
+class NxGraph.Fsm.StateMachine`1 : NxGraph.Fsm.StateMachine, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
+  method Void SetAgent(TAgent)
+abstract class NxGraph.Fsm.State`1 : NxGraph.Fsm.State, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor Void .ctor()
+  field TAgent Agent
+  method Void SetAgent(TAgent)
+sealed class NxGraph.Fsm.SwitchState`1 : NxGraph.Fsm.IDirector, NxGraph.Graphs.ILogic
+  ctor Void .ctor(System.Func`1[TKey], System.Collections.Generic.IReadOnlyDictionary`2[TKey,NxGraph.Graphs.NodeId], NxGraph.Graphs.NodeId)
+  method NxGraph.Graphs.NodeId SelectNext()
+  method NxGraph.Result Execute()
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+enum NxGraph.Fsm.TimeoutBehavior : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Fail = 0
+  Throw = 1
+sealed class NxGraph.Fsm.TracingObserver : NxGraph.Fsm.IAsyncStateMachineObserver
+  ctor Void .ctor()
+  method System.Threading.Tasks.ValueTask OnStateEntered(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineCancelled(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineReset(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineStarted(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask StateMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus, System.Threading.CancellationToken)
+sealed class NxGraph.Graphs.EmptyAsyncLogic : NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Graphs.EmptyLogic : NxGraph.Graphs.ILogic
+  ctor Void .ctor()
+  method NxGraph.Result Execute()
+sealed class NxGraph.Graphs.Graph : NxGraph.Graphs.IGraph, NxGraph.Graphs.INode
+  ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode[], NxGraph.Graphs.Transition[], NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.RetryPolicy[], Int32[], System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String])
+  method Boolean TryGetNode(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode ByRef)
+  method Boolean TryGetNodeByIndex(Int32, NxGraph.Graphs.INode ByRef)
+  method Boolean TryGetTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.Transition ByRef)
+  method NxGraph.Graphs.INode GetNodeByIndex(Int32)
+  method NxGraph.Graphs.Transition GetTransitionByIndex(Int32)
+  method Void SetAgent[TAgent](TAgent)
+  property Int32 NodeCount { get; }
+  property Int32 TransitionCount { get; }
+  property Int32[] OutcomeCodes { get; }
+  property NxGraph.Fsm.RetryPolicy[] RetryPolicies { get; }
+  property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
+  property NxGraph.Graphs.ILogic Logic { get; }
+  property NxGraph.Graphs.INode StartNode { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+  property System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String] OutcomeNames { get; }
+interface NxGraph.Graphs.IAsyncLogic
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+interface NxGraph.Graphs.IGraph
+  method Boolean TryGetNode(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode ByRef)
+  method Boolean TryGetTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.Transition ByRef)
+  method Void SetAgent[TAgent](TAgent)
+  property Int32 NodeCount { get; }
+  property Int32 TransitionCount { get; }
+  property NxGraph.Graphs.INode StartNode { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+interface NxGraph.Graphs.ILogic
+  method NxGraph.Result Execute()
+interface NxGraph.Graphs.INode
+  property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
+  property NxGraph.Graphs.ILogic Logic { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+interface NxGraph.Graphs.ISubGraphProvider
+  property System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.Graph] SubGraphs { get; }
+class NxGraph.Graphs.LogicNode : NxGraph.Graphs.INode
+  ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.IAsyncLogic, System.Action, System.Action)
+  field static readonly NxGraph.Graphs.LogicNode Empty
+  field static readonly NxGraph.Graphs.LogicNode StateMachineMarker
+  property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
+  property NxGraph.Graphs.ILogic Logic { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+  property System.Action EnterAction { get; }
+  property System.Action ExitAction { get; }
+struct NxGraph.Graphs.NodeId : System.IEquatable`1[[NxGraph.Graphs.NodeId, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+  ctor Void .ctor(Int32)
+  ctor Void .ctor(Int32, System.String)
+  ctor Void .ctor(NxGraph.Graphs.NodeId)
+  ctor Void .ctor(NxGraph.Graphs.NodeId, System.String)
+  method Boolean Equals(NxGraph.Graphs.NodeId)
+  method Boolean Equals(System.Object)
+  method Int32 GetHashCode()
+  method NxGraph.Graphs.NodeId WithName(System.String)
+  method System.String ToString()
+  operator Boolean op_Equality(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  operator Boolean op_Inequality(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  property Int32 Index { get; }
+  property NxGraph.Graphs.NodeId Default { get; }
+  property NxGraph.Graphs.NodeId Start { get; }
+  property NxGraph.Graphs.NodeId StateMachineMarker { get; }
+  property System.String Name { get; }
+sealed class NxGraph.Graphs.SyncLogicAdapter : NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(NxGraph.Graphs.ILogic)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  property NxGraph.Graphs.ILogic Logic { get; }
+struct NxGraph.Graphs.Transition
+  ctor Void .ctor(NxGraph.Graphs.NodeId)
+  ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  field static readonly NxGraph.Graphs.Transition Empty
+  property Boolean HasFailureDestination { get; }
+  property Boolean IsEmpty { get; }
+  property NxGraph.Graphs.NodeId Destination { get; }
+  property NxGraph.Graphs.NodeId FailureDestination { get; }
+struct NxGraph.Result : System.IEquatable`1[[NxGraph.Result, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+  field static readonly NxGraph.Result Continue
+  field static readonly NxGraph.Result Failure
+  field static readonly NxGraph.Result InProgress
+  field static readonly NxGraph.Result Success
+  method Boolean Equals(NxGraph.Result)
+  method Boolean Equals(System.Object)
+  method Int32 GetHashCode()
+  method NxGraph.Result Fail(System.String)
+  method NxGraph.Result Ok(System.String)
+  method System.String ToString()
+  operator Boolean op_Equality(NxGraph.Result, NxGraph.Result)
+  operator Boolean op_Inequality(NxGraph.Result, NxGraph.Result)
+  property Boolean IsCompleted { get; }
+  property Boolean IsFailure { get; }
+  property Boolean IsInProgress { get; }
+  property Boolean IsSuccess { get; }
+  property StatusCode Code { get; }
+  property System.String Message { get; }
+enum NxGraph.Result+StatusCode : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Continue = 2
+  Failure = 1
+  InProgress = 2
+  Success = 0
+static class NxGraph.ResultHelpers
+  field static readonly System.Threading.Tasks.ValueTask CompletedTask
+  field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]] Continue
+  field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]] Failure
+  field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]] InProgress
+  field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]] Success

--- a/NxGraph.Tests/PublicApi/PublicApiSurfaceTests.cs
+++ b/NxGraph.Tests/PublicApi/PublicApiSurfaceTests.cs
@@ -1,0 +1,223 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using NxGraph.Graphs;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Tests.PublicApi;
+
+/// <summary>
+/// Guards the public API surface of the shipped assemblies. Any addition, removal, or
+/// signature change of a public/protected symbol fails this fixture until the matching
+/// baseline file is updated — making every API change an explicit, reviewed diff.
+/// <para>
+/// To accept an intentional change, set the environment variable
+/// <c>NXGRAPH_UPDATE_PUBLIC_API=1</c> and re-run the tests: the baselines under
+/// <c>NxGraph.Tests/PublicApi/</c> are rewritten in place. Commit the resulting diff.
+/// </para>
+/// <para>
+/// The surface is captured for net8.0 (the richest target); the netstandard2.1 surface
+/// is compiled from the same sources minus <c>NET8_0_OR_GREATER</c> members.
+/// </para>
+/// </summary>
+[TestFixture]
+public class PublicApiSurfaceTests
+{
+    private static readonly (string BaselineFile, Assembly Assembly)[] Assemblies =
+    [
+        ("NxGraph.approved.txt", typeof(Graph).Assembly),
+        ("NxGraph.Serialization.approved.txt", typeof(Serialization.GraphSerializer).Assembly),
+        ("NxGraph.Serialization.Abstraction.approved.txt", typeof(ILogicCodec).Assembly),
+    ];
+
+    [Test]
+    public void Public_api_matches_approved_baseline(
+        [Range(0, 2)] int assemblyIndex)
+    {
+        (string baselineFile, Assembly assembly) = Assemblies[assemblyIndex];
+        string actual = DescribePublicApi(assembly);
+        string baselinePath = Path.Combine(BaselineDirectory(), baselineFile);
+
+        if (Environment.GetEnvironmentVariable("NXGRAPH_UPDATE_PUBLIC_API") == "1")
+        {
+            File.WriteAllText(baselinePath, actual);
+            Assert.Pass($"Baseline updated: {baselinePath}");
+        }
+
+        if (!File.Exists(baselinePath))
+        {
+            Assert.Fail(
+                $"Missing public API baseline '{baselineFile}'. " +
+                "Run the tests once with NXGRAPH_UPDATE_PUBLIC_API=1 to create it, then commit it.");
+        }
+
+        string expected = File.ReadAllText(baselinePath);
+        if (Normalize(expected) == Normalize(actual))
+        {
+            Assert.Pass();
+        }
+
+        Assert.Fail(
+            $"Public API of {assembly.GetName().Name} differs from the approved baseline.\n" +
+            Diff(Normalize(expected), Normalize(actual)) +
+            "\nIf this change is intentional, re-run with NXGRAPH_UPDATE_PUBLIC_API=1 and commit the baseline diff.");
+    }
+
+    private static string Normalize(string text) => text.Replace("\r\n", "\n").TrimEnd('\n');
+
+    private static string Diff(string expected, string actual)
+    {
+        HashSet<string> expectedLines = [..expected.Split('\n')];
+        HashSet<string> actualLines = [..actual.Split('\n')];
+
+        StringBuilder sb = new();
+        foreach (string line in expectedLines.Except(actualLines).Order())
+        {
+            sb.Append("  - ").AppendLine(line);
+        }
+
+        foreach (string line in actualLines.Except(expectedLines).Order())
+        {
+            sb.Append("  + ").AppendLine(line);
+        }
+
+        return sb.ToString();
+    }
+
+    private static string BaselineDirectory([CallerFilePath] string thisFile = "")
+        => Path.GetDirectoryName(thisFile)!;
+
+    private static string DescribePublicApi(Assembly assembly)
+    {
+        StringBuilder sb = new();
+        IOrderedEnumerable<Type> types = assembly.GetExportedTypes()
+            .OrderBy(t => t.FullName, StringComparer.Ordinal);
+
+        foreach (Type type in types)
+        {
+            sb.Append(TypeKind(type)).Append(' ').AppendLine(TypeDisplay(type));
+
+            foreach (string member in DescribeMembers(type).Order(StringComparer.Ordinal))
+            {
+                sb.Append("  ").AppendLine(member);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string TypeKind(Type type)
+    {
+        if (type.IsEnum) return "enum";
+        if (type.IsValueType) return "struct";
+        if (type.IsInterface) return "interface";
+        if (typeof(Delegate).IsAssignableFrom(type)) return "delegate";
+        if (type is { IsAbstract: true, IsSealed: true }) return "static class";
+        if (type.IsAbstract) return "abstract class";
+        if (type.IsSealed) return "sealed class";
+        return "class";
+    }
+
+    private static string TypeDisplay(Type type)
+    {
+        StringBuilder sb = new(type.FullName);
+        List<string> bases = [];
+        if (type.BaseType is not null &&
+            type.BaseType != typeof(object) &&
+            type.BaseType != typeof(ValueType) &&
+            type.BaseType != typeof(Enum) &&
+            type.BaseType != typeof(MulticastDelegate))
+        {
+            bases.Add(type.BaseType.FullName ?? type.BaseType.Name);
+        }
+
+        bases.AddRange(type.GetInterfaces()
+            .Select(i => i.FullName ?? i.Name)
+            .Order(StringComparer.Ordinal));
+
+        if (bases.Count > 0)
+        {
+            sb.Append(" : ").Append(string.Join(", ", bases));
+        }
+
+        return sb.ToString();
+    }
+
+    private static IEnumerable<string> DescribeMembers(Type type)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic |
+                                   BindingFlags.Instance | BindingFlags.Static |
+                                   BindingFlags.DeclaredOnly;
+
+        if (type.IsEnum)
+        {
+            foreach (string name in Enum.GetNames(type))
+            {
+                yield return $"{name} = {Convert.ToInt64(Enum.Parse(type, name))}";
+            }
+
+            yield break;
+        }
+
+        foreach (MemberInfo member in type.GetMembers(flags))
+        {
+            if (!IsVisible(member))
+            {
+                continue;
+            }
+
+            switch (member)
+            {
+                case MethodInfo { IsSpecialName: true }:
+                    // Property/event accessors and operators surface via their owners;
+                    // operators are IsSpecialName too, so re-admit them explicitly.
+                    if (member is MethodInfo op && op.Name.StartsWith("op_", StringComparison.Ordinal))
+                    {
+                        yield return $"operator {op}";
+                    }
+
+                    break;
+                case MethodInfo method:
+                    yield return $"method {method}";
+                    break;
+                case ConstructorInfo ctor:
+                    yield return $"ctor {ctor}";
+                    break;
+                case PropertyInfo property:
+                    yield return $"property {property} {{ {AccessorList(property)} }}";
+                    break;
+                case FieldInfo field:
+                    yield return $"field {(field.IsStatic ? "static " : "")}{(field.IsInitOnly ? "readonly " : "")}{field.FieldType.FullName ?? field.FieldType.Name} {field.Name}";
+                    break;
+                case EventInfo evt:
+                    yield return $"event {evt}";
+                    break;
+            }
+        }
+    }
+
+    private static string AccessorList(PropertyInfo property)
+    {
+        List<string> parts = [];
+        if (property.GetMethod is { } get && (get.IsPublic || get.IsFamily || get.IsFamilyOrAssembly))
+        {
+            parts.Add("get;");
+        }
+
+        if (property.SetMethod is { } set && (set.IsPublic || set.IsFamily || set.IsFamilyOrAssembly))
+        {
+            parts.Add("set;");
+        }
+
+        return string.Join(" ", parts);
+    }
+
+    private static bool IsVisible(MemberInfo member) => member switch
+    {
+        MethodBase method => method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly,
+        FieldInfo field => field.IsPublic || field.IsFamily || field.IsFamilyOrAssembly,
+        PropertyInfo property => (property.GetMethod ?? property.SetMethod) is { } accessor && IsVisible(accessor),
+        EventInfo evt => evt.AddMethod is { } add && IsVisible(add),
+        _ => false,
+    };
+}

--- a/NxGraph.Tests/ReplayTests.cs
+++ b/NxGraph.Tests/ReplayTests.cs
@@ -316,7 +316,7 @@ public class ReplayTests
 
         // Run to completion — sync machine ticks via Execute().
         Result r;
-        do { r = fsm.Execute(); } while (r == Result.Continue);
+        do { r = fsm.Execute(); } while (r == Result.InProgress);
 
         ReadOnlyMemory<ReplayEvent> events = recorder.GetEvents();
         Assert.Multiple(() =>
@@ -342,7 +342,7 @@ public class ReplayTests
         fsm.SetResetPolicy(RestartPolicy.Manual);
 
         Result r;
-        do { r = fsm.Execute(); } while (r == Result.Continue);
+        do { r = fsm.Execute(); } while (r == Result.InProgress);
 
         Assert.That(recorder.DroppedCount, Is.GreaterThan(0),
             "A four-node sync machine emits more than four events; ring of size 4 must have dropped some.");

--- a/NxGraph.Tests/RetryTests.cs
+++ b/NxGraph.Tests/RetryTests.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class RetryTests
+{
+    [Test]
+    public async Task async_node_failing_twice_then_succeeding_completes()
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ++executions < 3 ? ResultHelpers.Failure : ResultHelpers.Success)
+            .Retry(maxAttempts: 3)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executions, Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public async Task async_retries_are_exhausted_and_machine_fails()
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                executions++;
+                return ResultHelpers.Failure;
+            })
+            .Retry(maxAttempts: 2)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(executions, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public async Task exhausted_retries_route_through_the_failure_edge()
+    {
+        int executions = 0;
+        bool cleanupRan = false;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                executions++;
+                return ResultHelpers.Failure;
+            })
+            .Retry(maxAttempts: 2)
+            .OnErrorAsync(_ =>
+            {
+                cleanupRan = true;
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executions, Is.EqualTo(2));
+            Assert.That(cleanupRan, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task attempt_counter_resets_between_runs()
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                executions++;
+                return ResultHelpers.Failure;
+            })
+            .Retry(maxAttempts: 2)
+            .Build();
+
+        var machine = graph.ToAsyncStateMachine();
+        await machine.ExecuteAsync();
+        await machine.ExecuteAsync();
+
+        Assert.That(executions, Is.EqualTo(4), "Each run should get a fresh attempt budget.");
+    }
+
+    [Test]
+    public async Task backoff_delay_is_applied_between_async_attempts()
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ++executions < 2 ? ResultHelpers.Failure : ResultHelpers.Success)
+            .Retry(maxAttempts: 2, backoff: TimeSpan.FromMilliseconds(80))
+            .Build();
+
+        Stopwatch sw = Stopwatch.StartNew();
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+        sw.Stop();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(sw.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(60),
+                "The retry should have waited for the configured backoff.");
+        });
+    }
+
+    [Test]
+    public void sync_node_failing_twice_then_succeeding_completes()
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() => ++executions < 3 ? Result.Failure : Result.Success)
+            .Retry(maxAttempts: 3)
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executions, Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public void sync_retries_are_exhausted_and_machine_fails()
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() =>
+            {
+                executions++;
+                return Result.Failure;
+            })
+            .Retry(maxAttempts: 2)
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(executions, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void retry_policy_delays_scale_by_backoff_kind()
+    {
+        RetryPolicy fixedPolicy = new(4, TimeSpan.FromSeconds(1));
+        RetryPolicy linear = new(4, TimeSpan.FromSeconds(1), BackoffKind.Linear);
+        RetryPolicy exponential = new(4, TimeSpan.FromSeconds(1), BackoffKind.Exponential);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixedPolicy.DelayForAttempt(3), Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(linear.DelayForAttempt(3), Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(exponential.DelayForAttempt(3), Is.EqualTo(TimeSpan.FromSeconds(4)));
+        });
+    }
+
+    [Test]
+    public void zero_max_attempts_policy_is_rejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = new RetryPolicy(0));
+    }
+
+    [Test]
+    public void retry_on_unknown_node_throws()
+    {
+        GraphBuilder builder = new();
+        builder.AddNode(new RelayState(() => Result.Success), isStart: true);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            builder.SetRetryPolicy(new NodeId(7), new RetryPolicy(2)));
+    }
+}

--- a/NxGraph.Tests/StateMachineTests.cs
+++ b/NxGraph.Tests/StateMachineTests.cs
@@ -591,9 +591,9 @@ public class StateMachineTests
     /// </summary>
     private static Result RunToCompletion(StateMachine fsm, int maxSteps = 1000)
     {
-        Result result = Result.Continue;
+        Result result = Result.InProgress;
         int steps = 0;
-        while (result == Result.Continue)
+        while (result == Result.InProgress)
         {
             Assert.That(steps, Is.LessThan(maxSteps),
                 $"StateMachine did not terminate within {maxSteps} steps.");

--- a/NxGraph.Tests/StepAsyncTests.cs
+++ b/NxGraph.Tests/StepAsyncTests.cs
@@ -1,0 +1,149 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class StepAsyncTests
+{
+    private sealed class RecordingObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> Events = [];
+
+        public ValueTask OnStateEntered(NodeId id, CancellationToken ct = default)
+        {
+            Events.Add($"entered:{id.Index}");
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnStateExited(NodeId id, CancellationToken ct = default)
+        {
+            Events.Add($"exited:{id.Index}");
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnStateFailed(NodeId id, Exception? ex, CancellationToken ct = default)
+        {
+            Events.Add($"failed:{id.Index}");
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask OnTransition(NodeId from, NodeId to, CancellationToken ct = default)
+        {
+            Events.Add($"transition:{from.Index}->{to.Index}");
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private static Graph ThreeNodeChain()
+    {
+        return GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .ToAsync(_ => ResultHelpers.Success)
+            .ToAsync(_ => ResultHelpers.Success)
+            .Build();
+    }
+
+    [Test]
+    public async Task stepping_a_three_node_graph_yields_continue_continue_success()
+    {
+        AsyncStateMachine machine = ThreeNodeChain().ToAsyncStateMachine();
+
+        Result first = await machine.StepAsync();
+        Result second = await machine.StepAsync();
+        Result third = await machine.StepAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo(Result.InProgress));
+            Assert.That(second, Is.EqualTo(Result.InProgress));
+            Assert.That(third, Is.EqualTo(Result.Success));
+        });
+    }
+
+    [Test]
+    public async Task machine_stays_running_between_steps()
+    {
+        AsyncStateMachine machine = ThreeNodeChain().ToAsyncStateMachine();
+
+        await machine.StepAsync();
+        Assert.That(machine.Status, Is.EqualTo(ExecutionStatus.Running));
+
+        await machine.StepAsync();
+        Assert.That(machine.Status, Is.EqualTo(ExecutionStatus.Running));
+
+        await machine.StepAsync();
+        Assert.That(machine.Status, Is.EqualTo(ExecutionStatus.Ready),
+            "Auto restart policy resets the machine to Ready after the terminal step.");
+    }
+
+    [Test]
+    public async Task stepped_run_produces_the_same_observer_events_as_a_full_run()
+    {
+        RecordingObserver full = new();
+        RecordingObserver stepped = new();
+
+        await ThreeNodeChain().ToAsyncStateMachine(full).ExecuteAsync();
+
+        AsyncStateMachine machine = ThreeNodeChain().ToAsyncStateMachine(stepped);
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await machine.StepAsync();
+        }
+
+        Assert.That(stepped.Events, Is.EqualTo(full.Events));
+    }
+
+    [Test]
+    public async Task execute_during_a_stepped_run_throws()
+    {
+        AsyncStateMachine machine = ThreeNodeChain().ToAsyncStateMachine();
+        await machine.StepAsync();
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await machine.ExecuteAsync());
+    }
+
+    [Test]
+    public async Task stepping_after_completion_starts_a_fresh_run_under_auto_policy()
+    {
+        AsyncStateMachine machine = ThreeNodeChain().ToAsyncStateMachine();
+
+        for (int i = 0; i < 3; i++)
+        {
+            await machine.StepAsync();
+        }
+
+        Result restarted = await machine.StepAsync();
+        Assert.That(restarted, Is.EqualTo(Result.InProgress), "A new run should have begun at the start node.");
+    }
+
+    [Test]
+    public async Task stepping_routes_failures_through_error_edges()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Failure)
+            .OnErrorAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        Result first = await machine.StepAsync();
+        Result second = await machine.StepAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo(Result.InProgress), "The failure reroute counts as one step.");
+            Assert.That(second, Is.EqualTo(Result.Success));
+        });
+    }
+
+    [Test]
+    public async Task full_run_behavior_is_unchanged()
+    {
+        Result result = await ThreeNodeChain().ToAsyncStateMachine().ExecuteAsync();
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
+}

--- a/NxGraph.Tests/SteppedExecutionTests.cs
+++ b/NxGraph.Tests/SteppedExecutionTests.cs
@@ -56,7 +56,7 @@ public class SteppedExecutionTests
 
         Result first = fsm.Execute();
 
-        Assert.That(first, Is.EqualTo(Result.Continue));
+        Assert.That(first, Is.EqualTo(Result.InProgress));
     }
 
     [Test]
@@ -85,10 +85,10 @@ public class SteppedExecutionTests
             .ToStateMachine();
         fsm.SetResetPolicy(RestartPolicy.Manual);
 
-        Assert.That(fsm.Execute(), Is.EqualTo(Result.Continue));
+        Assert.That(fsm.Execute(), Is.EqualTo(Result.InProgress));
         Assert.That(counter, Is.EqualTo(1));
 
-        Assert.That(fsm.Execute(), Is.EqualTo(Result.Continue));
+        Assert.That(fsm.Execute(), Is.EqualTo(Result.InProgress));
         Assert.That(counter, Is.EqualTo(2));
 
         Assert.That(fsm.Execute(), Is.EqualTo(Result.Success));
@@ -265,7 +265,7 @@ public class SteppedExecutionTests
         int enterCount = 0, exitCount = 0, runCount = 0;
         StateMachine fsm = GraphBuilder
             .StartWith(new RelayState(
-                run: () => { runCount++; return runCount < 3 ? Result.Continue : Result.Success; },
+                run: () => { runCount++; return runCount < 3 ? Result.InProgress : Result.Success; },
                 onEnter: () => enterCount++,
                 onExit: () => exitCount++))
             .ToStateMachine();
@@ -291,7 +291,7 @@ public class SteppedExecutionTests
             .StartWith(() =>
             {
                 callCount++;
-                return callCount < 3 ? Result.Continue : Result.Success;
+                return callCount < 3 ? Result.InProgress : Result.Success;
             })
             .ToStateMachine();
         fsm.SetResetPolicy(RestartPolicy.Manual);
@@ -302,8 +302,8 @@ public class SteppedExecutionTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(r1, Is.EqualTo(Result.Continue));
-            Assert.That(r2, Is.EqualTo(Result.Continue));
+            Assert.That(r1, Is.EqualTo(Result.InProgress));
+            Assert.That(r2, Is.EqualTo(Result.InProgress));
             Assert.That(r3, Is.EqualTo(Result.Success));
             Assert.That(callCount, Is.EqualTo(3));
         }
@@ -317,7 +317,7 @@ public class SteppedExecutionTests
             .StartWith(() =>
             {
                 nodeACount++;
-                return nodeACount < 2 ? Result.Continue : Result.Success;
+                return nodeACount < 2 ? Result.InProgress : Result.Success;
             })
             .To(() => { nodeBCount++; return Result.Success; })
             .ToStateMachine();
@@ -428,9 +428,9 @@ public class SteppedExecutionTests
             Assert.That(Result.Failure.IsFailure, Is.True);
             Assert.That(Result.Failure.IsCompleted, Is.True);
 
-            Assert.That(Result.Continue.IsSuccess, Is.False);
-            Assert.That(Result.Continue.IsFailure, Is.False);
-            Assert.That(Result.Continue.IsCompleted, Is.False);
+            Assert.That(Result.InProgress.IsSuccess, Is.False);
+            Assert.That(Result.InProgress.IsFailure, Is.False);
+            Assert.That(Result.InProgress.IsCompleted, Is.False);
         }
     }
 

--- a/NxGraph.Tests/SubGraphHistoryTests.cs
+++ b/NxGraph.Tests/SubGraphHistoryTests.cs
@@ -1,0 +1,226 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class SubGraphHistoryTests
+{
+    [Test]
+    public async Task subgraph_runs_the_child_to_completion_within_the_parent()
+    {
+        List<string> log = [];
+        Graph child = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                log.Add("child:0");
+                return ResultHelpers.Success;
+            })
+            .ToAsync(_ =>
+            {
+                log.Add("child:1");
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Graph parent = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                log.Add("parent:start");
+                return ResultHelpers.Success;
+            })
+            .SubGraph(child)
+            .ToAsync(_ =>
+            {
+                log.Add("parent:end");
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "parent:start", "child:0", "child:1", "parent:end" }));
+        });
+    }
+
+    [Test]
+    public async Task history_composite_resumes_at_the_failed_child_node_on_reentry()
+    {
+        List<string> log = [];
+        bool repaired = false;
+
+        Graph child = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                log.Add("c0");
+                return ResultHelpers.Success;
+            })
+            .ToAsync(_ =>
+            {
+                log.Add("c1");
+                return repaired ? ResultHelpers.Success : ResultHelpers.Failure;
+            })
+            .ToAsync(_ =>
+            {
+                log.Add("c2");
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        StateToken sub = GraphBuilder
+            .Start()
+            .SubGraph(child, history: true)
+            .SetName("Sub");
+
+        StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new AsyncRelayState(_ =>
+        {
+            repaired = true;
+            log.Add("repair");
+            return ResultHelpers.Success;
+        })));
+        repair.Goto("Sub");
+
+        Graph parent = sub.OnError(repair).Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1", "repair", "c1", "c2" }),
+                "After the repair, the child resumed at the failed node c1 — c0 did not re-run.");
+        });
+    }
+
+    [Test]
+    public async Task without_history_reentry_restarts_the_child_from_its_start()
+    {
+        List<string> log = [];
+        bool repaired = false;
+
+        Graph child = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                log.Add("c0");
+                return ResultHelpers.Success;
+            })
+            .ToAsync(_ =>
+            {
+                log.Add("c1");
+                return repaired ? ResultHelpers.Success : ResultHelpers.Failure;
+            })
+            .Build();
+
+        StateToken sub = GraphBuilder
+            .Start()
+            .SubGraph(child)
+            .SetName("Sub");
+
+        StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new AsyncRelayState(_ =>
+        {
+            repaired = true;
+            return ResultHelpers.Success;
+        })));
+        repair.Goto("Sub");
+
+        Graph parent = sub.OnError(repair).Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1", "c0", "c1" }),
+                "Without history the child restarts from c0 on re-entry.");
+        });
+    }
+
+    [Test]
+    public async Task deep_history_resumes_nested_composites_at_their_own_position()
+    {
+        List<string> log = [];
+        bool repaired = false;
+
+        Graph inner = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                log.Add("i0");
+                return ResultHelpers.Success;
+            })
+            .ToAsync(_ =>
+            {
+                log.Add("i1");
+                return repaired ? ResultHelpers.Success : ResultHelpers.Failure;
+            })
+            .Build();
+
+        Graph middle = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                log.Add("m0");
+                return ResultHelpers.Success;
+            })
+            .SubGraph(inner, history: true)
+            .Build();
+
+        StateToken sub = GraphBuilder
+            .Start()
+            .SubGraph(middle, history: true)
+            .SetName("Sub");
+
+        StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new AsyncRelayState(_ =>
+        {
+            repaired = true;
+            log.Add("repair");
+            return ResultHelpers.Success;
+        })));
+        repair.Goto("Sub");
+
+        Graph parent = sub.OnError(repair).Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "m0", "i0", "i1", "repair", "i1" }),
+                "Both levels resumed their positions: neither m0 nor i0 re-ran.");
+        });
+    }
+
+    [Test]
+    public async Task completed_history_composite_restarts_from_the_top_on_reentry()
+    {
+        List<string> log = [];
+        int laps = 0;
+
+        Graph child = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                log.Add("c0");
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .SubGraph(child, history: true).SetName("Sub")
+            .ToAsync(_ => ++laps < 2 ? ResultHelpers.Success : ResultHelpers.Failure)
+            .Goto("Sub")
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c0" }),
+                "A completed child restarts from its start node on the next visit.");
+        });
+    }
+}

--- a/NxGraph.Tests/SuspendResumeTests.cs
+++ b/NxGraph.Tests/SuspendResumeTests.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class SuspendResumeTests
+{
+    private static Graph CountingChain(List<int> executed)
+    {
+        return GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                executed.Add(0);
+                return ResultHelpers.Success;
+            })
+            .ToAsync(_ =>
+            {
+                executed.Add(1);
+                return ResultHelpers.Success;
+            })
+            .ToAsync(_ =>
+            {
+                executed.Add(2);
+                return ResultHelpers.Success;
+            })
+            .Build();
+    }
+
+    [Test]
+    public async Task suspend_mid_run_and_resume_on_a_fresh_machine_completes_the_flow()
+    {
+        List<int> executed = [];
+        Graph graph = CountingChain(executed);
+
+        AsyncStateMachine first = graph.ToAsyncStateMachine();
+        Result step = await first.StepAsync();
+        Assert.That(step, Is.EqualTo(Result.InProgress));
+
+        StateMachineSnapshot snapshot = first.Suspend();
+
+        // Serialize/deserialize the snapshot to prove it survives a process boundary.
+        string json = JsonSerializer.Serialize(snapshot);
+        StateMachineSnapshot restored = JsonSerializer.Deserialize<StateMachineSnapshot>(json)!;
+
+        AsyncStateMachine second = graph.ToAsyncStateMachine();
+        second.Resume(restored);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await second.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }),
+                "Node 0 ran on the first machine; the resumed machine continued at node 1.");
+        });
+    }
+
+    [Test]
+    public async Task snapshot_preserves_retry_progress()
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                executions++;
+                return ResultHelpers.Failure;
+            })
+            .Retry(maxAttempts: 3)
+            .Build();
+
+        AsyncStateMachine first = graph.ToAsyncStateMachine();
+        await first.StepAsync(); // attempt 1 fails; retry pending
+        StateMachineSnapshot snapshot = first.Suspend();
+        Assert.That(snapshot.Attempts, Is.EqualTo(1));
+
+        AsyncStateMachine second = graph.ToAsyncStateMachine();
+        second.Resume(snapshot);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await second.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(executions, Is.EqualTo(3),
+                "The resumed machine had 2 attempts left, not a fresh budget of 3.");
+        });
+    }
+
+    [Test]
+    public async Task resumed_machine_reports_status_running_mid_run()
+    {
+        Graph graph = CountingChain([]);
+        AsyncStateMachine first = graph.ToAsyncStateMachine();
+        await first.StepAsync();
+
+        AsyncStateMachine second = graph.ToAsyncStateMachine();
+        second.Resume(first.Suspend());
+
+        Assert.That(second.Status, Is.EqualTo(ExecutionStatus.Running));
+    }
+
+    [Test]
+    public void resume_rejects_out_of_range_node_index()
+    {
+        Graph graph = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        StateMachineSnapshot bogus = new(42, ExecutionStatus.Running, 0, false, true, 0);
+        Assert.Throws<InvalidOperationException>(() => machine.Resume(bogus));
+    }
+
+    [Test]
+    public async Task suspend_of_an_idle_machine_roundtrips_through_execute()
+    {
+        List<int> executed = [];
+        Graph graph = CountingChain(executed);
+
+        AsyncStateMachine first = graph.ToAsyncStateMachine();
+        StateMachineSnapshot snapshot = first.Suspend();
+
+        AsyncStateMachine second = graph.ToAsyncStateMachine();
+        second.Resume(snapshot);
+
+        Result result = await second.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }));
+        });
+    }
+}

--- a/NxGraph.Tests/SwitchDefaultCaseTests.cs
+++ b/NxGraph.Tests/SwitchDefaultCaseTests.cs
@@ -65,7 +65,7 @@ public class SwitchDefaultCaseTests
         do
         {
             result = fsm.Execute();
-        } while (result == Result.Continue);
+        } while (result == Result.InProgress);
 
         Assert.That(result, Is.EqualTo(Result.Success));
     }

--- a/NxGraph.Tests/SyncSuspendResumeTests.cs
+++ b/NxGraph.Tests/SyncSuspendResumeTests.cs
@@ -1,0 +1,190 @@
+using System.Text.Json;
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class SyncSuspendResumeTests
+{
+    private static Graph CountingChain(List<int> executed)
+    {
+        return GraphBuilder
+            .StartWith(() =>
+            {
+                executed.Add(0);
+                return Result.Success;
+            })
+            .To(() =>
+            {
+                executed.Add(1);
+                return Result.Success;
+            })
+            .To(() =>
+            {
+                executed.Add(2);
+                return Result.Success;
+            })
+            .Build();
+    }
+
+    private static Result RunToCompletion(StateMachine machine)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+
+    [Test]
+    public void suspend_mid_run_and_resume_on_a_fresh_machine_completes_the_flow()
+    {
+        List<int> executed = [];
+        Graph graph = CountingChain(executed);
+
+        StateMachine first = graph.ToStateMachine();
+        Result tick = first.Execute();
+        Assert.That(tick, Is.EqualTo(Result.InProgress));
+
+        StateMachineSnapshot snapshot = first.Suspend();
+
+        // Serialize/deserialize the snapshot to prove it survives a process boundary.
+        string json = JsonSerializer.Serialize(snapshot);
+        StateMachineSnapshot restored = JsonSerializer.Deserialize<StateMachineSnapshot>(json)!;
+
+        StateMachine second = graph.ToStateMachine();
+        second.Resume(restored);
+
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }),
+                "Node 0 ran on the first machine; the resumed machine continued at node 1.");
+        });
+    }
+
+    [Test]
+    public void snapshot_preserves_retry_progress()
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() =>
+            {
+                executions++;
+                return Result.Failure;
+            })
+            .Retry(maxAttempts: 3)
+            .Build();
+
+        StateMachine first = graph.ToStateMachine();
+        first.Execute(); // attempt 1 fails; retry pending on the next tick
+        StateMachineSnapshot snapshot = first.Suspend();
+        Assert.That(snapshot.Attempts, Is.EqualTo(1));
+
+        StateMachine second = graph.ToStateMachine();
+        second.Resume(snapshot);
+
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(executions, Is.EqualTo(3),
+                "The resumed machine had 2 attempts left, not a fresh budget of 3.");
+        });
+    }
+
+    [Test]
+    public void resumed_machine_reports_status_running_mid_run()
+    {
+        Graph graph = CountingChain([]);
+        StateMachine first = graph.ToStateMachine();
+        first.Execute();
+
+        StateMachine second = graph.ToStateMachine();
+        second.Resume(first.Suspend());
+
+        Assert.That(second.Status, Is.EqualTo(ExecutionStatus.Running));
+    }
+
+    [Test]
+    public void resume_rejects_out_of_range_node_index()
+    {
+        Graph graph = GraphBuilder.StartWith(() => Result.Success).Build();
+        StateMachine machine = graph.ToStateMachine();
+
+        StateMachineSnapshot bogus = new(42, ExecutionStatus.Running, 0, false, true, 0);
+        Assert.Throws<InvalidOperationException>(() => machine.Resume(bogus));
+    }
+
+    [Test]
+    public void suspend_of_an_idle_machine_roundtrips_through_execute()
+    {
+        List<int> executed = [];
+        Graph graph = CountingChain(executed);
+
+        StateMachine first = graph.ToStateMachine();
+        StateMachineSnapshot snapshot = first.Suspend();
+
+        StateMachine second = graph.ToStateMachine();
+        second.Resume(snapshot);
+
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }));
+        });
+    }
+
+    [Test]
+    public void suspend_from_inside_node_logic_throws()
+    {
+        StateMachine? machine = null;
+        Graph graph = GraphBuilder
+            .StartWith(() =>
+            {
+                Assert.Throws<InvalidOperationException>(() => machine!.Suspend());
+                return Result.Success;
+            })
+            .Build();
+
+        machine = graph.ToStateMachine();
+        Result result = RunToCompletion(machine);
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
+
+    [Test]
+    public void snapshot_taken_by_async_machine_resumes_on_sync_machine()
+    {
+        // Same graph shape, sync-executable nodes: the snapshot format is runtime-agnostic.
+        List<int> executed = [];
+        Graph graph = CountingChain(executed);
+
+        StateMachine first = graph.ToStateMachine();
+        first.Execute();
+        StateMachineSnapshot snapshot = first.Suspend();
+
+        // Round-trip through the async machine's Resume/Suspend and back to sync.
+        Fsm.Async.AsyncStateMachine asyncMachine = graph.ToAsyncStateMachine();
+        asyncMachine.Resume(snapshot);
+        StateMachineSnapshot rebounced = asyncMachine.Suspend();
+
+        StateMachine second = graph.ToStateMachine();
+        second.Resume(rebounced);
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }));
+        });
+    }
+}

--- a/NxGraph.Tests/TerminalOutcomeTests.cs
+++ b/NxGraph.Tests/TerminalOutcomeTests.cs
@@ -1,0 +1,135 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+[TestFixture]
+public class TerminalOutcomeTests
+{
+    private const int Approved = 1;
+    private const int Rejected = 2;
+
+    private static Graph ApprovalGraph(Func<bool> approve)
+    {
+        GraphBuilder builder = new();
+        NodeId approved = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success));
+        NodeId rejected = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success));
+        builder.AddNode(new AsyncChoiceState(() => new ValueTask<bool>(approve()), approved, rejected),
+            isStart: true);
+        builder.SetName(approved, "Approved");
+        builder.SetName(rejected, "Rejected");
+        builder.SetOutcome(approved, Approved, "Approved");
+        builder.SetOutcome(rejected, Rejected, "Rejected");
+        return builder.Build(throwOnError: false);
+    }
+
+    [Test]
+    public async Task branch_ending_in_rejected_reports_its_outcome_code_and_name()
+    {
+        Graph graph = ApprovalGraph(() => false);
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        Result result = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(machine.LastOutcome, Is.EqualTo(Rejected));
+            Assert.That(machine.LastOutcomeName, Is.EqualTo("Rejected"));
+        });
+    }
+
+    [Test]
+    public async Task branch_ending_in_approved_reports_its_outcome_code_and_name()
+    {
+        Graph graph = ApprovalGraph(() => true);
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(machine.LastOutcome, Is.EqualTo(Approved));
+            Assert.That(machine.LastOutcomeName, Is.EqualTo("Approved"));
+        });
+    }
+
+    [Test]
+    public async Task outcome_defaults_to_zero_when_unset()
+    {
+        Graph graph = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(machine.LastOutcome, Is.Zero);
+            Assert.That(machine.LastOutcomeName, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task failing_terminal_node_reports_its_outcome()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Failure)
+            .WithOutcome(Rejected, "Rejected")
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+        Result result = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(machine.LastOutcome, Is.EqualTo(Rejected));
+        });
+    }
+
+    [Test]
+    public void sync_machine_reports_terminal_outcomes()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success)
+            .To(() => Result.Success)
+            .WithOutcome(Approved, "Approved")
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(machine.LastOutcome, Is.EqualTo(Approved));
+            Assert.That(machine.LastOutcomeName, Is.EqualTo("Approved"));
+        });
+    }
+
+    [Test]
+    public async Task outcome_resets_when_a_new_run_starts()
+    {
+        int runs = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ++runs == 1 ? ResultHelpers.Failure : ResultHelpers.Success)
+            .WithOutcome(Rejected)
+            .ToAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        await machine.ExecuteAsync();
+        Assert.That(machine.LastOutcome, Is.EqualTo(Rejected),
+            "First run terminates at the failing start node, which carries the Rejected outcome.");
+
+        await machine.ExecuteAsync();
+        Assert.That(machine.LastOutcome, Is.Zero,
+            "Second run terminates at the unmarked second node, so the stale outcome must not leak.");
+    }
+}

--- a/NxGraph.Tests/TimeoutFaultModelTests.cs
+++ b/NxGraph.Tests/TimeoutFaultModelTests.cs
@@ -1,0 +1,99 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Timeouts participate in the unified fault model: a timed-out node is an ordinary
+/// node failure, so failure edges and retry policies apply to it like any other failure.
+/// </summary>
+[TestFixture]
+public class TimeoutFaultModelTests
+{
+    private static readonly Func<CancellationToken, ValueTask<Result>> HangForever =
+        async ct =>
+        {
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, ct);
+            return Result.Success;
+        };
+
+    [Test]
+    public async Task timeout_routes_through_the_failure_edge()
+    {
+        bool cleanupRan = false;
+        Graph graph = GraphBuilder
+            .Start()
+            .ToWithTimeoutAsync(HangForever, TimeSpan.FromMilliseconds(30), TimeoutBehavior.Fail)
+            .OnErrorAsync(_ =>
+            {
+                cleanupRan = true;
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(cleanupRan, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task timeout_is_retried_by_the_node_retry_policy()
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .Start()
+            .ToWithTimeoutAsync(async ct =>
+            {
+                executions++;
+                if (executions < 2)
+                {
+                    await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, ct);
+                }
+
+                return Result.Success;
+            }, TimeSpan.FromMilliseconds(30), TimeoutBehavior.Fail)
+            .Retry(maxAttempts: 2)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executions, Is.EqualTo(2), "The timed-out first attempt should be retried.");
+        });
+    }
+
+    [Test]
+    public async Task timeout_without_error_edge_still_fails_the_machine()
+    {
+        Graph graph = GraphBuilder
+            .Start()
+            .ToWithTimeoutAsync(HangForever, TimeSpan.FromMilliseconds(30), TimeoutBehavior.Fail)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+        Assert.That(result, Is.EqualTo(Result.Failure));
+    }
+
+    [Test]
+    public async Task timeout_failure_carries_a_diagnostic_message()
+    {
+        AsyncTimeoutState state = new(
+            new AsyncRelayState(HangForever), TimeSpan.FromMilliseconds(30));
+
+        Result result = await state.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(result.Message, Does.Contain("timed out"));
+        });
+    }
+}

--- a/NxGraph/Authoring/Dsl.cs
+++ b/NxGraph/Authoring/Dsl.cs
@@ -20,6 +20,66 @@ public static partial class Dsl
         return prev.ToAsync(asyncLogic);
     }
 
+    /// <summary>
+    /// Adds a child graph as a composite state and wires a transition to it. The child runs
+    /// to completion within the parent's step. With <paramref name="history"/> enabled, a
+    /// failed child resumes at its last-active node when the parent re-enters the composite
+    /// (see <see cref="AsyncHistoryState"/>); without it, re-entry restarts the child.
+    /// </summary>
+    public static StateToken SubGraph(this StateToken prev, Graph child, bool history = false)
+    {
+        Guard.NotNull(child, nameof(child));
+        return prev.ToAsync(history ? new AsyncHistoryState(child) : new AsyncStateMachine(child));
+    }
+
+    /// <summary>
+    /// Starts the graph with a child graph as its first (composite) state.
+    /// </summary>
+    public static StateToken SubGraph(this StartToken root, Graph child, bool history = false)
+    {
+        Guard.NotNull(child, nameof(child));
+        IAsyncLogic composite = history ? new AsyncHistoryState(child) : new AsyncStateMachine(child);
+        NodeId id = root.Builder.AddNode(composite, true);
+        return new StateToken(id, root.Builder);
+    }
+
+    /// <summary>
+    /// Adds an orthogonal-regions composite and wires a transition to it: every region graph
+    /// progresses one node per round (cooperative interleaving) until all reach a terminal
+    /// result. Succeeds only when every region succeeded (see <see cref="AsyncParallelState"/>).
+    /// </summary>
+    public static StateToken Parallel(this StateToken prev, params Graph[] regions)
+    {
+        return prev.ToAsync(new AsyncParallelState(regions));
+    }
+
+    /// <summary>
+    /// Starts the graph with an orthogonal-regions composite as its first state.
+    /// </summary>
+    public static StateToken Parallel(this StartToken root, params Graph[] regions)
+    {
+        NodeId id = root.Builder.AddNode(new AsyncParallelState(regions), true);
+        return new StateToken(id, root.Builder);
+    }
+
+    /// <summary>
+    /// Routes this state's <c>Failure</c> outcome to a new sync handler state defined by a lambda.
+    /// </summary>
+    public static StateToken OnError(this StateToken prev, Func<Result> handler)
+    {
+        Guard.NotNull(handler, nameof(handler));
+        return prev.OnError(new RelayState(handler));
+    }
+
+    /// <summary>
+    /// Routes this state's <c>Failure</c> outcome to a new async handler state defined by a lambda.
+    /// </summary>
+    public static StateToken OnErrorAsync(this StateToken prev, Func<CancellationToken, ValueTask<Result>> handler)
+    {
+        Guard.NotNull(handler, nameof(handler));
+        return prev.OnErrorAsync(new AsyncRelayState(handler));
+    }
+
     public static StateToken SetName(this StateToken prev, string name)
     {
         Guard.NotNull(name, nameof(name));

--- a/NxGraph/Authoring/GraphBuilder.cs
+++ b/NxGraph/Authoring/GraphBuilder.cs
@@ -17,6 +17,13 @@ public sealed partial class GraphBuilder
     private readonly Dictionary<NodeId, IAsyncLogic?> _nodes = new(); // non-start nodes only
     private readonly Dictionary<object, NodeId> _byLogic = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<NodeId, Transition> _transitions = new();
+    private readonly Dictionary<int, string> _names = new(); // display names, applied at Build()
+    private readonly List<KeyValuePair<NodeId, string>> _pendingGotos = new(); // back-edges resolved by name at Build()
+    private readonly Dictionary<int, RetryPolicy> _retryPolicies = new(); // sparse; materialized at Build()
+    private readonly Dictionary<int, Action> _enterActions = new(); // sparse; attached to LogicNodes at Build()
+    private readonly Dictionary<int, Action> _exitActions = new(); // sparse; attached to LogicNodes at Build()
+    private readonly Dictionary<int, int> _outcomeCodes = new(); // sparse; materialized at Build()
+    private readonly Dictionary<int, string> _outcomeNames = new(); // code -> display name
 
     /// <summary>Add a node. If <paramref name="isStart"/> is true, this becomes the Start node (index 0).</summary>
     public NodeId AddNode(IAsyncLogic asyncLogic, bool isStart = false)
@@ -52,15 +59,130 @@ public sealed partial class GraphBuilder
         return _next;
     }
 
-    /// <summary>Add a single outgoing transition from <paramref name="from"/> to <paramref name="to"/>.</summary>
+    /// <summary>Add the single outgoing success transition from <paramref name="from"/> to <paramref name="to"/>.</summary>
     public GraphBuilder AddTransition(NodeId from, NodeId to)
     {
-        if (!_transitions.TryAdd(from, new Transition(to)))
+        if (HasPendingGoto(from))
         {
             throw new InvalidOperationException($"A transition from {from} is already defined.");
         }
 
+        AddSuccessEdge(from, to);
         return this;
+    }
+
+    /// <summary>
+    /// Add the failure transition from <paramref name="from"/> to <paramref name="to"/>:
+    /// when the node returns <c>Failure</c>, the machine routes there instead of terminating.
+    /// </summary>
+    public GraphBuilder AddFailureTransition(NodeId from, NodeId to)
+    {
+        if (to == NodeId.Default)
+        {
+            throw new ArgumentException("Failure transition target cannot be NodeId.Default.", nameof(to));
+        }
+
+        if (_transitions.TryGetValue(from, out Transition existing))
+        {
+            if (existing.HasFailureDestination)
+            {
+                throw new InvalidOperationException($"A failure transition from {from} is already defined.");
+            }
+
+            _transitions[from] = new Transition(existing.Destination, to);
+        }
+        else
+        {
+            _transitions.Add(from, new Transition(NodeId.Default, to));
+        }
+
+        return this;
+    }
+
+    private void AddSuccessEdge(NodeId from, NodeId to)
+    {
+        if (_transitions.TryGetValue(from, out Transition existing))
+        {
+            if (!existing.IsEmpty)
+            {
+                throw new InvalidOperationException($"A transition from {from} is already defined.");
+            }
+
+            _transitions[from] = new Transition(to, existing.FailureDestination);
+        }
+        else
+        {
+            _transitions.Add(from, new Transition(to));
+        }
+    }
+
+    /// <summary>
+    /// Adds a transition from <paramref name="from"/> to the node whose display name is
+    /// <paramref name="targetName"/>. The name is resolved at <c>Build()</c>, so it may be
+    /// assigned later in the chain. Unknown or ambiguous names fail the build.
+    /// </summary>
+    public GraphBuilder AddGoto(NodeId from, string targetName)
+    {
+        if (string.IsNullOrWhiteSpace(targetName))
+        {
+            throw new ArgumentException("Goto target name cannot be null or whitespace.", nameof(targetName));
+        }
+
+        if (HasPendingGoto(from) ||
+            (_transitions.TryGetValue(from, out Transition existing) && !existing.IsEmpty))
+        {
+            throw new InvalidOperationException($"A transition from {from} is already defined.");
+        }
+
+        _pendingGotos.Add(new KeyValuePair<NodeId, string>(from, targetName));
+        return this;
+    }
+
+    private bool HasPendingGoto(NodeId from)
+    {
+        foreach (KeyValuePair<NodeId, string> pending in _pendingGotos)
+        {
+            if (pending.Key.Index == from.Index)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void ResolvePendingGotos()
+    {
+        foreach ((NodeId from, string targetName) in _pendingGotos)
+        {
+            int targetIndex = -1;
+            foreach ((int index, string name) in _names)
+            {
+                if (!string.Equals(name, targetName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (targetIndex >= 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Goto target name '{targetName}' is ambiguous: nodes #{targetIndex} and #{index} both use it.");
+                }
+
+                targetIndex = index;
+            }
+
+            if (targetIndex < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Goto target '{targetName}' does not match any named node. " +
+                    "Name the target with SetName(...) before Build().");
+            }
+
+            AddSuccessEdge(from, new NodeId(targetIndex));
+        }
+
+        _pendingGotos.Clear();
     }
 
     /// <summary>Add a sync-only node. Wraps it in a <see cref="SyncLogicAdapter"/>.</summary>
@@ -86,6 +208,8 @@ public sealed partial class GraphBuilder
     /// <exception cref="InvalidOperationException">Thrown if no start node has been added or if there are inconsistencies in the graph structure.</exception>
     private Graph InternalBuild()
     {
+        ResolvePendingGotos();
+
         int maxIndex = 0;
         foreach (NodeId id in _nodes.Keys)
         {
@@ -105,8 +229,12 @@ public sealed partial class GraphBuilder
             edges[i] = Transition.Empty;
         }
 
-        nodes[NodeId.Start.Index] =
-            _startNode ?? throw new InvalidOperationException("No start node has been added to the graph.");
+        if (_startNode is null)
+        {
+            throw new InvalidOperationException("No start node has been added to the graph.");
+        }
+
+        nodes[NodeId.Start.Index] = CreateNode(_startNode.Id, _startNode.AsyncLogic);
 
         // Place the rest (null-safe checks)
         foreach ((NodeId id, IAsyncLogic? logic) in _nodes)
@@ -125,7 +253,7 @@ public sealed partial class GraphBuilder
 
             if (logic != null)
             {
-                nodes[idx] = new LogicNode(id, logic);
+                nodes[idx] = CreateNode(id, logic);
             }
             else
             {
@@ -142,11 +270,51 @@ public sealed partial class GraphBuilder
                 throw new InvalidOperationException($"Transition 'from' {from} is out of bounds.");
             }
 
-            edges[idx] = t;
+            edges[idx] = new Transition(ApplyName(t.Destination), ApplyName(t.FailureDestination));
         }
 
+        LogicNode CreateNode(NodeId id, IAsyncLogic logic)
+        {
+            _enterActions.TryGetValue(id.Index, out Action? enter);
+            _exitActions.TryGetValue(id.Index, out Action? exit);
+            return new LogicNode(ApplyName(id), logic, enter, exit);
+        }
+
+        RetryPolicy[]? retries = null;
+        if (_retryPolicies.Count > 0)
+        {
+            retries = new RetryPolicy[length];
+            foreach ((int idx, RetryPolicy policy) in _retryPolicies)
+            {
+                if ((uint)idx >= (uint)retries.Length)
+                {
+                    throw new InvalidOperationException($"Retry policy node index {idx} is out of bounds.");
+                }
+
+                retries[idx] = policy;
+            }
+        }
+
+        int[]? outcomes = null;
+        if (_outcomeCodes.Count > 0)
+        {
+            outcomes = new int[length];
+            foreach ((int idx, int code) in _outcomeCodes)
+            {
+                if ((uint)idx >= (uint)outcomes.Length)
+                {
+                    throw new InvalidOperationException($"Outcome code node index {idx} is out of bounds.");
+                }
+
+                outcomes[idx] = code;
+            }
+        }
+
+        IReadOnlyDictionary<int, string>? outcomeNames =
+            _outcomeNames.Count > 0 ? new Dictionary<int, string>(_outcomeNames) : null;
+
         NodeId graphId = _next.Next();
-        return new Graph(graphId, nodes, edges);
+        return new Graph(graphId, nodes, edges, logic: null, retries, outcomes, outcomeNames);
     }
 
 
@@ -207,7 +375,8 @@ public sealed partial class GraphBuilder
     }
 
     /// <summary>
-    /// Sets the name of a node in the graph.
+    /// Sets the display name of a node. Names are presentation data only — node identity
+    /// is the index — and are applied to the emitted <see cref="NodeId"/>s at <c>Build()</c>.
     /// </summary>
     public void SetName(NodeId id, string name)
     {
@@ -216,82 +385,86 @@ public sealed partial class GraphBuilder
             throw new ArgumentException("Node name cannot be null or whitespace.", nameof(name));
         }
 
-        NodeId oldId = id;
-        NodeId namedId = oldId.WithName(name);
-
-        bool isStart = _startNode is not null && _startNode.Id.Index == oldId.Index;
-        if (isStart)
+        bool isStart = _startNode is not null && _startNode.Id.Index == id.Index;
+        if (!isStart && !_nodes.ContainsKey(id))
         {
-            if (_startNode != null)
-            {
-                _startNode = new LogicNode(namedId, _startNode.AsyncLogic);
-            }
-            else
-            {
-                throw new InvalidOperationException("Start node is not defined.");
-            }
-        }
-        else if (_nodes.Remove(oldId, out IAsyncLogic? existingLogic))
-        {
-            // Normal path when callers pass in the exact key we stored
-            _nodes[namedId] = existingLogic;
-        }
-        else
-        {
-            // Fallback: look up by index only (in case callers passed an id with the right
-            // index but a different name than what we have as the key).
-            NodeId? keyToRename = null;
-            foreach (NodeId key in _nodes.Keys)
-            {
-                if (key.Index == oldId.Index)
-                {
-                    keyToRename = key;
-                    break;
-                }
-            }
-
-            if (keyToRename is null)
-            {
-                throw new InvalidOperationException($"Node with index {oldId.Index} does not exist in the graph.");
-            }
-
-            IAsyncLogic? logic = _nodes[keyToRename.Value];
-            if (logic == null)
-            {
-                throw new InvalidOperationException($"Node with index {oldId.Index} does not exist in the graph.");
-            }
-            _nodes.Remove(keyToRename.Value);
-            _nodes[namedId] = logic;
+            throw new InvalidOperationException($"Node with index {id.Index} does not exist in the graph.");
         }
 
-        // Update logic->id map so future AddNode(sameLogic) returns the named id
-        foreach (KeyValuePair<object, NodeId> pair in _byLogic.ToList())
+        _names[id.Index] = name;
+    }
+
+    private NodeId ApplyName(NodeId id)
+        => _names.TryGetValue(id.Index, out string? name) ? id.WithName(name) : id;
+
+    /// <summary>
+    /// Attaches an action fired when the machine enters the node (once per visit,
+    /// before its first execution).
+    /// </summary>
+    public GraphBuilder SetEnterAction(NodeId id, Action action)
+    {
+        Guard.NotNull(action, nameof(action));
+        RequireExistingNode(id);
+        _enterActions[id.Index] = action;
+        return this;
+    }
+
+    /// <summary>
+    /// Attaches an action fired when the machine leaves the node (once per visit,
+    /// after its final execution, regardless of outcome).
+    /// </summary>
+    public GraphBuilder SetExitAction(NodeId id, Action action)
+    {
+        Guard.NotNull(action, nameof(action));
+        RequireExistingNode(id);
+        _exitActions[id.Index] = action;
+        return this;
+    }
+
+    /// <summary>
+    /// Declares the terminal outcome reported when a run ends at this node
+    /// (e.g. "Approved" vs "Rejected"), with an optional display name for the code.
+    /// </summary>
+    public GraphBuilder SetOutcome(NodeId id, int code, string? name = null)
+    {
+        RequireExistingNode(id);
+        _outcomeCodes[id.Index] = code;
+        if (name is not null)
         {
-            if (pair.Value.Index == oldId.Index)
-            {
-                _byLogic[pair.Key] = namedId;
-            }
+            _outcomeNames[code] = name;
         }
 
-        // Update transitions: sources and destinations that reference this index
-        foreach ((NodeId from, Transition t) in _transitions.ToList())
+        return this;
+    }
+
+    private void RequireExistingNode(NodeId id)
+    {
+        bool isStart = _startNode is not null && _startNode.Id.Index == id.Index;
+        if (!isStart && !_nodes.ContainsKey(id))
         {
-            bool fromMatches = from.Index == oldId.Index;
-            bool toMatches = t.Destination.Index == oldId.Index;
-
-            NodeId newFrom = fromMatches ? namedId : from;
-            Transition newTransition = toMatches ? new Transition(namedId) : t;
-
-            if (fromMatches)
-            {
-                _transitions.Remove(from);
-                _transitions[newFrom] = newTransition;
-            }
-            else if (toMatches)
-            {
-                _transitions[from] = newTransition;
-            }
+            throw new InvalidOperationException($"Node with index {id.Index} does not exist in the graph.");
         }
+    }
+
+    /// <summary>
+    /// Declares a retry policy for a node: on <c>Failure</c> the node is re-run in place
+    /// until it succeeds or the policy's attempts are exhausted.
+    /// </summary>
+    public GraphBuilder SetRetryPolicy(NodeId id, RetryPolicy policy)
+    {
+        if (policy.MaxAttempts == 0)
+        {
+            throw new ArgumentException("Retry policy must allow at least one attempt.", nameof(policy));
+        }
+
+        bool isStart = _startNode is not null && _startNode.Id.Index == id.Index;
+        if (!isStart && !_nodes.ContainsKey(id))
+        {
+            throw new InvalidOperationException($"Node with index {id.Index} does not exist in the graph.");
+        }
+
+        _retryPolicies[id.Index] = policy;
+        return this;
     }
 
     public static void SetName(Graph graph, string name)
@@ -305,6 +478,21 @@ public sealed partial class GraphBuilder
         graph.Id = graph.Id.WithName(name);
     }
 
+    /// <summary>
+    /// Wraps an already-added node in a <see cref="StateToken"/> so detached chains
+    /// (e.g. failure handlers) can be built fluently with the same builder.
+    /// </summary>
+    public StateToken TokenFor(NodeId id)
+    {
+        bool isStart = _startNode is not null && _startNode.Id.Index == id.Index;
+        if (!isStart && !_nodes.ContainsKey(id))
+        {
+            throw new InvalidOperationException($"Node with index {id.Index} does not exist in the graph.");
+        }
+
+        return new StateToken(id, this);
+    }
+
     public IReadOnlyList<NodeId>? GetAllNodeIds()
     {
         if (_nodes.Count == 0 || _startNode == null)
@@ -312,10 +500,10 @@ public sealed partial class GraphBuilder
             return null;
         }
 
-        List<NodeId> ids = new(_nodes.Keys.Count) { _startNode.Id };
+        List<NodeId> ids = new(_nodes.Keys.Count) { ApplyName(_startNode.Id) };
         foreach (NodeId id in _nodes.Keys)
         {
-            ids.Add(id);
+            ids.Add(ApplyName(id));
         }
 
         return ids;

--- a/NxGraph/Authoring/StateToken.cs
+++ b/NxGraph/Authoring/StateToken.cs
@@ -1,4 +1,5 @@
-﻿using NxGraph.Graphs;
+﻿using NxGraph.Fsm;
+using NxGraph.Graphs;
 
 namespace NxGraph.Authoring;
 
@@ -40,6 +41,112 @@ public readonly struct StateToken
         Builder.AddTransition(Id, next);
         return new StateToken(next, Builder);
     }
+
+    /// <summary>
+    /// Declares the terminal outcome reported when a run ends at this state
+    /// (e.g. "Approved" vs "Rejected"), with an optional display name for the code.
+    /// </summary>
+    public StateToken WithOutcome(int code, string? name = null)
+    {
+        Builder.SetOutcome(Id, code, name);
+        return this;
+    }
+
+    /// <summary>
+    /// Attaches an action fired when the machine enters this state — once per visit,
+    /// before its first execution (retries do not re-fire it).
+    /// </summary>
+    public StateToken OnEnter(Action action)
+    {
+        Builder.SetEnterAction(Id, action);
+        return this;
+    }
+
+    /// <summary>
+    /// Attaches an action fired when the machine leaves this state — once per visit,
+    /// after its final execution, regardless of outcome.
+    /// </summary>
+    public StateToken OnExit(Action action)
+    {
+        Builder.SetExitAction(Id, action);
+        return this;
+    }
+
+    /// <summary>
+    /// Declares a retry policy for this state: on <c>Failure</c> it is re-run in place until
+    /// it succeeds or <paramref name="maxAttempts"/> executions are consumed, then normal
+    /// failure handling applies. Backoff is honored by the async runtime only.
+    /// </summary>
+    public StateToken Retry(byte maxAttempts, TimeSpan backoff = default,
+        BackoffKind backoffKind = BackoffKind.Fixed)
+    {
+        Builder.SetRetryPolicy(Id, new RetryPolicy(maxAttempts, backoff, backoffKind));
+        return this;
+    }
+
+    /// <summary>
+    /// Routes this state's <c>Failure</c> outcome to <paramref name="handler"/> instead of
+    /// terminating the machine. The success chain continues from this state.
+    /// </summary>
+    public StateToken OnError(StateToken handler)
+    {
+        Builder.AddFailureTransition(Id, handler.Id);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a brand-new sync state as the failure handler for this state.
+    /// The handler is terminal unless wired further; the success chain continues from this state.
+    /// </summary>
+    public StateToken OnError(ILogic handlerLogic)
+    {
+        NodeId handler = Builder.AddNode(handlerLogic);
+        Builder.AddFailureTransition(Id, handler);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a brand-new async state as the failure handler for this state.
+    /// The handler is terminal unless wired further; the success chain continues from this state.
+    /// </summary>
+    public StateToken OnErrorAsync(IAsyncLogic handlerLogic)
+    {
+        NodeId handler = Builder.AddNode(handlerLogic);
+        Builder.AddFailureTransition(Id, handler);
+        return this;
+    }
+
+    /// <summary>
+    /// Wires this state's outgoing transition back to the node named <paramref name="targetName"/>
+    /// (assigned via <c>SetName</c>, before or after this call). The name resolves at
+    /// <see cref="GraphBuilder.Build"/>; unknown or ambiguous names fail the build.
+    /// The chain ends here — a state has a single outgoing transition.
+    /// </summary>
+    public GotoToken Goto(string targetName)
+    {
+        Builder.AddGoto(Id, targetName);
+        return new GotoToken(Builder);
+    }
+
+    /// <summary> Finishes the DSL and produces an immutable <see cref="Graph"/>. </summary>
+    public Graph Build()
+    {
+        return Builder.Build();
+    }
+}
+
+/// <summary>
+/// Returned by <see cref="StateToken.Goto"/>. The chain is closed — the only remaining
+/// operation is producing the graph.
+/// </summary>
+public readonly struct GotoToken
+{
+    internal GotoToken(GraphBuilder builder)
+    {
+        Builder = builder;
+    }
+
+    public GraphBuilder Builder { get; }
 
     /// <summary> Finishes the DSL and produces an immutable <see cref="Graph"/>. </summary>
     public Graph Build()

--- a/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
+++ b/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
@@ -112,6 +112,23 @@ public sealed class MermaidGraphExporter : IGraphExporter
             }
         }
 
+        // Failure edges: emitted as labeled dashed arrows so fault routing is visible
+        // alongside the solid success flow.
+        for (int i = 0; i < graph.TransitionCount; i++)
+        {
+            Transition edge = graph.GetTransitionByIndex(i);
+            if (!edge.HasFailureDestination)
+            {
+                continue;
+            }
+
+            int dstIdx = edge.FailureDestination.Index;
+            if ((uint)dstIdx < (uint)graph.NodeCount)
+            {
+                sb.Append("  ").Append(NodeVar(i)).Append(" -. fail .-> ").Append(NodeVar(dstIdx)).AppendLine();
+            }
+        }
+
         // Director edges: directors don't carry a static transition (the runtime calls
         // SelectNext at execution time), so they're missed by the static-edge loop above.
         // Emit dashed edges to every statically-known target so the rendered diagram

--- a/NxGraph/Diagnostics/Validations/GraphValidator.cs
+++ b/NxGraph/Diagnostics/Validations/GraphValidator.cs
@@ -45,6 +45,27 @@ public static class GraphValidator
                 continue;
             }
 
+            // Failure edges apply to every node kind, directors included, so walk them
+            // before the director-specific handling below.
+            if (graph.TryGetTransition(current, out Transition outgoing) && outgoing.HasFailureDestination)
+            {
+                NodeId failureDest = outgoing.FailureDestination;
+                if (!graph.TryGetNode(failureDest, out _))
+                {
+                    result.Add(Severity.Error,
+                        $"Failure transition points to non-existent node #{failureDest.Index}.", current);
+                }
+                else
+                {
+                    if (options.WarnOnSelfLoop && failureDest.Index == current.Index)
+                    {
+                        result.Add(Severity.Warning, "Self-loop transition detected.", current);
+                    }
+
+                    queue.Enqueue(failureDest);
+                }
+            }
+
             // Director nodes route at runtime; their statically-known targets must be walked
             // explicitly because TryGetTransition returns Empty for them. EnumerateStaticTargets
             // returns the empty sequence for opaque custom directors — those remain invisible
@@ -62,8 +83,10 @@ public static class GraphValidator
             if (directorTargets is not null)
             {
                 bool sawTerminalBranch = false;
+                bool sawAnyTarget = false;
                 foreach (NodeId branchDest in directorTargets)
                 {
+                    sawAnyTarget = true;
                     if (branchDest.Equals(NodeId.Default))
                     {
                         // NodeId.Default is the runtime sentinel for "exit successfully" from
@@ -90,6 +113,14 @@ public static class GraphValidator
                 if (sawTerminalBranch)
                 {
                     sawTerminal = true;
+                }
+
+                if (!sawAnyTarget)
+                {
+                    result.Add(Severity.Warning,
+                        "Director exposes no static targets — its branches are invisible to reachability " +
+                        "validation and Mermaid export. Override EnumerateStaticTargets() to surface them.",
+                        current);
                 }
 
                 // Director nodes do not have a static fall-through transition; skip the

--- a/NxGraph/Fsm/Async/AsyncHistoryState.cs
+++ b/NxGraph/Fsm/Async/AsyncHistoryState.cs
@@ -1,0 +1,69 @@
+using NxGraph.Compatibility;
+using NxGraph.Graphs;
+
+namespace NxGraph.Fsm.Async;
+
+/// <summary>
+/// Wraps a child graph as a composite node with <b>history</b>: when the child fails (or is
+/// cancelled) and the parent later re-enters the composite — e.g. after a failure edge and a
+/// <c>Goto</c> back — execution resumes at the child's last-active node instead of restarting
+/// from its start node. A child that <i>completed</i> restarts from the top on re-entry.
+/// <para>
+/// This is <b>shallow</b> history for the wrapped graph: the resumed node itself restarts
+/// fresh. <b>Deep</b> history falls out of composition — wrap the nested subgraphs inside the
+/// child with their own history composites and each level resumes its own position.
+/// </para>
+/// <para>
+/// The happy path steps the child at 0 B; the resume bookkeeping allocates a small snapshot
+/// only on the failure-recovery path, which is off the hot loop by definition.
+/// </para>
+/// </summary>
+public sealed class AsyncHistoryState : IAsyncLogic, ISubGraphProvider
+{
+    /// <summary>The wrapped child machine.</summary>
+    public AsyncStateMachine Child { get; }
+
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Child.Graph];
+
+    public AsyncHistoryState(Graph child)
+    {
+        Guard.NotNull(child, nameof(child));
+        Child = new AsyncStateMachine(child);
+        // Manual keeps the child's position (current node) intact after a failure instead of
+        // auto-resetting to the start — that position is exactly the history to resume from.
+        Child.SetRestartPolicy(RestartPolicy.Manual);
+    }
+
+    public async ValueTask<Result> ExecuteAsync(CancellationToken ct = default)
+    {
+        ExecutionStatus status = Child.Status;
+        switch (status)
+        {
+            case ExecutionStatus.Failed:
+            case ExecutionStatus.Cancelled:
+            {
+                // Re-enter at the recorded position: lift the terminal snapshot back into a
+                // running stepped session with a fresh retry budget for the resumed node.
+                StateMachineSnapshot history = Child.Suspend();
+                Child.Resume(history with
+                {
+                    Status = ExecutionStatus.Running,
+                    MidRun = true,
+                    Attempts = 0,
+                });
+                break;
+            }
+            case ExecutionStatus.Completed:
+                await Child.Reset(ct).ConfigureAwait(false);
+                break;
+        }
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await Child.StepAsync(ct).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+}

--- a/NxGraph/Fsm/Async/AsyncParallelState.cs
+++ b/NxGraph/Fsm/Async/AsyncParallelState.cs
@@ -1,0 +1,92 @@
+using NxGraph.Compatibility;
+using NxGraph.Graphs;
+
+namespace NxGraph.Fsm.Async;
+
+/// <summary>
+/// Orthogonal (AND-state) regions via <b>cooperative interleaving</b>: each region is a child
+/// graph, and one execution of this composite round-robin steps every still-running region —
+/// one node per region per round — until all regions reach a terminal result (the join).
+/// The composite returns <see cref="Result.Success"/> only when every region succeeded;
+/// if any region failed it returns <see cref="Result.Failure"/> after the join, which then
+/// flows through the parent's unified fault model (failure edges, retries).
+/// <para>
+/// This is deliberately <b>not</b> thread-concurrent. True parallel execution would require
+/// multiple in-flight tasks and a join (<c>WhenAll</c>), which allocate — that variant is out
+/// of scope to preserve the library's zero-allocation hot-path guarantee. Interleaved progress
+/// gives AND-state semantics at 0 B per step, which covers the game/agent use cases this
+/// library targets; run truly CPU-parallel work inside a single node instead.
+/// </para>
+/// </summary>
+public sealed class AsyncParallelState : IAsyncLogic, ISubGraphProvider
+{
+    private readonly AsyncStateMachine[] _regions;
+    private readonly bool[] _done;
+
+    /// <summary>The region machines.</summary>
+    public IReadOnlyList<AsyncStateMachine> Regions => _regions;
+
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs
+    {
+        get
+        {
+            foreach (AsyncStateMachine region in _regions)
+            {
+                yield return region.Graph;
+            }
+        }
+    }
+
+    public AsyncParallelState(params Graph[] regions)
+    {
+        Guard.NotNull(regions, nameof(regions));
+        if (regions.Length == 0)
+        {
+            throw new ArgumentException("At least one region is required.", nameof(regions));
+        }
+
+        _regions = new AsyncStateMachine[regions.Length];
+        for (int i = 0; i < regions.Length; i++)
+        {
+            _regions[i] = new AsyncStateMachine(regions[i]);
+        }
+
+        _done = new bool[regions.Length];
+    }
+
+    public async ValueTask<Result> ExecuteAsync(CancellationToken ct = default)
+    {
+        int remaining = _regions.Length;
+        for (int i = 0; i < _done.Length; i++)
+        {
+            _done[i] = false;
+        }
+
+        bool anyFailed = false;
+        while (remaining > 0)
+        {
+            for (int i = 0; i < _regions.Length; i++)
+            {
+                if (_done[i])
+                {
+                    continue;
+                }
+
+                Result step = await _regions[i].StepAsync(ct).ConfigureAwait(false);
+                if (!step.IsCompleted)
+                {
+                    continue;
+                }
+
+                _done[i] = true;
+                remaining--;
+                if (step.IsFailure)
+                {
+                    anyFailed = true;
+                }
+            }
+        }
+
+        return anyFailed ? Result.Failure : Result.Success;
+    }
+}

--- a/NxGraph/Fsm/Async/AsyncRelayState.cs
+++ b/NxGraph/Fsm/Async/AsyncRelayState.cs
@@ -1,4 +1,4 @@
-﻿namespace NxGraph.Fsm.Async;
+namespace NxGraph.Fsm.Async;
 
 /// <summary>
 /// AsyncRelayState is a state that can be used to encapsulate a function that returns a Result.
@@ -16,7 +16,7 @@ public sealed class AsyncRelayState(
 
     protected override  ValueTask<Result> OnEnterAsync(CancellationToken ct)
     {
-        return onEnter?.Invoke(ct) ?? ResultHelpers.Continue;
+        return onEnter?.Invoke(ct) ?? ResultHelpers.InProgress;
     }
 
     protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
@@ -47,7 +47,7 @@ public sealed class AsyncRelayState<TAgent>(
 
     protected override ValueTask<Result> OnEnterAsync(CancellationToken ct)
     {
-        return onEnter?.Invoke(Agent, ct) ?? ResultHelpers.Continue;
+        return onEnter?.Invoke(Agent, ct) ?? ResultHelpers.InProgress;
     }
 
     protected override ValueTask<Result> OnRunAsync(CancellationToken ct)

--- a/NxGraph/Fsm/Async/AsyncState.cs
+++ b/NxGraph/Fsm/Async/AsyncState.cs
@@ -1,4 +1,4 @@
-﻿using NxGraph.Diagnostics.Replay;
+using NxGraph.Diagnostics.Replay;
 using NxGraph.Graphs;
 
 namespace NxGraph.Fsm.Async;
@@ -40,12 +40,12 @@ public abstract class AsyncState : IAsyncLogic, ILogReporter
 
     protected virtual ValueTask<Result> OnEnterAsync(CancellationToken ct)
     {
-        return ResultHelpers.Continue;
+        return ResultHelpers.InProgress;
     }
 
     protected virtual ValueTask<Result> OnRunAsync(CancellationToken ct)
     {
-        return ResultHelpers.Continue;
+        return ResultHelpers.InProgress;
     }
 
     protected virtual ValueTask<Result> OnExitAsync(CancellationToken ct)

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using NxGraph.Diagnostics.Replay;
 using NxGraph.Graphs;
 
@@ -10,15 +10,39 @@ namespace NxGraph.Fsm.Async;
 public class AsyncStateMachine<TAgent>(Graph graph, IAsyncStateMachineObserver? observer = null)
     : AsyncStateMachine(graph, observer), IAgentSettable<TAgent>
 {
-    public void SetAgent(TAgent agent) => Graph.SetAgent(agent);
+    private TAgent? _agent;
+    private bool _hasAgent;
+
+    /// <summary>
+    /// Binds the agent (typed context) to this machine. It is applied to the graph's nodes
+    /// immediately and re-applied at the start of every execution, so several machines can
+    /// share one <see cref="Graph"/> with distinct contexts as long as their executions do
+    /// not overlap. For concurrently-running machines, give each its own graph instance.
+    /// </summary>
+    public void SetAgent(TAgent agent)
+    {
+        _agent = agent;
+        _hasAgent = true;
+        Graph.SetAgent(agent);
+    }
+
+    private protected override void ApplyExecutionContext()
+    {
+        if (_hasAgent)
+        {
+            Graph.SetAgent(_agent!);
+        }
+    }
 }
 
 /// <summary>
 /// Non-generic AsyncStateMachine.
 /// </summary>
-public class AsyncStateMachine : AsyncState
+public class AsyncStateMachine : AsyncState, ISubGraphProvider
 {
     public readonly Graph Graph;
+
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Graph];
     private readonly IAsyncStateMachineObserver? _observer;
 
     private int _statusInt = (int)ExecutionStatus.Created; // atomic state
@@ -31,6 +55,25 @@ public class AsyncStateMachine : AsyncState
     private Result _terminalResult = Result.Success;
     private int _executeGate;
     private readonly Func<string, CancellationToken, ValueTask> _cachedLogReportCallback;
+    private readonly ILogReporter?[] _reporters; // indexed by NodeId.Index, resolved once at construction
+    private readonly RetryPolicy[]? _retryPolicies; // graph-owned; null when no node declares one
+    private int _attempts; // executions of the current node in this run
+    private bool _stepping; // a StepAsync-driven run is in flight (status stays Running between steps)
+    private bool _nodeEntered; // the current node's EnterAction has fired for this visit
+    private readonly int[]? _outcomeCodes; // graph-owned; null when no node declares one
+
+    /// <summary>
+    /// The outcome code of the node the last run terminated at (default 0).
+    /// Reset when a new run starts.
+    /// </summary>
+    public int LastOutcome { get; private set; }
+
+    /// <summary>
+    /// The display name registered for <see cref="LastOutcome"/>, or <c>null</c>.
+    /// Resolved lazily — never on the run loop.
+    /// </summary>
+    public string? LastOutcomeName =>
+        Graph.OutcomeNames is { } names && names.TryGetValue(LastOutcome, out string? name) ? name : null;
 
     /// <summary>Public execution status (volatile for visibility).</summary>
     public ExecutionStatus Status => (ExecutionStatus)Volatile.Read(ref _statusInt);
@@ -42,7 +85,34 @@ public class AsyncStateMachine : AsyncState
         _initial = graph.StartNode.Id;
         _current = _initial;
         _cachedLogReportCallback = LogReportCallback;
+        _reporters = BuildReporterTable(graph);
+        _retryPolicies = graph.RetryPolicies;
+        _outcomeCodes = graph.OutcomeCodes;
         // _statusInt already initialized to Created at field declaration; no transition needed.
+    }
+
+    /// <summary>
+    /// Hook for derived machines to (re)apply per-machine execution context (e.g. the typed
+    /// agent) to the graph's nodes. Runs under the execute gate, right before Starting.
+    /// </summary>
+    private protected virtual void ApplyExecutionContext()
+    {
+    }
+
+    private int OutcomeOf(NodeId id) => _outcomeCodes is null ? 0 : _outcomeCodes[id.Index];
+
+    private static ILogReporter?[] BuildReporterTable(Graph graph)
+    {
+        ILogReporter?[] table = new ILogReporter?[graph.NodeCount];
+        for (int i = 0; i < table.Length; i++)
+        {
+            if (graph.TryGetNodeByIndex(i, out INode? node) && node is LogicNode logicNode)
+            {
+                table[i] = logicNode.AsyncLogic as ILogReporter ?? logicNode.Logic as ILogReporter;
+            }
+        }
+
+        return table;
     }
 
     /// <summary>
@@ -126,6 +196,8 @@ public class AsyncStateMachine : AsyncState
         }
 
         _current = _initial;
+        _attempts = 0;
+        _nodeEntered = false;
 
         await TransitionTo(ExecutionStatus.Ready).ConfigureAwait(false);
         return Result.Success;
@@ -136,6 +208,13 @@ public class AsyncStateMachine : AsyncState
         if (Interlocked.Exchange(ref _executeGate, 1) == 1) // Prevent re-entrance
         {
             throw new InvalidOperationException("AsyncStateMachine is already executing.");
+        }
+
+        if (_stepping)
+        {
+            Volatile.Write(ref _executeGate, 0);
+            throw new InvalidOperationException(
+                "A stepped run is in progress. Finish it with StepAsync or Reset() before calling ExecuteAsync.");
         }
 
         // If we're terminal, apply reset policy.
@@ -149,7 +228,7 @@ public class AsyncStateMachine : AsyncState
                     // Keep the gate held so a concurrent caller cannot enter while this
                     // ExecuteAsync is still on its way to OnRunAsync (which returns the
                     // cached terminal result) and OnExitAsync (which releases the gate).
-                    return Result.Continue;
+                    return Result.InProgress;
                 case RestartPolicy.Manual:
                     Volatile.Write(ref _executeGate, 0); // Release the gate before throwing.
                     throw new InvalidOperationException(
@@ -162,9 +241,15 @@ public class AsyncStateMachine : AsyncState
             }
         }
 
+        // Re-stamp this machine's context onto the (potentially shared) graph before running.
+        ApplyExecutionContext();
+
         // First entry or re-entry after Ready: Starting -> (enter first node) -> Running
         await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
         _current = _initial;
+        _attempts = 0;
+        _nodeEntered = false;
+        LastOutcome = 0;
         if (_observer is not null)
         {
             await _observer.OnStateEntered(_current, ct).ConfigureAwait(false);
@@ -172,7 +257,7 @@ public class AsyncStateMachine : AsyncState
 
         await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
         
-        return Result.Continue;
+        return Result.InProgress;
     }
 
     protected override async ValueTask<Result> OnRunAsync(CancellationToken ct)
@@ -249,31 +334,243 @@ public class AsyncStateMachine : AsyncState
         return ResultHelpers.Success;
     }
 
+    /// <summary>
+    /// Captures the machine's runtime position into a serializable snapshot. Legal only at a
+    /// step boundary: between <see cref="StepAsync"/> calls of a stepped run, or on a machine
+    /// that is not currently executing. Suspending never touches the run loop.
+    /// </summary>
+    public StateMachineSnapshot Suspend()
+    {
+        if (Interlocked.Exchange(ref _executeGate, 1) == 1)
+        {
+            throw new InvalidOperationException(
+                "Cannot suspend while the machine is executing. Suspend between StepAsync calls.");
+        }
+
+        try
+        {
+            ExecutionStatus status = Status;
+            if (status is ExecutionStatus.Starting or ExecutionStatus.Transitioning or ExecutionStatus.Resetting)
+            {
+                throw new InvalidOperationException($"Cannot suspend in transient status '{status}'.");
+            }
+
+            return new StateMachineSnapshot(_current.Index, status, _attempts, _nodeEntered, _stepping, LastOutcome);
+        }
+        finally
+        {
+            Volatile.Write(ref _executeGate, 0);
+        }
+    }
+
+    /// <summary>
+    /// Restores a snapshot produced by <see cref="Suspend"/> onto this machine. The graph must
+    /// be structurally equivalent to the one the snapshot was taken from (same node indices).
+    /// A mid-run snapshot is continued with <see cref="StepAsync"/> until it returns a terminal
+    /// result; re-attach the user context via <c>SetAgent</c> before stepping if the graph
+    /// uses one. No observer events are replayed by the restore itself.
+    /// </summary>
+    public void Resume(StateMachineSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        if (Interlocked.Exchange(ref _executeGate, 1) == 1)
+        {
+            throw new InvalidOperationException("Cannot resume while the machine is executing.");
+        }
+
+        try
+        {
+            if (snapshot.Status is ExecutionStatus.Starting or ExecutionStatus.Transitioning
+                or ExecutionStatus.Resetting)
+            {
+                throw new InvalidOperationException(
+                    $"Snapshot captured in transient status '{snapshot.Status}' cannot be resumed.");
+            }
+
+            if ((uint)snapshot.CurrentNodeIndex >= (uint)Graph.NodeCount)
+            {
+                throw new InvalidOperationException(
+                    $"Snapshot node index {snapshot.CurrentNodeIndex} is out of range for this graph " +
+                    $"(0..{Graph.NodeCount - 1}).");
+            }
+
+            _current = Graph.GetNodeByIndex(snapshot.CurrentNodeIndex).Id;
+            _attempts = snapshot.Attempts;
+            _nodeEntered = snapshot.NodeEntered;
+            _stepping = snapshot.MidRun;
+            LastOutcome = snapshot.LastOutcome;
+            Volatile.Write(ref _statusInt, (int)snapshot.Status);
+        }
+        finally
+        {
+            Volatile.Write(ref _executeGate, 0);
+        }
+    }
+
+    /// <summary>
+    /// Advances the machine by exactly one node execution, mirroring the sync machine's
+    /// frame-stepped <c>Execute()</c>. Returns <see cref="Result.InProgress"/> while more nodes
+    /// remain and the terminal result when the run finishes. The first call begins a run
+    /// (applying the restart policy exactly like <c>ExecuteAsync</c>); between steps the
+    /// machine stays <see cref="ExecutionStatus.Running"/>. Observer events and terminal
+    /// status transitions are identical to a full <c>ExecuteAsync</c> run.
+    /// </summary>
+    public async ValueTask<Result> StepAsync(CancellationToken ct = default)
+    {
+        if (Interlocked.Exchange(ref _executeGate, 1) == 1)
+        {
+            throw new InvalidOperationException("AsyncStateMachine is already executing.");
+        }
+
+        try
+        {
+            if (!_stepping)
+            {
+                ExecutionStatus status = Status;
+                if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+                {
+                    switch (_restartPolicy)
+                    {
+                        case RestartPolicy.Ignore:
+                            return _terminalResult;
+                        case RestartPolicy.Manual:
+                            throw new InvalidOperationException(
+                                $"AsyncStateMachine is in terminal state '{status}'. Call Reset() before stepping again.");
+                        default:
+                            await ResetCore(ct).ConfigureAwait(false);
+                            break;
+                    }
+                }
+
+                ApplyExecutionContext();
+
+                await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
+                _current = _initial;
+                _attempts = 0;
+                _nodeEntered = false;
+                LastOutcome = 0;
+                if (_observer is not null)
+                {
+                    await _observer.OnStateEntered(_current, ct).ConfigureAwait(false);
+                }
+
+                await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
+                _stepping = true;
+            }
+
+            Result result;
+            try
+            {
+                result = await StepCoreAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                _stepping = false;
+                await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
+                _terminalResult = Result.Failure;
+                if (_restartPolicy == RestartPolicy.Auto)
+                {
+                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                }
+
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _stepping = false;
+                if (_observer is not null)
+                {
+                    await _observer.OnStateFailed(_current, ex, ct).ConfigureAwait(false);
+                }
+
+                await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
+                _terminalResult = Result.Failure;
+                if (_restartPolicy == RestartPolicy.Auto)
+                {
+                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                }
+
+                throw;
+            }
+
+            if (!result.IsCompleted)
+            {
+                return Result.InProgress;
+            }
+
+            _stepping = false;
+            _terminalResult = result;
+            await TransitionTo(result == Result.Success ? ExecutionStatus.Completed : ExecutionStatus.Failed)
+                .ConfigureAwait(false);
+
+            if (_restartPolicy == RestartPolicy.Auto)
+            {
+                await ResetCore(ct).ConfigureAwait(false);
+            }
+
+            return result;
+        }
+        finally
+        {
+            Volatile.Write(ref _executeGate, 0);
+        }
+    }
+
     private async ValueTask<Result> InternalRunAsync(CancellationToken ct)
     {
-        while (!ct.IsCancellationRequested)
+        while (true)
+        {
+            Result step = await StepCoreAsync(ct).ConfigureAwait(false);
+            if (step.IsCompleted)
+            {
+                return step;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Advances the machine by exactly one node execution. Returns <see cref="Result.InProgress"/>
+    /// while more nodes remain (including in-place retries and failure-edge reroutes) and a
+    /// terminal <see cref="Result.Success"/>/<see cref="Result.Failure"/> when the run finished.
+    /// </summary>
+    private async ValueTask<Result> StepCoreAsync(CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
         {
             if (!Graph.TryGetNode(_current, out INode? node))
             {
                 throw new InvalidOperationException($"Node '{_current}' not found.");
             }
 
-            if (node is LogicNode logicNode)
+            ILogReporter? reporter = _reporters[_current.Index];
+            if (reporter is not null)
             {
-                ILogReporter? reporter = logicNode.AsyncLogic as ILogReporter ?? logicNode.Logic as ILogReporter;
-                if (reporter is not null)
-                {
-                    //We need to capture the current node in the closure for correct attribution
-                    reporter.LogReport = _cachedLogReportCallback;
-                }
+                // Reassigned on every visit so interleaved machines sharing a graph each
+                // attribute log reports to their own observer.
+                reporter.LogReport = _cachedLogReportCallback;
             }
 
             LogicNode logic = (LogicNode)node;
+            if (!_nodeEntered)
+            {
+                _nodeEntered = true;
+                logic.EnterAction?.Invoke();
+            }
+
             Result result = await logic.AsyncLogic.ExecuteAsync(ct).ConfigureAwait(false);
+            _attempts++;
             switch (result.Code)
             {
                 case Result.StatusCode.Success:
                 {
+                    _nodeEntered = false;
+                    logic.ExitAction?.Invoke();
+
                     if (_observer is not null)
                     {
                         await _observer.OnStateExited(_current, ct).ConfigureAwait(false);
@@ -286,6 +583,7 @@ public class AsyncStateMachine : AsyncState
                         next = await director.SelectNextAsync(ct).ConfigureAwait(false);
                         if (next.Equals(NodeId.Default))
                         {
+                            LastOutcome = OutcomeOf(_current);
                             return Result.Success;
                         }
                     }
@@ -302,11 +600,13 @@ public class AsyncStateMachine : AsyncState
                                 ).ConfigureAwait(false);
                             }
 
+                            LastOutcome = OutcomeOf(_current);
                             return Result.Failure;
                         }
 
                         if (edge.IsEmpty)
                         {
+                            LastOutcome = OutcomeOf(_current);
                             return Result.Success; // terminal
                         }
 
@@ -321,6 +621,7 @@ public class AsyncStateMachine : AsyncState
                     }
 
                     _current = next;
+                    _attempts = 0;
 
                     if (_observer is not null)
                     {
@@ -329,21 +630,69 @@ public class AsyncStateMachine : AsyncState
 
                     await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
 
-                    continue;
+                    return Result.InProgress;
                 }
                 case Result.StatusCode.Failure:
-                    return Result.Failure;
-                case Result.StatusCode.Continue:
+                {
+                    if (_retryPolicies is not null)
+                    {
+                        RetryPolicy retry = _retryPolicies[_current.Index];
+                        if (_attempts < retry.MaxAttempts)
+                        {
+                            TimeSpan delay = retry.DelayForAttempt(_attempts);
+                            if (delay > TimeSpan.Zero)
+                            {
+                                await Task.Delay(delay, ct).ConfigureAwait(false);
+                            }
+
+                            return Result.InProgress;
+                        }
+                    }
+
+                    _nodeEntered = false;
+                    logic.ExitAction?.Invoke();
+
+                    if (!Graph.TryGetTransition(_current, out Transition failEdge) ||
+                        !failEdge.HasFailureDestination)
+                    {
+                        LastOutcome = OutcomeOf(_current);
+                        return Result.Failure;
+                    }
+
+                    if (_observer is not null)
+                    {
+                        await _observer.OnStateFailed(_current, null, ct).ConfigureAwait(false);
+                    }
+
+                    NodeId handler = failEdge.FailureDestination;
+
+                    await TransitionTo(ExecutionStatus.Transitioning).ConfigureAwait(false);
+
+                    if (_observer is not null)
+                    {
+                        await _observer.OnTransition(_current, handler, ct).ConfigureAwait(false);
+                    }
+
+                    _current = handler;
+                    _attempts = 0;
+
+                    if (_observer is not null)
+                    {
+                        await _observer.OnStateEntered(_current, ct).ConfigureAwait(false);
+                    }
+
+                    await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
+
+                    return Result.InProgress;
+                }
+                case Result.StatusCode.InProgress:
                     throw new InvalidOperationException(
-                        $"Node '{_current}' returned Result.Continue, which is reserved for the " +
+                        $"Node '{_current}' returned Result.InProgress, which is reserved for the " +
                         "stepped-execution runtime. Node logic must return Success or Failure.");
                 default:
                     throw new InvalidOperationException("Unknown node result.");
             }
         }
-
-        ct.ThrowIfCancellationRequested();
-        return Result.Failure;
     }
 
     private async ValueTask LogReportCallback(string message, CancellationToken ct)

--- a/NxGraph/Fsm/Async/AsyncTimeoutState.cs
+++ b/NxGraph/Fsm/Async/AsyncTimeoutState.cs
@@ -15,6 +15,7 @@ public class AsyncTimeoutState : IAsyncLogic
     private readonly TimeSpan _timeout;
     private readonly TimeoutBehavior _behavior;
     private readonly Action<object?> _cachedCancelCallback = CancelCallback;
+    private readonly string _timeoutMessage;
 
     public AsyncTimeoutState(IAsyncLogic inner, TimeSpan timeout, TimeoutBehavior behavior = TimeoutBehavior.Fail)
     {
@@ -26,6 +27,7 @@ public class AsyncTimeoutState : IAsyncLogic
 
         _timeout = timeout;
         _behavior = behavior;
+        _timeoutMessage = $"Node timed out after {timeout}.";
     }
 
     public async ValueTask<Result> ExecuteAsync(CancellationToken ct = default)
@@ -58,10 +60,13 @@ public class AsyncTimeoutState : IAsyncLogic
             {
                 if (_behavior == TimeoutBehavior.Throw)
                 {
-                    throw new TimeoutException($"Node timed out after {_timeout}.");
+                    throw new TimeoutException(_timeoutMessage);
                 }
 
-                return Result.Failure;
+                // A timeout is an ordinary node failure: it participates in the unified
+                // fault model — per-node retry policies and failure edges — exactly like
+                // a node returning Failure itself.
+                return Result.Fail(_timeoutMessage);
             }
         }
         finally

--- a/NxGraph/Fsm/RetryPolicy.cs
+++ b/NxGraph/Fsm/RetryPolicy.cs
@@ -1,0 +1,77 @@
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// How the delay between retry attempts grows.
+/// </summary>
+public enum BackoffKind : byte
+{
+    /// <summary>Every retry waits the same base delay.</summary>
+    Fixed = 0,
+
+    /// <summary>Retry N waits N × base delay.</summary>
+    Linear = 1,
+
+    /// <summary>Retry N waits 2^(N-1) × base delay.</summary>
+    Exponential = 2,
+}
+
+/// <summary>
+/// Per-node retry policy: when the node's logic returns <c>Failure</c>, the machine
+/// re-runs it in place until it succeeds or <see cref="MaxAttempts"/> executions have
+/// been consumed, then falls through to the normal failure handling (failure edge or
+/// terminal failure). Attempt counters live in the executing state machine, not the graph.
+/// <para>
+/// Backoff delays are honored by the async runtime only. The synchronous runtime is
+/// frame-stepped (one node per <c>Execute()</c> call) and must never block, so it retries
+/// on the next tick regardless of the configured backoff.
+/// </para>
+/// </summary>
+public readonly struct RetryPolicy
+{
+    public RetryPolicy(byte maxAttempts, TimeSpan backoff = default, BackoffKind backoffKind = BackoffKind.Fixed)
+    {
+        if (maxAttempts == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxAttempts),
+                "MaxAttempts must be at least 1 (use RetryPolicy.None for no retries).");
+        }
+
+        if (backoff < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(backoff), "Backoff cannot be negative.");
+        }
+
+        MaxAttempts = maxAttempts;
+        Backoff = backoff;
+        BackoffKind = backoffKind;
+    }
+
+    /// <summary>Total executions allowed for the node, including the first one. 0 = no policy.</summary>
+    public byte MaxAttempts { get; }
+
+    /// <summary>Base delay between attempts; <see cref="TimeSpan.Zero"/> retries immediately.</summary>
+    public TimeSpan Backoff { get; }
+
+    public BackoffKind BackoffKind { get; }
+
+    /// <summary>No retry policy — a failing node fails on its first attempt.</summary>
+    public static readonly RetryPolicy None = default;
+
+    /// <summary>
+    /// The delay to wait before the next attempt, given how many attempts have already failed.
+    /// </summary>
+    public TimeSpan DelayForAttempt(int failedAttempts)
+    {
+        if (Backoff <= TimeSpan.Zero || failedAttempts <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        return BackoffKind switch
+        {
+            BackoffKind.Linear => Backoff * failedAttempts,
+            BackoffKind.Exponential => Backoff * (1L << Math.Min(failedAttempts - 1, 30)),
+            _ => Backoff,
+        };
+    }
+}

--- a/NxGraph/Fsm/State.cs
+++ b/NxGraph/Fsm/State.cs
@@ -31,6 +31,18 @@ public abstract class State : ILogic, ILogReporter
     private bool _hasEntered;
 
     /// <summary>
+    /// Lifecycle position for same-assembly runtimes: whether <see cref="OnEnter"/> has run
+    /// for the current pass. <see cref="StateMachine.Resume"/> sets this so a restored
+    /// mid-run machine skips <see cref="OnEnter"/> (which would restart the run) on its
+    /// next <see cref="Execute"/> call.
+    /// </summary>
+    private protected bool HasEntered
+    {
+        get => _hasEntered;
+        set => _hasEntered = value;
+    }
+
+    /// <summary>
     /// Executes the state lifecycle: OnEnter once on first call, OnRun every call,
     /// OnExit once when a terminal result (non-Continue) is returned or an exception is thrown.
     /// </summary>

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -11,7 +11,28 @@ namespace NxGraph.Fsm;
 public class StateMachine<TAgent>(Graph graph, IStateMachineObserver? observer = null)
     : StateMachine(graph, observer), IAgentSettable<TAgent>
 {
-    public void SetAgent(TAgent agent) => Graph.SetAgent(agent);
+    private TAgent? _agent;
+    private bool _hasAgent;
+
+    /// <summary>
+    /// Binds the agent (typed context) to this machine. It is applied to the graph's nodes
+    /// immediately and re-applied at the start of every run, so several machines can share
+    /// one <see cref="Graph"/> with distinct contexts as long as their runs do not interleave.
+    /// </summary>
+    public void SetAgent(TAgent agent)
+    {
+        _agent = agent;
+        _hasAgent = true;
+        Graph.SetAgent(agent);
+    }
+
+    private protected override void ApplyExecutionContext()
+    {
+        if (_hasAgent)
+        {
+            Graph.SetAgent(_agent!);
+        }
+    }
 }
 
 /// <summary>
@@ -41,9 +62,11 @@ public class StateMachine<TAgent>(Graph graph, IStateMachineObserver? observer =
 /// must have its <see cref="INode.Logic"/> populated (i.e. implement <see cref="ILogic"/>).
 /// </para>
 /// </summary>
-public class StateMachine : State
+public class StateMachine : State, ISubGraphProvider
 {
     public readonly Graph Graph;
+
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Graph];
     private readonly IStateMachineObserver? _observer;
 
     private ExecutionStatus _status = ExecutionStatus.Created;
@@ -60,6 +83,24 @@ public class StateMachine : State
     // skips OnEnter entirely and never observes _executeGate.
     private bool _reentranceGuard;
     private readonly Action<string> _cachedLogReportCallback;
+    private readonly State?[] _logReportStates; // indexed by NodeId.Index, resolved once at construction
+    private readonly RetryPolicy[]? _retryPolicies; // graph-owned; null when no node declares one
+    private int _attempts; // executions of the current node in this run
+    private bool _nodeEntered; // the current node's EnterAction has fired for this visit
+    private readonly int[]? _outcomeCodes; // graph-owned; null when no node declares one
+
+    /// <summary>
+    /// The outcome code of the node the last run terminated at (default 0).
+    /// Reset when a new run starts.
+    /// </summary>
+    public int LastOutcome { get; private set; }
+
+    /// <summary>
+    /// The display name registered for <see cref="LastOutcome"/>, or <c>null</c>.
+    /// Resolved lazily — never on the run loop.
+    /// </summary>
+    public string? LastOutcomeName =>
+        Graph.OutcomeNames is { } names && names.TryGetValue(LastOutcome, out string? name) ? name : null;
 
     /// <summary>Public execution status.</summary>
     public ExecutionStatus Status
@@ -75,6 +116,33 @@ public class StateMachine : State
         _initial = graph.StartNode.Id;
         _current = _initial;
         _cachedLogReportCallback = LogReportCallback;
+        _logReportStates = BuildLogReportTable(graph);
+        _retryPolicies = graph.RetryPolicies;
+        _outcomeCodes = graph.OutcomeCodes;
+    }
+
+    private int OutcomeOf(NodeId id) => _outcomeCodes is null ? 0 : _outcomeCodes[id.Index];
+
+    /// <summary>
+    /// Hook for derived machines to (re)apply per-machine execution context (e.g. the typed
+    /// agent) to the graph's nodes. Runs under the execute gate, right before Starting.
+    /// </summary>
+    private protected virtual void ApplyExecutionContext()
+    {
+    }
+
+    private static State?[] BuildLogReportTable(Graph graph)
+    {
+        State?[] table = new State?[graph.NodeCount];
+        for (int i = 0; i < table.Length; i++)
+        {
+            if (graph.TryGetNodeByIndex(i, out INode? node) && node is LogicNode logicNode)
+            {
+                table[i] = logicNode.Logic as State;
+            }
+        }
+
+        return table;
     }
 
     /// <summary>
@@ -122,14 +190,84 @@ public class StateMachine : State
 
         TransitionTo(ExecutionStatus.Resetting);
         _current = _initial;
+        _attempts = 0;
+        _nodeEntered = false;
         TransitionTo(ExecutionStatus.Ready);
         return Result.Success;
+    }
+
+    /// <summary>
+    /// Captures the machine's runtime position into a serializable snapshot. The sync runtime
+    /// is frame-stepped, so any point between <see cref="State.Execute"/> calls is a legal
+    /// step boundary — including the middle of a run (the machine stays Running between ticks).
+    /// Only calling from <i>inside</i> node logic is rejected.
+    /// </summary>
+    public StateMachineSnapshot Suspend()
+    {
+        if (_reentranceGuard)
+        {
+            throw new InvalidOperationException(
+                "Cannot suspend from inside node logic. Suspend between Execute() calls.");
+        }
+
+        ExecutionStatus status = _status;
+        if (status is ExecutionStatus.Starting or ExecutionStatus.Transitioning or ExecutionStatus.Resetting)
+        {
+            throw new InvalidOperationException($"Cannot suspend in transient status '{status}'.");
+        }
+
+        return new StateMachineSnapshot(_current.Index, status, _attempts, _nodeEntered,
+            MidRun: _executeGate, LastOutcome);
+    }
+
+    /// <summary>
+    /// Restores a snapshot produced by <see cref="Suspend"/> onto this machine. The graph must
+    /// be structurally equivalent to the one the snapshot was taken from (same node indices).
+    /// A mid-run snapshot is continued by calling <see cref="State.Execute"/> until it returns
+    /// a terminal result; re-attach the user context via <c>SetAgent</c> before resuming if
+    /// the graph uses one. No observer events are replayed by the restore itself.
+    /// </summary>
+    public void Resume(StateMachineSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        if (_reentranceGuard)
+        {
+            throw new InvalidOperationException("Cannot resume from inside node logic.");
+        }
+
+        if (snapshot.Status is ExecutionStatus.Starting or ExecutionStatus.Transitioning
+            or ExecutionStatus.Resetting)
+        {
+            throw new InvalidOperationException(
+                $"Snapshot captured in transient status '{snapshot.Status}' cannot be resumed.");
+        }
+
+        if ((uint)snapshot.CurrentNodeIndex >= (uint)Graph.NodeCount)
+        {
+            throw new InvalidOperationException(
+                $"Snapshot node index {snapshot.CurrentNodeIndex} is out of range for this graph " +
+                $"(0..{Graph.NodeCount - 1}).");
+        }
+
+        _current = Graph.GetNodeByIndex(snapshot.CurrentNodeIndex).Id;
+        _attempts = snapshot.Attempts;
+        _nodeEntered = snapshot.NodeEntered;
+        LastOutcome = snapshot.LastOutcome;
+        // Mid-run: the gate stays held between ticks and the State lifecycle must skip
+        // OnEnter (which would restart the run from the initial node) on the next Execute().
+        _executeGate = snapshot.MidRun;
+        HasEntered = snapshot.MidRun;
+        _status = snapshot.Status;
     }
 
     // ── State overrides — Execute() is the stepped entry point ────────────
     // Call Execute() once per frame from Unity's Update().
     // It initialises on the first call, advances one node, and returns:
-    //   Result.Continue  — more nodes remain; call again next frame.
+    //   Result.InProgress  — more nodes remain; call again next frame.
     //   Result.Success / Result.Failure — machine has finished.
 
     protected override void OnEnter()
@@ -152,8 +290,14 @@ public class StateMachine : State
 
         _executeGate = true;
 
+        // Re-stamp this machine's context onto the (potentially shared) graph before running.
+        ApplyExecutionContext();
+
         TransitionTo(ExecutionStatus.Starting);
         _current = _initial;
+        _attempts = 0;
+        _nodeEntered = false;
+        LastOutcome = 0;
         _observer?.OnStateEntered(_current);
         TransitionTo(ExecutionStatus.Running);
     }
@@ -175,8 +319,8 @@ public class StateMachine : State
         try
         {
             Result result = TickInternal();
-            if (result == Result.Continue)
-                return Result.Continue; // not finished; caller will Execute() again next frame
+            if (result == Result.InProgress)
+                return Result.InProgress; // not finished; caller will Execute() again next frame
 
             Finalise(result);
             return result;
@@ -235,7 +379,7 @@ public class StateMachine : State
     }
 
     /// <summary>
-    /// Executes the current node. Returns <see cref="Result.Continue"/> when the machine
+    /// Executes the current node. Returns <see cref="Result.InProgress"/> when the machine
     /// transitions to a next node, or a terminal result (<see cref="Result.Success"/> /
     /// <see cref="Result.Failure"/>) when the run is finished.
     /// </summary>
@@ -249,8 +393,10 @@ public class StateMachine : State
 
         LogicNode logicNode = (LogicNode)node;
 
-        // Wire log-report callback for nodes that support it.
-        if (logicNode.Logic is State stateForLog)
+        // Wire log-report callback for nodes that support it. Reassigned on every visit so
+        // interleaved machines sharing a graph each attribute reports to their own observer.
+        State? stateForLog = _logReportStates[_current.Index];
+        if (stateForLog is not null)
         {
             stateForLog.SyncLogReport = _cachedLogReportCallback;
         }
@@ -261,12 +407,25 @@ public class StateMachine : State
                 $"Node '{_current}' logic ({logicNode.AsyncLogic.GetType().Name}) does not implement ILogic. " +
                 "All nodes in a StateMachine must implement ILogic.");
 
+        if (!_nodeEntered)
+        {
+            _nodeEntered = true;
+            logicNode.EnterAction?.Invoke();
+        }
+
         Result result = syncLogic.Execute();
+        if (result.Code != Result.StatusCode.InProgress)
+        {
+            _attempts++;
+        }
 
         switch (result.Code)
         {
             case Result.StatusCode.Success:
             {
+                _nodeEntered = false;
+                logicNode.ExitAction?.Invoke();
+
                 _observer?.OnStateExited(_current);
 
                 NodeId next;
@@ -276,6 +435,7 @@ public class StateMachine : State
                     next = director.SelectNext();
                     if (next.Equals(NodeId.Default))
                     {
+                        LastOutcome = OutcomeOf(_current);
                         return Result.Success;
                     }
                 }
@@ -287,11 +447,13 @@ public class StateMachine : State
                             _current,
                             new InvalidOperationException($"No transition found for state '{_current}'."));
 
+                        LastOutcome = OutcomeOf(_current);
                         return Result.Failure;
                     }
 
                     if (edge.IsEmpty)
                     {
+                        LastOutcome = OutcomeOf(_current);
                         return Result.Success; // terminal
                     }
 
@@ -303,19 +465,58 @@ public class StateMachine : State
                 _observer?.OnTransition(_current, next);
 
                 _current = next;
+                _attempts = 0;
 
                 _observer?.OnStateEntered(_current);
 
                 TransitionTo(ExecutionStatus.Running);
 
-                return Result.Continue;
+                return Result.InProgress;
             }
             case Result.StatusCode.Failure:
-                return Result.Failure;
-            case Result.StatusCode.Continue:
+            {
+                if (_retryPolicies is not null)
+                {
+                    RetryPolicy retry = _retryPolicies[_current.Index];
+                    if (_attempts < retry.MaxAttempts)
+                    {
+                        // Frame-stepped runtime: the retry happens on the next tick and the
+                        // configured backoff is intentionally not honored (never block a frame).
+                        return Result.InProgress;
+                    }
+                }
+
+                _nodeEntered = false;
+                logicNode.ExitAction?.Invoke();
+
+                if (!Graph.TryGetTransition(_current, out Transition failEdge) ||
+                    !failEdge.HasFailureDestination)
+                {
+                    LastOutcome = OutcomeOf(_current);
+                    return Result.Failure;
+                }
+
+                _observer?.OnStateFailed(_current, null);
+
+                NodeId handler = failEdge.FailureDestination;
+
+                TransitionTo(ExecutionStatus.Transitioning);
+
+                _observer?.OnTransition(_current, handler);
+
+                _current = handler;
+                _attempts = 0;
+
+                _observer?.OnStateEntered(_current);
+
+                TransitionTo(ExecutionStatus.Running);
+
+                return Result.InProgress;
+            }
+            case Result.StatusCode.InProgress:
                 // Node is still in progress (e.g. a multi-frame Unity state).
                 // Tick() will call it again next frame; Execute()'s while-loop will spin.
-                return Result.Continue;
+                return Result.InProgress;
             default:
                 throw new InvalidOperationException("Unknown node result.");
         }

--- a/NxGraph/Fsm/StateMachineSnapshot.cs
+++ b/NxGraph/Fsm/StateMachineSnapshot.cs
@@ -1,0 +1,22 @@
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// A serialization-friendly capture of a state machine's runtime position — current node,
+/// status, retry progress, and terminal outcome. Produced by <c>Suspend()</c> and consumed
+/// by <c>Resume(...)</c> on <see cref="Async.AsyncStateMachine"/> or <see cref="StateMachine"/>
+/// built over an equivalent graph (same node indices — e.g. one round-tripped through
+/// NxGraph.Serialization). Snapshots are interchangeable between the two runtimes as long as
+/// the graph's nodes are executable by the target runtime.
+/// <para>
+/// The snapshot deliberately contains only primitives, so it serializes cleanly with any
+/// serializer. The user context (agent/blackboard) is owned by the caller and must be
+/// re-attached via <c>SetAgent</c> after resuming.
+/// </para>
+/// </summary>
+public sealed record StateMachineSnapshot(
+    int CurrentNodeIndex,
+    ExecutionStatus Status,
+    int Attempts,
+    bool NodeEntered,
+    bool MidRun,
+    int LastOutcome);

--- a/NxGraph/Graphs/Graph.cs
+++ b/NxGraph/Graphs/Graph.cs
@@ -12,6 +12,8 @@ public sealed class Graph : INode, IGraph
 {
     private readonly INode[] _nodes; // index = NodeId.Index
     private readonly Transition[] _edges; // index = from.Index
+    private readonly RetryPolicy[]? _retryPolicies; // index = NodeId.Index; null when no node has a policy
+    private readonly int[]? _outcomeCodes; // index = NodeId.Index; null when no node declares an outcome
 
     /// <summary>
     /// The unique identifier for this graph. 
@@ -52,7 +54,9 @@ public sealed class Graph : INode, IGraph
     /// <param name="edges">The array of transitions (edges) in the graph. Must be non-empty and have the same length as the nodes array.</param>
     /// <param name="logic">The logic associated with the graph. If null, an empty logic is used.</param>
     /// <exception cref="ArgumentException">Thrown when the nodes or edges arrays are empty, have unequal lengths, or the first node is not the start node.</exception>
-    public Graph(NodeId id, INode[] nodes, Transition[] edges, IAsyncLogic? logic = null)
+    public Graph(NodeId id, INode[] nodes, Transition[] edges, IAsyncLogic? logic = null,
+        RetryPolicy[]? retryPolicies = null, int[]? outcomeCodes = null,
+        IReadOnlyDictionary<int, string>? outcomeNames = null)
     {
         Guard.NotNull(nodes, nameof(nodes));
         Guard.NotNull(edges, nameof(edges));
@@ -67,12 +71,46 @@ public sealed class Graph : INode, IGraph
             throw new ArgumentException("Nodes/edges arrays must be non-empty and have equal length.");
         }
 
+        if (retryPolicies is not null && retryPolicies.Length != nodes.Length)
+        {
+            throw new ArgumentException("Retry policy array must match the nodes array length.",
+                nameof(retryPolicies));
+        }
+
+        if (outcomeCodes is not null && outcomeCodes.Length != nodes.Length)
+        {
+            throw new ArgumentException("Outcome code array must match the nodes array length.",
+                nameof(outcomeCodes));
+        }
+
         Id = id;
         StartNode = nodes[0];
         _nodes = nodes;
         _edges = edges;
+        _retryPolicies = retryPolicies;
+        _outcomeCodes = outcomeCodes;
+        OutcomeNames = outcomeNames;
         AsyncLogic = logic ?? new EmptyAsyncLogic();
     }
+
+    /// <summary>
+    /// The per-node retry policies indexed by <see cref="NodeId.Index"/>, or <c>null</c>
+    /// when no node declares one. Exposed for the runtimes and serializers.
+    /// </summary>
+    public RetryPolicy[]? RetryPolicies => _retryPolicies;
+
+    /// <summary>
+    /// Per-node terminal outcome codes indexed by <see cref="NodeId.Index"/>, or <c>null</c>
+    /// when no node declares one. When a run terminates at a node, the machine reports the
+    /// node's code (default 0) as <c>LastOutcome</c>.
+    /// </summary>
+    public int[]? OutcomeCodes => _outcomeCodes;
+
+    /// <summary>
+    /// Optional display names for outcome codes, resolved lazily for reporting —
+    /// never on the run loop.
+    /// </summary>
+    public IReadOnlyDictionary<int, string>? OutcomeNames { get; }
 
     /// <summary>
     /// Attempts to retrieve the transition from a given node.
@@ -170,14 +208,20 @@ public sealed class Graph : INode, IGraph
                 continue;
             }
 
-            // Non-generic nested state machines do not implement IAgentSettable<TAgent>, so
-            // the direct match misses them. Walk their inner graph explicitly so
-            // IAgentSettable<TAgent> nodes deeper in the tree still receive the agent.
-            Graph? nested = (logicNode.AsyncLogic as AsyncStateMachine)?.Graph
-                         ?? (logicNode.Logic as StateMachine)?.Graph;
-            if (nested is not null && !ReferenceEquals(nested, this))
+            // Composite logic (nested machines, history/parallel composites, user-defined
+            // containers) surfaces its children via ISubGraphProvider — walk them without
+            // knowing the concrete types, so new composites need no changes here.
+            ISubGraphProvider? provider =
+                logicNode.AsyncLogic as ISubGraphProvider
+                ?? logicNode.Logic as ISubGraphProvider;
+            if (provider is null)
             {
-                if (nested.SetAgentRecursive(agent))
+                continue;
+            }
+
+            foreach (Graph nested in provider.SubGraphs)
+            {
+                if (!ReferenceEquals(nested, this) && nested.SetAgentRecursive(agent))
                 {
                     found = true;
                 }

--- a/NxGraph/Graphs/ISubGraphProvider.cs
+++ b/NxGraph/Graphs/ISubGraphProvider.cs
@@ -1,0 +1,16 @@
+namespace NxGraph.Graphs;
+
+/// <summary>
+/// Implemented by node logic that embeds child graphs (nested state machines, history and
+/// parallel composites, user-defined containers). Graph-wide operations that must reach
+/// every node — agent injection today, tooling walks tomorrow — discover nested graphs
+/// through this interface instead of hard-coding each composite type.
+/// </summary>
+public interface ISubGraphProvider
+{
+    /// <summary>
+    /// The directly-embedded child graphs (one level deep — nested providers inside a
+    /// child graph are discovered recursively by the caller).
+    /// </summary>
+    IEnumerable<Graph> SubGraphs { get; }
+}

--- a/NxGraph/Graphs/LogicNode.cs
+++ b/NxGraph/Graphs/LogicNode.cs
@@ -15,11 +15,13 @@ public interface INode
 
 public class LogicNode : INode
 {
-    public LogicNode(NodeId id, IAsyncLogic asyncLogic)
+    public LogicNode(NodeId id, IAsyncLogic asyncLogic, Action? enterAction = null, Action? exitAction = null)
     {
         Id = id;
         AsyncLogic = asyncLogic;
         Logic = asyncLogic is SyncLogicAdapter sla ? sla.Logic : asyncLogic as ILogic;
+        EnterAction = enterAction;
+        ExitAction = exitAction;
     }
 
     public NodeId Id { get; }
@@ -30,6 +32,19 @@ public class LogicNode : INode
     /// unwraps <see cref="SyncLogicAdapter"/>, or detects direct <see cref="ILogic"/> implementations.
     /// </summary>
     public ILogic? Logic { get; }
+
+    /// <summary>
+    /// Optional action invoked by the run loops when the machine enters this node —
+    /// once per visit, before the node's first execution (retries do not re-fire it).
+    /// Cached at build time; a null check plus a cached-delegate invoke costs nothing.
+    /// </summary>
+    public Action? EnterAction { get; }
+
+    /// <summary>
+    /// Optional action invoked by the run loops when the machine leaves this node —
+    /// once per visit, after its final execution, regardless of outcome.
+    /// </summary>
+    public Action? ExitAction { get; }
 
     public static readonly LogicNode Empty = new(NodeId.Default, new EmptyAsyncLogic());
     public static readonly LogicNode StateMachineMarker = new(NodeId.Default, new EmptyAsyncLogic());

--- a/NxGraph/Graphs/Transition.cs
+++ b/NxGraph/Graphs/Transition.cs
@@ -1,13 +1,38 @@
-﻿namespace NxGraph.Graphs;
+namespace NxGraph.Graphs;
 
 /// <summary>
-/// Represents a transition in a finite state machine (FSM) graph.
+/// Represents the outgoing edges of a node in a finite state machine (FSM) graph:
+/// one success destination and an optional failure destination. Either side may be
+/// <see cref="NodeId.Default"/>, meaning the machine terminates on that outcome.
 /// </summary>
-/// <param name="Destination">The destination node ID for the transition.</param>
-public readonly struct Transition(NodeId destination)
+public readonly struct Transition
 {
-    public NodeId Destination { get; } = destination;
+    public Transition(NodeId destination)
+        : this(destination, NodeId.Default)
+    {
+    }
+
+    public Transition(NodeId destination, NodeId failureDestination)
+    {
+        Destination = destination;
+        FailureDestination = failureDestination;
+    }
+
+    /// <summary>Where the machine goes when the node returns Success.</summary>
+    public NodeId Destination { get; }
+
+    /// <summary>
+    /// Where the machine goes when the node returns Failure.
+    /// <see cref="NodeId.Default"/> (the default) preserves the classic behaviour:
+    /// a failing node terminates the machine with <c>Result.Failure</c>.
+    /// </summary>
+    public NodeId FailureDestination { get; }
 
     public static readonly Transition Empty = new(NodeId.Default);
+
+    /// <summary>True when the success edge is unset (the node is terminal on success).</summary>
     public bool IsEmpty => Destination == NodeId.Default;
+
+    /// <summary>True when a failure edge is present.</summary>
+    public bool HasFailureDestination => FailureDestination != NodeId.Default;
 }

--- a/NxGraph/Result.cs
+++ b/NxGraph/Result.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 namespace NxGraph;
 
@@ -6,7 +6,7 @@ namespace NxGraph;
 /// Represents the outcome of a state-machine operation.
 /// <para>
 /// Use the static fields <see cref="Success"/>, <see cref="Failure"/>, and
-/// <see cref="Continue"/> for standard results, or the factory methods
+/// <see cref="InProgress"/> for standard results, or the factory methods
 /// <see cref="Ok"/> / <see cref="Fail"/> to attach a diagnostic message.
 /// </para>
 /// <para>
@@ -29,19 +29,19 @@ public readonly struct Result : IEquatable<Result>
         Failure = 1,
 
         /// <summary>
-        /// The operation is still in progress.
+        /// The operation has not finished yet — it is a status report, not a command.
         /// <para>
-        /// Returned by <see cref="Fsm.StateMachine.Tick"/> while more nodes remain, and by
-        /// node logic to indicate the current node needs another tick (e.g. a multi-frame
+        /// Returned by the stepped runtimes (<see cref="Fsm.StateMachine.Execute"/>,
+        /// <c>AsyncStateMachine.StepAsync</c>) while more nodes remain, and by sync node
+        /// logic to indicate the current node needs another tick (e.g. a multi-frame
         /// Unity state such as a timer or animation wait).
         /// </para>
-        /// <para>
-        /// In the blocking full-run path (<see cref="State.Execute"/>), a node returning
-        /// this value causes the machine to spin on that node until it returns
-        /// <see cref="Success"/> or <see cref="Failure"/>.
-        /// </para>
         /// </summary>
-        Continue = 2
+        InProgress = 2,
+
+        /// <inheritdoc cref="InProgress"/>
+        [Obsolete("Renamed to StatusCode.InProgress — 'Continue' read like a command rather than a status.")]
+        Continue = 2,
     }
 
     // ── Static singletons ───────────────────────────────────────────────
@@ -54,10 +54,14 @@ public readonly struct Result : IEquatable<Result>
 
     /// <summary>
     /// Indicates the state machine has more work to do.
-    /// Returned by <see cref="Fsm.StateMachine.Execute"/> during frame-stepped execution;
-    /// node logic must <b>never</b> return this value.
+    /// Returned by the stepped runtimes during frame-stepped execution; async node logic
+    /// must <b>never</b> return this value (sync multi-frame states may).
     /// </summary>
-    public static readonly Result Continue = new(StatusCode.Continue);
+    public static readonly Result InProgress = new(StatusCode.InProgress);
+
+    /// <inheritdoc cref="InProgress"/>
+    [Obsolete("Renamed to Result.InProgress — 'Continue' read like a command rather than a status.")]
+    public static readonly Result Continue = new(StatusCode.InProgress);
 
     // ── Factory methods ─────────────────────────────────────────────────
 
@@ -93,15 +97,22 @@ public readonly struct Result : IEquatable<Result>
         get => Code == StatusCode.Failure;
     }
 
+    /// <summary><see langword="true"/> when <see cref="Code"/> is <see cref="StatusCode.InProgress"/>.</summary>
+    public bool IsInProgress
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Code == StatusCode.InProgress;
+    }
+
     /// <summary>
     /// <see langword="true"/> when the state machine has finished
     /// (<see cref="StatusCode.Success"/> or <see cref="StatusCode.Failure"/>).
-    /// Equivalent to <c>Code != StatusCode.Continue</c>.
+    /// Equivalent to <c>Code != StatusCode.InProgress</c>.
     /// </summary>
     public bool IsCompleted
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Code != StatusCode.Continue;
+        get => Code != StatusCode.InProgress;
     }
 
     // ── Constructor ─────────────────────────────────────────────────────

--- a/NxGraph/ResultHelpers.cs
+++ b/NxGraph/ResultHelpers.cs
@@ -19,5 +19,12 @@ public static class ResultHelpers
     /// </summary>
     public static readonly ValueTask CompletedTask = default;
 
-    public static readonly ValueTask<Result> Continue = new(Result.Continue);
+    /// <summary>
+    /// Represents an in-progress (not yet finished) result.
+    /// </summary>
+    public static readonly ValueTask<Result> InProgress = new(Result.InProgress);
+
+    /// <inheritdoc cref="InProgress"/>
+    [Obsolete("Renamed to ResultHelpers.InProgress — 'Continue' read like a command rather than a status.")]
+    public static readonly ValueTask<Result> Continue = new(Result.InProgress);
 }

--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ StateMachine fsm = GraphBuilder
     .ToStateMachine();
 
 // Execute() advances one node per call; loop to run to completion:
-Result result = Result.Continue;
-while (result == Result.Continue)
+Result result = Result.InProgress;
+while (result == Result.InProgress)
     result = fsm.Execute();
 ```
 
-For a single-node graph `Execute()` returns `Result.Success` (or `Result.Failure`) immediately. For multi-node graphs it returns `Result.Continue` after each intermediate node, signalling that more nodes remain. See [Sync execution, stepped model](#sync-execution--stepped-model) for the Unity pattern.
+For a single-node graph `Execute()` returns `Result.Success` (or `Result.Failure`) immediately. For multi-node graphs it returns `Result.InProgress` after each intermediate node, signalling that more nodes remain. See [Sync execution, stepped model](#sync-execution--stepped-model) for the Unity pattern.
 
 ---
 
@@ -282,7 +282,7 @@ Result result = await sm.ExecuteAsync();
 
 | Return value | Meaning |
 |---|---|
-| `Result.Continue` | Node completed; there are more nodes to run. Call `Execute()` again. |
+| `Result.InProgress` | Node completed; there are more nodes to run. Call `Execute()` again. |
 | `Result.Success` | Machine finished successfully, no more nodes. |
 | `Result.Failure` | A node failed or threw. Machine is now in `Failed` status. |
 
@@ -290,12 +290,12 @@ Result result = await sm.ExecuteAsync();
 
 ```csharp
 StateMachine sm = graph.ToStateMachine();
-Result result = Result.Continue;
-while (result == Result.Continue)
+Result result = Result.InProgress;
+while (result == Result.InProgress)
     result = sm.Execute();
 ```
 
-**Multi-frame nodes:** A node can return `Result.Continue` from its own `OnRun()` to signal it needs another frame (e.g. a countdown timer or a wait-for-input node). The machine stays on that node and invokes it again on the next `Execute()` call.
+**Multi-frame nodes:** A node can return `Result.InProgress` from its own `OnRun()` to signal it needs another frame (e.g. a countdown timer or a wait-for-input node). The machine stays on that node and invokes it again on the next `Execute()` call.
 
 ### Unity integration
 
@@ -347,8 +347,8 @@ StateMachine parentFsm = GraphBuilder
 
 // Each Execute() advances exactly one node — even one inside the child.
 // 3 ticks: child node 1 → child node 2 (child done) → parent Cleanup
-Result r = Result.Continue;
-while (r == Result.Continue)
+Result r = Result.InProgress;
+while (r == Result.InProgress)
     r = parentFsm.Execute();
 ```
 
@@ -370,7 +370,7 @@ AsyncStateMachine parentFsm = GraphBuilder
 Result result = await parentFsm.ExecuteAsync();
 ```
 
-Nesting can be arbitrarily deep. Each level is stepped independently; the parent treats a running child as `Result.Continue` and a completed child as `Result.Success`.
+Nesting can be arbitrarily deep. Each level is stepped independently; the parent treats a running child as `Result.InProgress` and a completed child as `Result.Success`.
 
 ### Restart policy
 
@@ -746,8 +746,8 @@ Yes. Those features are part of `NxGraph` itself; graph serialization is the opt
 **Can I use NxGraph in Unity?**  
 Yes. Use `StateMachine` (the sync runtime) and call `Execute()` from `MonoBehaviour.Update()`. `Execute()` advances exactly one node per call so the main thread is never blocked. Set `RestartPolicy.Auto` for automatic reset between runs, or `RestartPolicy.Ignore` to freeze the machine in its terminal state until you explicitly call `Reset()`. See [Unity integration](#unity-integration) for a full example.
 
-**What does `Result.Continue` mean?**  
-The machine has more nodes to process but is returning control to the caller (e.g. to avoid blocking a frame in Unity). Call `Execute()` again on the next frame. A node can also return `Result.Continue` from its own `OnRun()` to signal it needs multiple frames (e.g. a frame-based timer).
+**What does `Result.InProgress` mean?**  
+The machine has more nodes to process but is returning control to the caller (e.g. to avoid blocking a frame in Unity). Call `Execute()` again on the next frame. A node can also return `Result.InProgress` from its own `OnRun()` to signal it needs multiple frames (e.g. a frame-based timer).
 
 ---
 


### PR DESCRIPTION
## Summary

This branch lands two arcs of work on top of `main`:

**Correctness fixes** (first 13 commits): closes Reset/cancellation/CAS races in `AsyncStateMachine`, repairs the `AsyncTimeoutState` fallback callback and `CtsPool` rent polarity, releases the sync execute gate on observer failure, aligns sync/async `SwitchState` default routing on `NodeId.Default`, propagates `SetAgent` into nested non-generic machines, and hardens serialization/replay (JSON payload versioning, correct MessagePack array headers, `NodeId` rebuild with duplicate/gap checks, bounded subgraph recursion, versioned replay payloads). Director branches (`ChoiceState`/`SwitchState` and custom `IDirector`s via `EnumerateStaticTargets()`) are now visible to the validator and Mermaid exporter.

**Feature work** (final commit):

- **Unified fault model** — `Transition` now carries an optional `FailureDestination` alongside the success edge; `.OnError(...)` routes a failing node instead of terminating the machine. Per-node retry via `.Retry(maxAttempts, backoff, kind)` with the attempt counter on the machine (the sync runtime never blocks; it retries next tick). Timeouts under `TimeoutBehavior.Fail` flow through the same failure path. Named terminal outcomes via `.WithOutcome(code, name)` / `LastOutcome`, with no strings on the run loop.
- **Execution** — agent/context binding moved to the machine and re-stamped at run start, so multiple machines can share one immutable `Graph` with distinct contexts (non-overlapping runs); `ISubGraphProvider` lets the agent reach composite children generically. Async single-step execution via `StepAsync`; stepped runs report `Result.InProgress` (`Result.Continue` kept as an obsolete alias). `Suspend()`/`Resume(snapshot)` on both runtimes via a primitives-only `StateMachineSnapshot` taken at step boundaries — snapshots are interchangeable between sync and async machines, and the full durable loop (serialize graph + snapshot, resume on a fresh machine) is tested.
- **Composites** — `.SubGraph(child, history:)` nests a child graph as one node, with history re-entering a failed child at its last-active node. `.Parallel(regions...)` provides cooperative interleaved AND-states (one node per region per round); true thread-concurrency is deliberately excluded to preserve the 0 B hot-path guarantee.
- **Authoring** — `.Goto("name")` back-edges resolved at `Build()`; `SetName` is now O(1); per-state `.OnEnter`/`.OnExit` actions via build-time cached delegates; the validator warns on custom directors exposing no static targets.
- **Guardrails** — public API surface baseline test (fails `ci` on unapproved changes; regenerate with `NXGRAPH_UPDATE_PUBLIC_API=1`), line coverage enforced in `ci` (`COVERAGE_THRESHOLD` default 70), and an allocation regression gate asserting 0 B/step across hot-path scenarios in Release.

Serialization payload version is bumped to 2 (retry policies, failure edges, outcome codes); version-1 payloads still load.

## Test plan

- 270 core + 20 serialization NUnit tests green
- Full `dotnet run --project NxGraph.Build -- ci` gate passes (restore, build, tests, coverage >= 70)
- Allocation gate asserts 0 B/step on the hot path in Release
- Back-compat verified: version-1 serialization payloads load; obsolete aliases (`Result.Continue`, `Graph.SetAgent`) keep existing code compiling