### PR TITLE
Scoped blackboards, parallel-composite parity, and 2026-07 review fixes

### DIFF
--- a/.github/workflows/upm-release.yml
+++ b/.github/workflows/upm-release.yml
@@ -78,6 +78,11 @@ jobs:
           set -euo pipefail
           VER="${{ steps.meta.outputs.version }}"
 
+          # Park the tarball outside the worktree: `git clean -fdx` below would delete it
+          # (it is untracked and not covered by the package-dir exclusion), and the release
+          # step needs it as an asset.
+          mv "com.enzx.nxgraph-${VER}.tgz" /tmp/
+
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -90,10 +95,16 @@ jobs:
           cp -r ${UPM_PACKAGE_DIR}/* .
           cp -r ${UPM_PACKAGE_DIR}/.* . 2>/dev/null || true
 
+          # Drop the nested copy so the published branch is only the package layout.
+          rm -rf upm
+
           git add -A
           git commit -m "Release UPM v${VER}"
 
           git push origin upm-staging:upm --force
+
+          # Restore the tarball for the release step.
+          mv "/tmp/com.enzx.nxgraph-${VER}.tgz" .
 
           echo "Pushed UPM package v${VER} to 'upm' branch."
 
@@ -102,6 +113,7 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: "UPM v${{ steps.meta.outputs.version }}"
+          fail_on_unmatched_files: true
           body: |
             ## Unity Package Manager Release
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,12 @@ riderModule.iml
 *.DotSettings.user
 .tools/
 artifacts/
-NxGraph.Serialization.Tests/TestResults
-NxGraph.Tests/TestResults
+TestResults/
 coverage.info
 coverage.json
 /BenchmarkDotNet.Artifacts/
 upm/com.enzx.nxgraph/Runtime/**/*.dll
 upm/com.enzx.nxgraph/Runtime/**/*.pdb
+upm/com.enzx.nxgraph/Runtime/**/*.xml
 *.log
+*.tgz

--- a/NxFSM.Examples/BlackboardDemo/BlackboardDemoExample.cs
+++ b/NxFSM.Examples/BlackboardDemo/BlackboardDemoExample.cs
@@ -1,0 +1,182 @@
+using System.Text;
+using NxGraph;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Serialization;
+
+namespace NxFSM.Examples.BlackboardDemo;
+
+/// <summary>
+/// Comprehensive scoped-blackboard demo: a squad of guards patrolling a building while an
+/// intruder sneaks through it, built on the <b>async</b> runtime.
+/// <para>
+/// Features demonstrated:
+/// <list type="bullet">
+///   <item>Agent vs blackboard as orthogonal channels — <c>WithBlackboard(...).WithBlackboard(...).WithAgent(...)</c></item>
+///   <item><see cref="BlackboardScope.Global"/> world board shared by every machine (one guard raises the alarm, all react)</item>
+///   <item><see cref="BlackboardScope.Graph"/> boards: one graph template, N guards, each with private working memory</item>
+///   <item>Schema declarations on the graph (<c>.WithSchema</c>) with bind-time validation</item>
+///   <item>Blackboard-driven branching: <c>.Switch(bb =&gt; bb.Get(GuardKeys.Mode))</c></item>
+///   <item>Combined agent + context relay lambdas: <c>.ToAsync&lt;Guard&gt;((guard, bb, ct) =&gt; ...)</c></item>
+///   <item>In-place struct mutation through <c>Bb.GetRef(...)</c></item>
+///   <item>Durability: boards saved with <see cref="BlackboardSerializer"/>, restored into fresh
+///   boards after a simulated restart, simulation resumes seamlessly</item>
+/// </list>
+/// </para>
+/// </summary>
+public static class BlackboardDemoExample
+{
+    public const int RoomCount = 5;
+
+    /// <summary>The intruder's scripted route, one room per tick.</summary>
+    private static readonly int[] IntruderPath = [2, 2, 3, 4, 4, 3, 2, 1, 1, 2];
+
+    public static async ValueTask RunAsync()
+    {
+        Console.OutputEncoding = Encoding.UTF8;
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("┌───────────────────────────────────────────┐");
+        Console.WriteLine("│  Guard Patrol – Scoped Blackboards Demo   │");
+        Console.WriteLine("└───────────────────────────────────────────┘");
+        Console.ResetColor();
+
+        // ── 1. One graph template for every guard ───────────────────────
+        // Sense → Decide (combined agent+context relay) → Switch on the guard's mode.
+        // The schemas are declared on the graph, so binding a board over the wrong
+        // schema fails fast at WithBlackboard time.
+        Graph guardBrain = GraphBuilder
+            .StartWithAsync(new SenseState()).SetName("Sense")
+            .ToAsync<Guard>((guard, bb, _) =>
+            {
+                GuardMode mode =
+                    bb.Get(WorldKeys.IntruderCaught) ? GuardMode.Rest :
+                    bb.Get(GuardKeys.Stamina) < 20 ? GuardMode.Rest :
+                    bb.Get(GuardKeys.Suspicion) >= 50 ? GuardMode.Chase :
+                    bb.Get(WorldKeys.AlarmLevel) > 0 ? GuardMode.Investigate :
+                    GuardMode.Patrol;
+                bb.Set(GuardKeys.Mode, mode);
+                return ResultHelpers.Success;
+            }).SetName("Decide")
+            .Switch(bb => bb.Get(GuardKeys.Mode))
+            .CaseAsync(GuardMode.Patrol, new PatrolState())
+            .CaseAsync(GuardMode.Investigate, new InvestigateState())
+            .CaseAsync(GuardMode.Chase, new ChaseState())
+            .CaseAsync(GuardMode.Rest, new RestState())
+            .End().SetName("ModeSwitch")
+            .WithSchema(GuardKeys.Schema)
+            .WithSchema(WorldKeys.Schema)
+            .Build();
+
+        // ── 2. One world board, one machine + board + agent per guard ───
+        Blackboard world = new(WorldKeys.Schema);
+
+        (Guard guard, Blackboard board, AsyncStateMachine<Guard> fsm)[] squad =
+        [
+            CreateGuard(guardBrain, world, new Guard("Aldric", +1), startRoom: 0),
+            CreateGuard(guardBrain, world, new Guard("Benna", +1), startRoom: 4),
+        ];
+
+        // ── 3. Run the first shift ───────────────────────────────────────
+        int tick = 0;
+        while (tick < 3)
+        {
+            await Tick(world, squad, tick++);
+        }
+
+        // ── 4. Save the world + every guard's board, then "restart" ─────
+        // Boards are independent durability artifacts; between runs the machines are idle,
+        // so no machine snapshot is needed here — the boards ARE the simulation state.
+        BlackboardSerializer serializer = new();
+
+        MemoryStream worldSave = new();
+        await serializer.ToJsonAsync(world, worldSave);
+        List<MemoryStream> guardSaves = [];
+        foreach ((_, Blackboard board, _) in squad)
+        {
+            MemoryStream save = new();
+            await serializer.ToJsonAsync(board, save);
+            guardSaves.Add(save);
+        }
+
+        Console.WriteLine();
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine("  💾 Saved 1 world board + 2 guard boards. Simulating an app restart...");
+        Console.ResetColor();
+
+        // Fresh boards over the same schemas (schemas are code), fresh machines over the
+        // same graph template — then restore each payload into its new board.
+        Blackboard restoredWorld = new(WorldKeys.Schema);
+        worldSave.Position = 0;
+        await serializer.RestoreFromJsonAsync(restoredWorld, worldSave);
+
+        (Guard guard, Blackboard board, AsyncStateMachine<Guard> fsm)[] restoredSquad =
+        [
+            CreateGuard(guardBrain, restoredWorld, new Guard("Aldric", +1), startRoom: 0),
+            CreateGuard(guardBrain, restoredWorld, new Guard("Benna", +1), startRoom: 4),
+        ];
+        for (int i = 0; i < restoredSquad.Length; i++)
+        {
+            guardSaves[i].Position = 0;
+            await serializer.RestoreFromJsonAsync(restoredSquad[i].board, guardSaves[i]);
+        }
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine($"  💾 Restored. Alarm level {restoredWorld.Get(WorldKeys.AlarmLevel)}, " +
+                          $"sightings {restoredWorld.Get(WorldKeys.Sightings)} — the shift continues.");
+        Console.ResetColor();
+
+        // ── 5. Second shift: resume until the intruder is caught ────────
+        while (!restoredWorld.Get(WorldKeys.IntruderCaught) && tick < IntruderPath.Length)
+        {
+            await Tick(restoredWorld, restoredSquad, tick++);
+        }
+
+        Console.WriteLine();
+        if (restoredWorld.Get(WorldKeys.IntruderCaught))
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"  ✅ Intruder caught by {restoredWorld.Get(WorldKeys.CaughtBy)} " +
+                              $"after {restoredWorld.Get(WorldKeys.Sightings)} sighting(s).");
+        }
+        else
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine("  ❌ The intruder slipped away.");
+        }
+
+        Console.ResetColor();
+    }
+
+    private static (Guard, Blackboard, AsyncStateMachine<Guard>) CreateGuard(
+        Graph guardBrain, Blackboard world, Guard guard, int startRoom)
+    {
+        Blackboard board = new(GuardKeys.Schema);
+        board.Set(GuardKeys.Room, startRoom);
+
+        AsyncStateMachine<Guard> fsm = guardBrain.ToAsyncStateMachine<Guard>()
+            .WithBlackboard(world) // routed to the Global slot by the schema's scope
+            .WithBlackboard(board) // routed to the Graph slot
+            .WithAgent(guard);     // the agent channel is untouched by all of this
+
+        return (guard, board, fsm);
+    }
+
+    private static async ValueTask Tick(
+        Blackboard world, (Guard guard, Blackboard board, AsyncStateMachine<Guard> fsm)[] squad, int tick)
+    {
+        if (!world.Get(WorldKeys.IntruderCaught))
+        {
+            world.Set(WorldKeys.IntruderRoom, IntruderPath[tick]);
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"  ── Tick {tick + 1} — intruder sneaks through room {world.Get(WorldKeys.IntruderRoom)} ──");
+
+        foreach ((_, _, AsyncStateMachine<Guard> fsm) in squad)
+        {
+            await fsm.ExecuteAsync(); // context + agent are re-stamped at every run start
+        }
+    }
+}

--- a/NxFSM.Examples/BlackboardDemo/Guard.cs
+++ b/NxFSM.Examples/BlackboardDemo/Guard.cs
@@ -1,0 +1,13 @@
+namespace NxFSM.Examples.BlackboardDemo;
+
+/// <summary>
+/// The agent: the entity that *has* the state machine and the blackboards. Identity and
+/// innate traits live here; per-run working memory lives on the boards.
+/// </summary>
+public sealed class Guard(string name, int patrolDirection)
+{
+    public string Name { get; } = name;
+
+    /// <summary>+1 patrols clockwise, -1 counter-clockwise.</summary>
+    public int PatrolDirection { get; } = patrolDirection;
+}

--- a/NxFSM.Examples/BlackboardDemo/GuardStates.cs
+++ b/NxFSM.Examples/BlackboardDemo/GuardStates.cs
@@ -1,0 +1,106 @@
+using NxGraph;
+using NxGraph.Fsm.Async;
+
+namespace NxFSM.Examples.BlackboardDemo;
+
+/// <summary>
+/// The guard's senses: reads the shared world board, writes both boards. Demonstrates the
+/// two channels side by side — <c>Agent</c> (who am I) and <c>Bb</c> (what do I / we know),
+/// with global and graph keys flowing through the same routed context.
+/// </summary>
+public sealed class SenseState : AsyncState<Guard>
+{
+    protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        int room = Bb.Get(GuardKeys.Room);
+        int intruderRoom = Bb.Get(WorldKeys.IntruderRoom);
+
+        if (!Bb.Get(WorldKeys.IntruderCaught) && room == intruderRoom)
+        {
+            Bb.Set(WorldKeys.IntruderCaught, true);
+            Bb.Set(WorldKeys.CaughtBy, Agent.Name);
+            Console.WriteLine($"    {Agent.Name} corners the intruder in room {room} — caught!");
+        }
+        else if (!Bb.Get(WorldKeys.IntruderCaught) && Math.Abs(room - intruderRoom) == 1)
+        {
+            // Spotted one room away: the guard gives chase, the intruder keeps moving.
+            Bb.Set(GuardKeys.Suspicion, 100);
+            Bb.Set(WorldKeys.LastSeenRoom, intruderRoom);   // global write — every guard sees it
+            Bb.GetRef(WorldKeys.Sightings)++;               // in-place mutation via GetRef
+            if (Bb.Get(WorldKeys.AlarmLevel) < 2)
+            {
+                Bb.GetRef(WorldKeys.AlarmLevel)++;
+            }
+
+            Console.WriteLine($"    {Agent.Name} spots the intruder near room {intruderRoom}! " +
+                              $"(alarm level {Bb.Get(WorldKeys.AlarmLevel)})");
+        }
+        else
+        {
+            ref int suspicion = ref Bb.GetRef(GuardKeys.Suspicion);
+            suspicion = Math.Max(0, suspicion - 25); // cools off when nothing is seen
+        }
+
+        return ResultHelpers.Success;
+    }
+}
+
+/// <summary>Walks the guard's fixed route; direction is an agent trait, position is board state.</summary>
+public sealed class PatrolState : AsyncState<Guard>
+{
+    protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        ref int room = ref Bb.GetRef(GuardKeys.Room);
+        room = (room + Agent.PatrolDirection + BlackboardDemoExample.RoomCount) % BlackboardDemoExample.RoomCount;
+        Bb.GetRef(GuardKeys.Stamina) -= 10;
+
+        Console.WriteLine($"    {Agent.Name} patrols to room {room}.");
+        return ResultHelpers.Success;
+    }
+}
+
+/// <summary>Moves one room toward the last reported sighting (global memory).</summary>
+public sealed class InvestigateState : AsyncState<Guard>
+{
+    protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        ref int room = ref Bb.GetRef(GuardKeys.Room);
+        int target = Bb.Get(WorldKeys.LastSeenRoom);
+        room += Math.Sign(target - room);
+        Bb.GetRef(GuardKeys.Stamina) -= 15;
+
+        Console.WriteLine($"    {Agent.Name} investigates room {room} (last sighting: room {target}).");
+        return ResultHelpers.Success;
+    }
+}
+
+/// <summary>Sprints toward the last reported sighting; the catch resolves next tick in <see cref="SenseState"/>.</summary>
+public sealed class ChaseState : AsyncState<Guard>
+{
+    protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        ref int room = ref Bb.GetRef(GuardKeys.Room);
+        int target = Bb.Get(WorldKeys.LastSeenRoom);
+        room += Math.Sign(target - room);
+        Bb.GetRef(GuardKeys.Stamina) -= 25;
+
+        Console.WriteLine($"    {Agent.Name} chases toward room {target} " +
+                          $"(now in room {room}, stamina {Bb.Get(GuardKeys.Stamina)}).");
+        return ResultHelpers.Success;
+    }
+}
+
+/// <summary>Catches breath (or stands down once the intruder is caught).</summary>
+public sealed class RestState : AsyncState<Guard>
+{
+    protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        ref int stamina = ref Bb.GetRef(GuardKeys.Stamina);
+        stamina = Math.Min(100, stamina + 40);
+
+        Console.WriteLine(Bb.Get(WorldKeys.IntruderCaught)
+            ? $"    {Agent.Name} stands down."
+            : $"    {Agent.Name} rests (stamina {stamina}).");
+        return ResultHelpers.Success;
+    }
+}

--- a/NxFSM.Examples/BlackboardDemo/Keys.cs
+++ b/NxFSM.Examples/BlackboardDemo/Keys.cs
@@ -1,0 +1,42 @@
+using NxGraph.Blackboards;
+
+namespace NxFSM.Examples.BlackboardDemo;
+
+/// <summary>What a guard is currently doing — stored on the guard's own (Graph-scoped) board.</summary>
+public enum GuardMode
+{
+    Patrol = 0,
+    Investigate = 1,
+    Chase = 2,
+    Rest = 3,
+}
+
+/// <summary>
+/// The shared world memory: one <see cref="BlackboardScope.Global"/> board bound to every
+/// guard's machine. A write by one guard (raising the alarm) is visible to all others.
+/// </summary>
+public static class WorldKeys
+{
+    public static readonly BlackboardSchema Schema = new("patrol-world", BlackboardScope.Global);
+
+    public static readonly BlackboardKey<int> AlarmLevel = Schema.Register<int>("AlarmLevel");
+    public static readonly BlackboardKey<int> IntruderRoom = Schema.Register<int>("IntruderRoom", -1);
+    public static readonly BlackboardKey<int> LastSeenRoom = Schema.Register<int>("LastSeenRoom", -1);
+    public static readonly BlackboardKey<int> Sightings = Schema.Register<int>("Sightings");
+    public static readonly BlackboardKey<bool> IntruderCaught = Schema.Register<bool>("IntruderCaught");
+    public static readonly BlackboardKey<string> CaughtBy = Schema.Register<string>("CaughtBy", "");
+}
+
+/// <summary>
+/// Per-guard working memory: a <see cref="BlackboardScope.Graph"/> schema — every guard's
+/// machine binds its own board over this one shared layout.
+/// </summary>
+public static class GuardKeys
+{
+    public static readonly BlackboardSchema Schema = new("guard");
+
+    public static readonly BlackboardKey<GuardMode> Mode = Schema.Register<GuardMode>("Mode");
+    public static readonly BlackboardKey<int> Room = Schema.Register<int>("Room");
+    public static readonly BlackboardKey<int> Suspicion = Schema.Register<int>("Suspicion");
+    public static readonly BlackboardKey<int> Stamina = Schema.Register<int>("Stamina", 100);
+}

--- a/NxFSM.Examples/DungeonCrawler/DungeonObserver.cs
+++ b/NxFSM.Examples/DungeonCrawler/DungeonObserver.cs
@@ -29,9 +29,9 @@ public sealed class DungeonObserver : IStateMachineObserver
         WriteColour(ConsoleColor.DarkYellow, $"{Indent}→ Transition: [{from.Name}] ──► [{to.Name}]");
     }
 
-    public void OnStateFailed(NodeId id, Exception ex)
+    public void OnStateFailed(NodeId id, Exception? ex)
     {
-        WriteColour(ConsoleColor.Red, $"{Indent}✖ FAILED [{id.Name}]: {ex.Message}");
+        WriteColour(ConsoleColor.Red, $"{Indent}✖ FAILED [{id.Name}]: {ex?.Message ?? "node returned Failure"}");
     }
 
     // ── Machine lifecycle ───────────────────────────────────────────────

--- a/NxFSM.Examples/ParallelDemo/AsyncParallelDemoExample.cs
+++ b/NxFSM.Examples/ParallelDemo/AsyncParallelDemoExample.cs
@@ -1,0 +1,130 @@
+using System.Text;
+using NxGraph;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxFSM.Examples.ParallelDemo;
+
+/// <summary>
+/// Async parallel composites demo: an expedition setting up camp, run under the
+/// <see cref="AsyncStateMachine"/>.
+/// <para>
+/// Features demonstrated:
+/// <list type="bullet">
+///   <item><see cref="AsyncParallelState"/> via <c>.Parallel(regions...)</c> — three regions of
+///   different lengths advance one node per round (cooperative interleaving, not threads);
+///   one <c>ExecuteAsync</c> call runs rounds until every region joins.</item>
+///   <item><see cref="AsyncDynamicParallelState"/> via <c>.Parallel(selector, regions...)</c> —
+///   a blackboard-driven selector picks which drill regions run each execution, composed
+///   allocation-free with <c>RegionMask.Bit(i) | ...</c>.</item>
+///   <item>Join semantics: <see cref="Result.Success"/> only when every selected region
+///   succeeded; failures flow through the parent's unified fault model.</item>
+/// </list>
+/// The sync twin of this demo (step modes, per-frame ticking) is
+/// <see cref="ParallelDemoExample"/>.
+/// </para>
+/// </summary>
+public static class AsyncParallelDemoExample
+{
+    private static readonly BlackboardSchema Schema = new("expedition");
+    private static readonly BlackboardKey<bool> StormComing = Schema.Register<bool>("storm");
+
+    public static async Task RunAsync()
+    {
+        Console.OutputEncoding = Encoding.UTF8;
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("┌─────────────────────────────────────────────┐");
+        Console.WriteLine("│  Expedition Camp – Async Parallel Regions   │");
+        Console.WriteLine("└─────────────────────────────────────────────┘");
+        Console.ResetColor();
+
+        await RunCampSetupAsync();
+        await RunWeatherDrillsAsync();
+    }
+
+    // ── Part 1: static AND-state — all regions run, rounds interleave ────
+
+    private static async Task RunCampSetupAsync()
+    {
+        Console.WriteLine();
+        Console.WriteLine("  Camp setup — three crews of different sizes, one node per crew per round:");
+
+        Graph tents = GraphBuilder
+            .StartWithAsync(_ => Report("Tent crew", "clears the ground"))
+            .ToAsync(_ => Report("Tent crew", "raises the poles"))
+            .ToAsync(_ => Report("Tent crew", "pegs the canvas"))
+            .Build();
+
+        Graph fire = GraphBuilder
+            .StartWithAsync(_ => Report("Fire crew", "gathers kindling"))
+            .ToAsync(_ => Report("Fire crew", "lights the fire"))
+            .Build();
+
+        Graph scouts = GraphBuilder
+            .StartWithAsync(_ => Report("Scouts", "circle the perimeter"))
+            .Build();
+
+        AsyncStateMachine fsm = GraphBuilder
+            .Start()
+            .Parallel(tents, fire, scouts)
+            .ToAsyncStateMachine();
+
+        // One call runs round after round until every region reaches a terminal result —
+        // the interleaved output shows one node per still-running region per round.
+        Result result = await fsm.ExecuteAsync();
+        Console.WriteLine($"  Camp is up (all regions joined): {result}");
+    }
+
+    // ── Part 2: dynamic selection from the blackboard ─────────────────────
+
+    private static async Task RunWeatherDrillsAsync()
+    {
+        Console.WriteLine();
+        Console.WriteLine("  Weather drills — the forecast on the blackboard picks the drills:");
+
+        Graph gearDrill = GraphBuilder
+            .StartWithAsync(_ => Report("Crew", "stows loose gear"))
+            .Build();
+
+        Graph shelterDrill = GraphBuilder
+            .StartWithAsync(_ => Report("Crew", "reinforces the shelter"))
+            .Build();
+
+        Blackboard board = new(Schema);
+
+        AsyncStateMachine fsm = GraphBuilder
+            .Start()
+            .Parallel(SelectDrills, gearDrill, shelterDrill)
+            .ToAsyncStateMachine()
+            .WithBlackboard(board);
+
+        foreach (bool storm in (bool[]) [false, true])
+        {
+            board.Set(StormComing, storm);
+            Console.WriteLine($"  ── forecast: {(storm ? "storm front incoming" : "clear skies")} ──");
+            await fsm.ExecuteAsync(); // the selector re-runs at every composite entry
+        }
+    }
+
+    private static RegionMask SelectDrills(BlackboardContext bb)
+    {
+        // Composed with Bit | Bit — selectors run once per composite execution, so the
+        // allocating RegionMask.Of(params) stays setup-only.
+        RegionMask mask = RegionMask.Bit(0); // the gear drill always runs
+        if (bb.Get(StormComing))
+        {
+            mask |= RegionMask.Bit(1); // shelter drill only when a storm is coming
+        }
+
+        return mask;
+    }
+
+    private static ValueTask<Result> Report(string who, string what)
+    {
+        Console.WriteLine($"    {who,-10} {what}");
+        return ResultHelpers.Success;
+    }
+}

--- a/NxFSM.Examples/ParallelDemo/ParallelDemoExample.cs
+++ b/NxFSM.Examples/ParallelDemo/ParallelDemoExample.cs
@@ -1,0 +1,152 @@
+using System.Text;
+using NxGraph;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxFSM.Examples.ParallelDemo;
+
+/// <summary>
+/// Sync parallel composites demo: a stronghold under siege, driven tick-by-tick the way a
+/// game loop would call <c>fsm.Execute()</c> from <c>Update()</c>.
+/// <para>
+/// Features demonstrated:
+/// <list type="bullet">
+///   <item><see cref="ParallelState"/> with <see cref="ParallelStepMode.RoundPerTick"/> —
+///   two always-on regions (watchtower, gate crew) advance one node per frame, so region
+///   progress aligns 1:1 with game-loop ticks; the join lands on the final frame.</item>
+///   <item><see cref="DynamicParallelState"/> with <see cref="ParallelStepMode.RunToJoin"/> —
+///   a blackboard-driven selector picks which defense regions run each wave, composed
+///   allocation-free with <c>RegionMask.Bit(i) | ...</c>.</item>
+///   <item>An empty selection is a vacuous join: no threat, no regions stepped, immediate
+///   <see cref="Result.Success"/>.</item>
+///   <item>Context forwarding: the selector <i>and</i> the region nodes read the same
+///   machine-bound board — the composite hands the stamped context to its region machines.</item>
+/// </list>
+/// </para>
+/// </summary>
+public static class ParallelDemoExample
+{
+    private static readonly BlackboardSchema Schema = new("siege");
+    private static readonly BlackboardKey<int> Threat = Schema.Register<int>("threat");
+
+    public static void Run()
+    {
+        Console.OutputEncoding = Encoding.UTF8;
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("┌───────────────────────────────────────────┐");
+        Console.WriteLine("│  Stronghold Siege – Parallel Regions Demo │");
+        Console.WriteLine("└───────────────────────────────────────────┘");
+        Console.ResetColor();
+
+        RunMorningWatch();
+        RunSiegeWaves();
+    }
+
+    // ── Part 1: static AND-state, one round per frame ────────────────────
+
+    private static void RunMorningWatch()
+    {
+        Console.WriteLine();
+        Console.WriteLine("  Morning watch — every subsystem runs, one node per frame (RoundPerTick):");
+
+        Graph watchtower = GraphBuilder
+            .StartWith(() => Report("Watchtower", "scans the horizon"))
+            .To(() => Report("Watchtower", "spots a dust cloud to the east"))
+            .To(() => Report("Watchtower", "signals the yard"))
+            .Build();
+
+        Graph gateCrew = GraphBuilder
+            .StartWith(() => Report("Gate crew", "swings the gate shut"))
+            .To(() => Report("Gate crew", "drops the bar"))
+            .Build();
+
+        StateMachine fsm = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick, watchtower, gateCrew)
+            .ToStateMachine();
+
+        int frame = 0;
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"  ── frame {++frame} ──");
+            Console.ResetColor();
+            result = fsm.Execute(); // one round: each still-running region advances one node
+        }
+
+        Console.WriteLine($"  Both regions joined on frame {frame}: {result}");
+    }
+
+    // ── Part 2: dynamic selection by threat level ────────────────────────
+
+    private static void RunSiegeWaves()
+    {
+        Console.WriteLine();
+        Console.WriteLine("  Siege waves — the threat level on the blackboard picks the defenses:");
+
+        // Region nodes read the same board the selector does — the composite forwards the
+        // machine-bound context into its region machines.
+        Graph archers = DefenseRegion("Archers", "loose a volley");
+        Graph cauldrons = DefenseRegion("Cauldrons", "pour boiling oil");
+        Graph catapults = DefenseRegion("Catapults", "hurl a boulder");
+
+        Blackboard board = new(Schema);
+
+        StateMachine fsm = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RunToJoin, SelectDefenses, archers, cauldrons, catapults)
+            .ToStateMachine()
+            .WithBlackboard(board);
+
+        foreach (int level in (int[]) [1, 3, 0])
+        {
+            board.Set(Threat, level);
+            Console.WriteLine($"  ── wave: threat level {level} ──");
+            Result result = fsm.Execute(); // RunToJoin: the whole wave resolves in one tick
+            if (level == 0)
+            {
+                Console.WriteLine($"    (no threat — vacuous join, nothing stepped: {result})");
+            }
+        }
+    }
+
+    private static RegionMask SelectDefenses(BlackboardContext bb)
+    {
+        // Composed with Bit | Bit — selectors run once per composite execution, on the
+        // measured hot path, so RegionMask.Of(params) (which allocates) stays setup-only.
+        int level = bb.Get(Threat);
+        RegionMask mask = RegionMask.None;
+        if (level >= 1)
+        {
+            mask |= RegionMask.Bit(0); // archers
+        }
+
+        if (level >= 2)
+        {
+            mask |= RegionMask.Bit(1); // cauldrons
+        }
+
+        if (level >= 3)
+        {
+            mask |= RegionMask.Bit(2); // catapults
+        }
+
+        return mask;
+    }
+
+    private static Graph DefenseRegion(string crew, string action)
+    {
+        return GraphBuilder
+            .StartWith(bb => Report(crew, $"{action} (threat {bb.Get(Threat)})"))
+            .Build();
+    }
+
+    private static Result Report(string who, string what)
+    {
+        Console.WriteLine($"    {who,-10} {what}");
+        return Result.Success;
+    }
+}

--- a/NxFSM.Examples/Program.cs
+++ b/NxFSM.Examples/Program.cs
@@ -3,6 +3,7 @@
 using NxFSM.Examples;
 using NxFSM.Examples.BlackboardDemo;
 using NxFSM.Examples.DungeonCrawler;
+using NxFSM.Examples.ParallelDemo;
 using NxFSM.Examples.ReadmeExamples;
 using NxGraph;
 using NxGraph.Authoring;
@@ -55,6 +56,10 @@ DungeonCrawlerExample.Run();
 Console.WriteLine();
 Console.WriteLine();
 await BlackboardDemoExample.RunAsync();
+
+Console.WriteLine();
+Console.WriteLine();
+ParallelDemoExample.Run();
 
 Console.WriteLine();
 Console.WriteLine();

--- a/NxFSM.Examples/Program.cs
+++ b/NxFSM.Examples/Program.cs
@@ -63,6 +63,10 @@ ParallelDemoExample.Run();
 
 Console.WriteLine();
 Console.WriteLine();
+await AsyncParallelDemoExample.RunAsync();
+
+Console.WriteLine();
+Console.WriteLine();
 Console.WriteLine("=== README Examples ===");
 Console.WriteLine();
 await QuickStartExample.RunAsync();
@@ -76,6 +80,8 @@ Console.WriteLine();
 await BlackboardExample.RunAsync();
 Console.WriteLine();
 ObserverExample.Run();
+Console.WriteLine();
+await FeatureExamples.RunAsync();
 
 return 0;
 

--- a/NxFSM.Examples/Program.cs
+++ b/NxFSM.Examples/Program.cs
@@ -1,6 +1,7 @@
 // See https://aka.ms/new-console-template for more information
 
 using NxFSM.Examples;
+using NxFSM.Examples.BlackboardDemo;
 using NxFSM.Examples.DungeonCrawler;
 using NxFSM.Examples.ReadmeExamples;
 using NxGraph;
@@ -53,6 +54,10 @@ DungeonCrawlerExample.Run();
 
 Console.WriteLine();
 Console.WriteLine();
+await BlackboardDemoExample.RunAsync();
+
+Console.WriteLine();
+Console.WriteLine();
 Console.WriteLine("=== README Examples ===");
 Console.WriteLine();
 await QuickStartExample.RunAsync();
@@ -62,6 +67,8 @@ Console.WriteLine();
 await DslExamples.RunAsync();
 Console.WriteLine();
 await AgentExample.RunAsync();
+Console.WriteLine();
+await BlackboardExample.RunAsync();
 Console.WriteLine();
 ObserverExample.Run();
 

--- a/NxFSM.Examples/ReadmeExamples/BlackboardExample.cs
+++ b/NxFSM.Examples/ReadmeExamples/BlackboardExample.cs
@@ -1,0 +1,100 @@
+using NxGraph;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxFSM.Examples.ReadmeExamples;
+
+/// <summary>
+/// Scoped blackboards: one Global "world" board shared by every machine, plus one
+/// Graph-scoped board per enemy. Keys are declared once in static schemas; the graph is a
+/// shared template and each enemy binds its own board + agent.
+/// </summary>
+public static class BlackboardExample
+{
+    // Schemas are code: declare keys once, typically in a static holder like this.
+    private static class WorldKeys
+    {
+        public static readonly BlackboardSchema Schema = new("world", BlackboardScope.Global);
+        public static readonly BlackboardKey<bool> AlarmRaised = Schema.Register<bool>("AlarmRaised");
+        public static readonly BlackboardKey<int> Sightings = Schema.Register<int>("Sightings");
+    }
+
+    private static class EnemyKeys
+    {
+        public static readonly BlackboardSchema Schema = new("enemy");
+        public static readonly BlackboardKey<int> TargetDistance = Schema.Register<int>("TargetDistance", 10);
+        public static readonly BlackboardKey<int> Speed = Schema.Register<int>("Speed", 1);
+    }
+
+    private sealed class Enemy(string name)
+    {
+        public string Name { get; } = name;
+    }
+
+    private sealed class ScoutState : AsyncState<Enemy>
+    {
+        protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+        {
+            // Bb routes by the key's schema scope: global keys hit the shared world board,
+            // graph keys hit this machine's own board — one call site, no chain walk.
+            Bb.GetRef(EnemyKeys.TargetDistance) -= Bb.Get(EnemyKeys.Speed);
+            if (Bb.Get(EnemyKeys.TargetDistance) <= 5 && !Bb.Get(WorldKeys.AlarmRaised))
+            {
+                Bb.Set(WorldKeys.AlarmRaised, true);
+                Console.WriteLine($"  {Agent.Name} spotted the player — raising the world alarm!");
+            }
+
+            Bb.GetRef(WorldKeys.Sightings)++;
+            return ResultHelpers.Success;
+        }
+    }
+
+    public static async ValueTask RunAsync()
+    {
+        Console.WriteLine("=== Scoped Blackboards (Global + Graph) ===");
+
+        // One shared graph template. The schema declarations travel with the graph and are
+        // checked when boards are bound.
+        Graph graph = GraphBuilder
+            .StartWithAsync(new ScoutState()).SetName("Scout")
+            .If(bb => bb.Get(WorldKeys.AlarmRaised))
+            .ThenAsync((bb, _) =>
+            {
+                bb.Set(EnemyKeys.Speed, 3); // alarm up — everyone hunts faster
+                return ResultHelpers.Success;
+            })
+            .ElseAsync((bb, _) => ResultHelpers.Success)
+            .WithSchema(EnemyKeys.Schema)
+            .WithSchema(WorldKeys.Schema)
+            .Build();
+
+        // One world board for everyone; one graph board + machine + agent per enemy.
+        Blackboard world = new(WorldKeys.Schema);
+
+        Enemy goblin = new("Goblin");
+        Enemy archer = new("Archer");
+        Blackboard goblinBoard = new(EnemyKeys.Schema);
+        Blackboard archerBoard = new(EnemyKeys.Schema);
+        goblinBoard.Set(EnemyKeys.TargetDistance, 6); // the goblin starts close
+
+        AsyncStateMachine<Enemy> goblinFsm = graph.ToAsyncStateMachine<Enemy>()
+            .WithBlackboard(world)
+            .WithBlackboard(goblinBoard)
+            .WithAgent(goblin);
+
+        AsyncStateMachine<Enemy> archerFsm = graph.ToAsyncStateMachine<Enemy>()
+            .WithBlackboard(world)
+            .WithBlackboard(archerBoard)
+            .WithAgent(archer);
+
+        await goblinFsm.ExecuteAsync(); // goblin closes to 5 → raises the alarm
+        await archerFsm.ExecuteAsync(); // archer sees the alarm → speeds up
+
+        Console.WriteLine($"  Alarm raised: {world.Get(WorldKeys.AlarmRaised)}, " +
+                          $"sightings: {world.Get(WorldKeys.Sightings)}");
+        Console.WriteLine($"  Goblin distance: {goblinBoard.Get(EnemyKeys.TargetDistance)}, " +
+                          $"archer speed after alarm: {archerBoard.Get(EnemyKeys.Speed)}");
+    }
+}

--- a/NxFSM.Examples/ReadmeExamples/FeatureExamples.cs
+++ b/NxFSM.Examples/ReadmeExamples/FeatureExamples.cs
@@ -1,0 +1,168 @@
+using System.Text.Json;
+using NxGraph;
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxFSM.Examples.ReadmeExamples;
+
+/// <summary>
+/// Runnable versions of the README sections added with the 2.x feature wave:
+/// error handling (retries + failure edges), Goto loops, named outcomes,
+/// subgraph composites, and durable suspend/resume.
+/// </summary>
+public static class FeatureExamples
+{
+    public static async ValueTask RunAsync()
+    {
+        await RetryAndFailureEdgeAsync();
+        GotoLoop();
+        await NamedOutcomesAsync();
+        await SubGraphCompositeAsync();
+        await DurableSuspendResumeAsync();
+    }
+
+    // ── Error handling: retries and failure edges ─────────────────────────
+
+    static async ValueTask RetryAndFailureEdgeAsync()
+    {
+        Console.WriteLine("=== Feature: Retry + OnError ===");
+
+        int attempts = 0;
+
+        ValueTask<Result> CallFlakyService(CancellationToken _)
+        {
+            attempts++;
+            Console.WriteLine($"  Call attempt {attempts}");
+            return ResultHelpers.Failure; // always fails — exhausts retries, takes the failure edge
+        }
+
+        ValueTask<Result> Cleanup()
+        {
+            Console.WriteLine("  Cleanup handler ran");
+            return ResultHelpers.Success;
+        }
+
+        Graph graph = GraphBuilder
+            .StartWithAsync(CallFlakyService).SetName("Call")
+                .Retry(maxAttempts: 3, backoff: 1.Milliseconds(), BackoffKind.Exponential)
+                .OnErrorAsync(_ => Cleanup()).SetName("Cleanup")
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+        Console.WriteLine($"Result after {attempts} attempts: {result}");
+    }
+
+    // ── Loops with Goto ───────────────────────────────────────────────────
+
+    static void GotoLoop()
+    {
+        Console.WriteLine("=== Feature: Goto loop ===");
+
+        int laps = 0;
+
+        Graph loop = GraphBuilder
+            .StartWith(() => Result.Success).SetName("Gather")
+            .To(() => ++laps < 3 ? Result.Success : Result.Failure).SetName("Craft")
+            .Goto("Gather") // Craft's success edge loops back to Gather
+            .Build();
+
+        StateMachine fsm = loop.ToStateMachine();
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+            result = fsm.Execute();
+
+        Console.WriteLine($"Looped {laps} laps, exit: {result}");
+    }
+
+    // ── Named outcomes ────────────────────────────────────────────────────
+
+    static async ValueTask NamedOutcomesAsync()
+    {
+        Console.WriteLine("=== Feature: Named outcomes ===");
+
+        const int delivered = 1;
+
+        static ValueTask<Result> ProcessOrder(CancellationToken _) => ResultHelpers.Success;
+
+        Graph graph = GraphBuilder
+            .StartWithAsync(ProcessOrder).SetName("Process")
+            .ToAsync(_ => ResultHelpers.Success).SetName("Deliver").WithOutcome(delivered, "Delivered")
+            .Build();
+
+        AsyncStateMachine fsm = graph.ToAsyncStateMachine();
+        await fsm.ExecuteAsync();
+        Console.WriteLine($"Outcome {fsm.LastOutcome}: {fsm.LastOutcomeName}");
+    }
+
+    // ── Composites: subgraph nesting ──────────────────────────────────────
+
+    static async ValueTask SubGraphCompositeAsync()
+    {
+        Console.WriteLine("=== Feature: SubGraph composite ===");
+
+        Graph child = GraphBuilder
+            .StartWithAsync(_ =>
+            {
+                Console.WriteLine("  child step 1");
+                return ResultHelpers.Success;
+            })
+            .ToAsync(_ =>
+            {
+                Console.WriteLine("  child step 2");
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Graph flow = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success).SetName("Prepare")
+            .SubGraph(child, history: true).SetName("Work")
+            .ToAsync(_ => ResultHelpers.Success).SetName("Finish")
+            .Build();
+
+        Result result = await flow.ToAsyncStateMachine().ExecuteAsync();
+        Console.WriteLine($"Result: {result}");
+    }
+
+    // ── Durable suspend / resume ──────────────────────────────────────────
+
+    static async ValueTask DurableSuspendResumeAsync()
+    {
+        Console.WriteLine("=== Feature: Durable suspend/resume (cross-runtime) ===");
+
+        Graph graph = GraphBuilder
+            .StartWith(() =>
+            {
+                Console.WriteLine("  node 0 (async machine)");
+                return Result.Success;
+            })
+            .To(() =>
+            {
+                Console.WriteLine("  node 1 (sync machine)");
+                return Result.Success;
+            })
+            .To(() =>
+            {
+                Console.WriteLine("  node 2 (sync machine)");
+                return Result.Success;
+            })
+            .Build();
+
+        AsyncStateMachine first = graph.ToAsyncStateMachine();
+        await first.StepAsync();                          // advance one node
+        StateMachineSnapshot snapshot = first.Suspend();  // primitives-only record
+
+        string json = JsonSerializer.Serialize(snapshot); // any serializer works
+
+        // Continue on the sync runtime — snapshots are interchangeable.
+        StateMachine second = graph.ToStateMachine();
+        second.Resume(JsonSerializer.Deserialize<StateMachineSnapshot>(json)!);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+            result = second.Execute();
+
+        Console.WriteLine($"Resumed run finished: {result}");
+    }
+}

--- a/NxFSM.Examples/ReadmeExamples/ObserverExample.cs
+++ b/NxFSM.Examples/ReadmeExamples/ObserverExample.cs
@@ -21,8 +21,8 @@ public sealed class DiagnosticObserver : IStateMachineObserver
     public void OnStateExited(NodeId id)  => Console.WriteLine($"  << {id.Name}");
     public void OnTransition(NodeId from, NodeId to) =>
         Console.WriteLine($"     {from.Name} -> {to.Name}");
-    public void OnStateFailed(NodeId id, Exception ex) =>
-        Console.WriteLine($"  FAIL {id.Name}: {ex.Message}");
+    public void OnStateFailed(NodeId id, Exception? ex) =>
+        Console.WriteLine($"  FAIL {id.Name}: {ex?.Message ?? "node returned Failure"}");
     public void OnStateMachineCompleted(NodeId graphId, Result result) =>
         Console.WriteLine($"  FSM done: {result}");
     public void OnLogReport(NodeId nodeId, string message) =>

--- a/NxGraph.Build/BuildHelpers.cs
+++ b/NxGraph.Build/BuildHelpers.cs
@@ -104,7 +104,9 @@ public static partial class BuildHelpers
         {
             "pack", projectRelPath,
             "--configuration", configuration,
-            "--no-build",
+            // No --no-build: ContinuousIntegrationBuild/Deterministic/Version only take
+            // effect at compile time. Packing a --no-build output produced assemblies
+            // stamped 1.0.0.0 with none of the determinism flags applied.
             "-o", artifactsDir,
             "-p:ContinuousIntegrationBuild=true",
             "-p:Deterministic=true",
@@ -112,6 +114,7 @@ public static partial class BuildHelpers
             "-p:SymbolPackageFormat=snupkg",
             "-p:DebugType=portable",
             $"-p:PackageVersion={version}",
+            $"-p:Version={version}",
         };
 
         if (!string.IsNullOrEmpty(repoUrl))

--- a/NxGraph.Build/Program.cs
+++ b/NxGraph.Build/Program.cs
@@ -9,6 +9,7 @@ public static class Program
     private static readonly string[] DirectoriesToCopy =
     [
         Path.Combine("Authoring"),
+        Path.Combine("Blackboards"),
         Path.Combine("Compatibility"),
         Path.Combine("Diagnostics", "Export"),
         Path.Combine("Diagnostics", "Replay"),

--- a/NxGraph.Serialization.Abstraction/IBlackboardSerializer.cs
+++ b/NxGraph.Serialization.Abstraction/IBlackboardSerializer.cs
@@ -1,0 +1,46 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Serialization.Abstraction;
+
+/// <summary>
+/// How restore treats payload entries that no longer line up with the live schema.
+/// Independent of direction: schema keys absent from the payload always keep their
+/// registered defaults (forward compatibility for schemas that added keys).
+/// </summary>
+public enum BlackboardMismatchPolicy
+{
+    /// <summary>
+    /// Fail loudly: an unknown payload key, a changed value type, or a schema-name/scope
+    /// mismatch throws.
+    /// </summary>
+    Strict = 0,
+
+    /// <summary>
+    /// Skip entries that don't fit the schema (schema evolution). Corrupt values still throw.
+    /// </summary>
+    Skip = 1,
+}
+
+/// <summary>
+/// Serializes one <see cref="Blackboard"/> to/from JSON as an independent durability
+/// artifact (alongside the graph payload and the machine snapshot). Restore writes into an
+/// existing board — the schema is code and cannot be reconstructed from a payload.
+/// </summary>
+public interface IBlackboardJsonSerializer
+{
+    ValueTask ToJsonAsync(Blackboard blackboard, Stream destination, CancellationToken ct = default);
+
+    ValueTask RestoreFromJsonAsync(Blackboard target, Stream source,
+        BlackboardMismatchPolicy policy = BlackboardMismatchPolicy.Strict, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Binary counterpart of <see cref="IBlackboardJsonSerializer"/>.
+/// </summary>
+public interface IBlackboardBinarySerializer
+{
+    ValueTask ToBinaryAsync(Blackboard blackboard, Stream destination, CancellationToken ct = default);
+
+    ValueTask RestoreFromBinaryAsync(Blackboard target, Stream source,
+        BlackboardMismatchPolicy policy = BlackboardMismatchPolicy.Strict, CancellationToken ct = default);
+}

--- a/NxGraph.Serialization.Abstraction/NxGraph.Serialization.Abstraction.csproj
+++ b/NxGraph.Serialization.Abstraction/NxGraph.Serialization.Abstraction.csproj
@@ -4,16 +4,22 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Description>NxGraph Serialization Abstraction</Description>
-        <Copyright>Moe Iraji</Copyright>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <Title>NxGraph.Serialization.Abstraction</Title>
+        <Authors>Moe Iraji</Authors>
+        <Description>Serializer and codec abstractions for NxGraph — reference this package to implement custom graph serializers or node-logic codecs without depending on a concrete format.</Description>
         <PackageProjectUrl>https://github.com/Enzx/NxGraph</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/Enzx/NxGraph</RepositoryUrl>
-        <PackageTags>Statemachine, FSM, Serialization</PackageTags>
+        <PackageTags>statemachine fsm serialization abstractions</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>Docs/readme.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\NxGraph\NxGraph.csproj"/>

--- a/NxGraph.Serialization.Tests/BlackboardSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/BlackboardSerializationTests.cs
@@ -1,0 +1,354 @@
+using System.Text;
+using System.Text.Json;
+using MessagePack;
+using MessagePack.Resolvers;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// The blackboard as a durability artifact: JSON/MessagePack round-trips, mismatch policies,
+/// and the full three-artifact loop (graph + snapshot + boards).
+/// </summary>
+[TestFixture]
+[Category("serialization")]
+public class BlackboardSerializationTests
+{
+    private readonly BlackboardSerializer _serializer = new();
+
+    private static BlackboardSchema NewSchema(string? name = "stats")
+    {
+        return new BlackboardSchema(name);
+    }
+
+    private static async Task<MemoryStream> SaveJson(BlackboardSerializer serializer, Blackboard board)
+    {
+        MemoryStream stream = new();
+        await serializer.ToJsonAsync(board, stream);
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static async Task<MemoryStream> SaveBinary(BlackboardSerializer serializer, Blackboard board)
+    {
+        MemoryStream stream = new();
+        await serializer.ToBinaryAsync(board, stream);
+        stream.Position = 0;
+        return stream;
+    }
+
+    [Test]
+    public async Task json_round_trip_restores_values_and_defaults()
+    {
+        BlackboardSchema schema = NewSchema();
+        BlackboardKey<int> score = schema.Register<int>("score");
+        BlackboardKey<string> label = schema.Register<string>("label", "fresh");
+        BlackboardKey<float> speed = schema.Register<float>("speed", 1.5f);
+
+        Blackboard source = new(schema);
+        source.Set(score, 42);
+        source.Set(label, "saved");
+        // speed left on its default
+
+        await using MemoryStream stream = await SaveJson(_serializer, source);
+
+        Blackboard target = new(schema);
+        target.Set(speed, 99f); // stale value — restore must reset it to defaults + payload
+        await _serializer.RestoreFromJsonAsync(target, stream);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(target.Get(score), Is.EqualTo(42));
+            Assert.That(target.Get(label), Is.EqualTo("saved"));
+            Assert.That(target.Get(speed), Is.EqualTo(1.5f), "Restore is defaults + payload, never stale state.");
+        });
+    }
+
+    [Test]
+    public async Task binary_round_trip_restores_values_and_defaults()
+    {
+        BlackboardSchema schema = NewSchema();
+        BlackboardKey<int> score = schema.Register<int>("score");
+        BlackboardKey<string> label = schema.Register<string>("label", "fresh");
+        BlackboardKey<bool> flag = schema.Register<bool>("flag");
+
+        Blackboard source = new(schema);
+        source.Set(score, -7);
+        source.Set(flag, true);
+
+        await using MemoryStream stream = await SaveBinary(_serializer, source);
+
+        Blackboard target = new(schema);
+        await _serializer.RestoreFromBinaryAsync(target, stream);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(target.Get(score), Is.EqualTo(-7));
+            Assert.That(target.Get(label), Is.EqualTo("fresh"));
+            Assert.That(target.Get(flag), Is.True);
+        });
+    }
+
+    public sealed record Loadout(string Weapon, int Ammo);
+
+    [Test]
+    public async Task custom_types_round_trip_via_caller_supplied_options()
+    {
+        BlackboardSchema schema = NewSchema("loadouts");
+        BlackboardKey<Loadout?> loadout = schema.Register<Loadout?>("loadout");
+
+        Blackboard source = new(schema);
+        source.Set(loadout, new Loadout("bow", 12));
+
+        // JSON handles POCOs out of the box; MessagePack gets a contractless resolver via
+        // the options extension point.
+        BlackboardSerializer serializer = new(
+            binaryOptions: MessagePackSerializerOptions.Standard
+                .WithSecurity(MessagePackSecurity.UntrustedData)
+                .WithResolver(ContractlessStandardResolver.Instance));
+
+        await using MemoryStream json = await SaveJson(serializer, source);
+        Blackboard jsonTarget = new(schema);
+        await serializer.RestoreFromJsonAsync(jsonTarget, json);
+
+        await using MemoryStream binary = await SaveBinary(serializer, source);
+        Blackboard binaryTarget = new(schema);
+        await serializer.RestoreFromBinaryAsync(binaryTarget, binary);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(jsonTarget.Get(loadout), Is.EqualTo(new Loadout("bow", 12)));
+            Assert.That(binaryTarget.Get(loadout), Is.EqualTo(new Loadout("bow", 12)));
+        });
+    }
+
+    // ── Mismatch matrix ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task unknown_payload_key_throws_strict_and_skips_skip()
+    {
+        BlackboardSchema saved = NewSchema();
+        BlackboardKey<int> kept = saved.Register<int>("kept");
+        saved.Register<int>("removed");
+
+        Blackboard source = new(saved);
+        source.Set(kept, 5);
+
+        // The live schema no longer has "removed".
+        BlackboardSchema live = NewSchema();
+        BlackboardKey<int> liveKept = live.Register<int>("kept");
+
+        await using (MemoryStream strictStream = await SaveJson(_serializer, source))
+        {
+            Blackboard target = new(live);
+            Assert.That(() => _serializer.RestoreFromJsonAsync(target, strictStream).AsTask().GetAwaiter().GetResult(),
+                Throws.InvalidOperationException.With.Message.Contain("unknown key 'removed'"));
+        }
+
+        await using (MemoryStream skipStream = await SaveJson(_serializer, source))
+        {
+            Blackboard target = new(live);
+            await _serializer.RestoreFromJsonAsync(target, skipStream, BlackboardMismatchPolicy.Skip);
+            Assert.That(target.Get(liveKept), Is.EqualTo(5), "Known keys still restore under Skip.");
+        }
+    }
+
+    [Test]
+    public async Task changed_value_type_throws_strict_and_leaves_default_skip()
+    {
+        BlackboardSchema saved = NewSchema();
+        BlackboardKey<int> savedScore = saved.Register<int>("score");
+        Blackboard source = new(saved);
+        source.Set(savedScore, 9);
+
+        BlackboardSchema live = NewSchema();
+        BlackboardKey<string> liveScore = live.Register<string>("score", "default");
+
+        await using (MemoryStream strictStream = await SaveJson(_serializer, source))
+        {
+            Blackboard target = new(live);
+            Assert.That(() => _serializer.RestoreFromJsonAsync(target, strictStream).AsTask().GetAwaiter().GetResult(),
+                Throws.InvalidOperationException.With.Message.Contain("saved as").And.Message.Contain("score"));
+        }
+
+        await using (MemoryStream skipStream = await SaveJson(_serializer, source))
+        {
+            Blackboard target = new(live);
+            await _serializer.RestoreFromJsonAsync(target, skipStream, BlackboardMismatchPolicy.Skip);
+            Assert.That(target.Get(liveScore), Is.EqualTo("default"));
+        }
+    }
+
+    [Test]
+    public async Task schema_added_key_lands_on_default_under_both_policies()
+    {
+        BlackboardSchema saved = NewSchema();
+        BlackboardKey<int> old = saved.Register<int>("old");
+        Blackboard source = new(saved);
+        source.Set(old, 3);
+
+        BlackboardSchema live = NewSchema();
+        BlackboardKey<int> liveOld = live.Register<int>("old");
+        BlackboardKey<int> added = live.Register<int>("added", 77);
+
+        foreach (BlackboardMismatchPolicy policy in new[]
+                     { BlackboardMismatchPolicy.Strict, BlackboardMismatchPolicy.Skip })
+        {
+            await using MemoryStream stream = await SaveJson(_serializer, source);
+            Blackboard target = new(live);
+            await _serializer.RestoreFromJsonAsync(target, stream, policy);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(target.Get(liveOld), Is.EqualTo(3));
+                Assert.That(target.Get(added), Is.EqualTo(77),
+                    $"Keys added after the save keep their defaults ({policy}).");
+            });
+        }
+    }
+
+    [Test]
+    public async Task schema_name_or_scope_mismatch_throws_strict_and_no_ops_skip()
+    {
+        BlackboardSchema saved = new("world", BlackboardScope.Global);
+        BlackboardKey<int> savedKey = saved.Register<int>("value");
+        Blackboard source = new(saved);
+        source.Set(savedKey, 1);
+
+        // Same key layout, but Graph-scoped and differently named.
+        BlackboardSchema live = new("enemy");
+        BlackboardKey<int> liveKey = live.Register<int>("value", 100);
+
+        await using (MemoryStream strictStream = await SaveJson(_serializer, source))
+        {
+            Blackboard target = new(live);
+            Assert.That(() => _serializer.RestoreFromJsonAsync(target, strictStream).AsTask().GetAwaiter().GetResult(),
+                Throws.InvalidOperationException);
+        }
+
+        await using (MemoryStream skipStream = await SaveJson(_serializer, source))
+        {
+            Blackboard target = new(live);
+            target.Set(liveKey, 55);
+            await _serializer.RestoreFromJsonAsync(target, skipStream, BlackboardMismatchPolicy.Skip);
+            Assert.That(target.Get(liveKey), Is.EqualTo(55),
+                "A header mismatch under Skip must leave the target completely untouched.");
+        }
+    }
+
+    [Test]
+    public void newer_payload_version_is_rejected()
+    {
+        BlackboardSchema schema = NewSchema();
+        schema.Register<int>("x");
+        Blackboard target = new(schema);
+
+        const string json = """{"values":[],"schema":"stats","scope":1,"version":99}""";
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(json));
+
+        Assert.That(() => _serializer.RestoreFromJsonAsync(target, stream).AsTask().GetAwaiter().GetResult(),
+            Throws.InvalidOperationException.With.Message.Contain("version 99"));
+    }
+
+    // ── Three artifacts: graph + snapshot + boards ────────────────────────
+
+    private static class DurableKeys
+    {
+        public static readonly BlackboardSchema World = new("world", BlackboardScope.Global);
+        public static readonly BlackboardKey<int> TotalSteps = World.Register<int>("totalSteps");
+
+        public static readonly BlackboardSchema Flow = new("flow");
+        public static readonly BlackboardKey<int> Steps = Flow.Register<int>("steps");
+    }
+
+    private sealed class StepCountingState : AsyncState
+    {
+        protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+        {
+            Bb.GetRef(DurableKeys.Steps)++;
+            Bb.GetRef(DurableKeys.TotalSteps)++;
+            return ResultHelpers.Success;
+        }
+    }
+
+    private sealed class StepCountingCodec : ILogicTextCodec
+    {
+        public string Serialize(IAsyncLogic asyncLogic) => "step";
+
+        public IAsyncLogic Deserialize(string data) => new StepCountingState();
+    }
+
+    [Test]
+    public async Task three_artifact_durability_loop_restores_boards_and_resumes()
+    {
+        GraphSerializer graphSerializer = new(new StepCountingCodec());
+
+        Graph original = GraphBuilder
+            .StartWithAsync(new StepCountingState())
+            .ToAsync(new StepCountingState())
+            .ToAsync(new StepCountingState())
+            .WithSchema(DurableKeys.Flow)
+            .WithSchema(DurableKeys.World)
+            .Build();
+
+        Blackboard world = new(DurableKeys.World);
+        Blackboard flow = new(DurableKeys.Flow);
+
+        AsyncStateMachine running = original.ToAsyncStateMachine()
+            .WithBlackboard(world)
+            .WithBlackboard(flow);
+
+        Result first = await running.StepAsync();
+        Assert.That(first, Is.EqualTo(Result.InProgress));
+        StateMachineSnapshot snapshot = running.Suspend();
+
+        // Ship all artifacts: graph, snapshot, and one payload per board.
+        await using MemoryStream graphStream = new();
+        await graphSerializer.ToJsonAsync(original, graphStream);
+        string snapshotJson = JsonSerializer.Serialize(snapshot);
+        await using MemoryStream worldStream = await SaveJson(_serializer, world);
+        await using MemoryStream flowStream = await SaveJson(_serializer, flow);
+
+        // Rebuild on the "other side".
+        graphStream.Position = 0;
+        Graph rebuilt = await graphSerializer.FromJsonAsync(graphStream);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rebuilt.Schema, Is.Null,
+                "Schema declarations are code — the graph payload does not carry them (GraphDto unchanged).");
+            Assert.That(rebuilt.GlobalSchema, Is.Null);
+        });
+
+        Blackboard restoredWorld = new(DurableKeys.World);
+        Blackboard restoredFlow = new(DurableKeys.Flow);
+        await _serializer.RestoreFromJsonAsync(restoredWorld, worldStream);
+        await _serializer.RestoreFromJsonAsync(restoredFlow, flowStream);
+
+        StateMachineSnapshot restoredSnapshot = JsonSerializer.Deserialize<StateMachineSnapshot>(snapshotJson)!;
+
+        AsyncStateMachine resumed = rebuilt.ToAsyncStateMachine()
+            .WithBlackboard(restoredWorld) // permissive: rebuilt graph has no declarations
+            .WithBlackboard(restoredFlow);
+        resumed.Resume(restoredSnapshot);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await resumed.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(restoredFlow.Get(DurableKeys.Steps), Is.EqualTo(3),
+                "One step before the suspend plus two after the resume.");
+            Assert.That(restoredWorld.Get(DurableKeys.TotalSteps), Is.EqualTo(3));
+        });
+    }
+}

--- a/NxGraph.Serialization.Tests/BlackboardSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/BlackboardSerializationTests.cs
@@ -127,6 +127,71 @@ public class BlackboardSerializationTests
         });
     }
 
+    [Test]
+    public async Task generic_key_type_names_are_runtime_stable_and_round_trip()
+    {
+        // Regression: Type.FullName embeds the core-lib assembly version for constructed
+        // generics ("...List`1[[System.Int32, System.Private.CoreLib, Version=8.0.0.0, ...]]"),
+        // so a payload saved on one runtime failed Strict verification (or silently dropped
+        // values under Skip) after a runtime upgrade.
+        BlackboardSchema schema = NewSchema("inventory");
+        BlackboardKey<List<string>> items = schema.Register<List<string>>("items", []);
+        BlackboardKey<int?> optional = schema.Register<int?>("optional");
+
+        Blackboard source = new(schema);
+        source.Set(items, ["sword", "shield"]);
+        source.Set(optional, 5);
+
+        await using MemoryStream stream = await SaveJson(_serializer, source);
+        string payload = Encoding.UTF8.GetString(stream.ToArray());
+        stream.Position = 0;
+
+        Blackboard target = new(schema);
+        await _serializer.RestoreFromJsonAsync(target, stream);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(payload, Does.Not.Contain("Version="),
+                "Payload type names must not embed runtime assembly versions.");
+            Assert.That(target.Get(items), Is.EqualTo(new List<string> { "sword", "shield" }));
+            Assert.That(target.Get(optional), Is.EqualTo(5));
+        });
+    }
+
+    [Test]
+    public async Task strict_restore_failure_leaves_the_target_board_untouched()
+    {
+        // Regression: restore used to ResetToDefaults before validating entries, so a Strict
+        // mismatch part-way through destroyed the caller's pre-restore state (defaults +
+        // partial payload). Restore is now all-or-nothing.
+        BlackboardSchema savedSchema = NewSchema();
+        BlackboardKey<int> savedScore = savedSchema.Register<int>("score");
+        BlackboardKey<int> extra = savedSchema.Register<int>("renamed_key");
+
+        Blackboard source = new(savedSchema);
+        source.Set(savedScore, 42);
+        source.Set(extra, 7);
+        await using MemoryStream jsonStream = await SaveJson(_serializer, source);
+        await using MemoryStream binaryStream = await SaveBinary(_serializer, source);
+
+        // The live schema no longer declares "renamed_key" — Strict restore must throw.
+        BlackboardSchema liveSchema = NewSchema();
+        BlackboardKey<int> liveScore = liveSchema.Register<int>("score");
+
+        Blackboard target = new(liveSchema);
+        target.Set(liveScore, 1234); // live mid-run value that a failed restore must not destroy
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await _serializer.RestoreFromJsonAsync(target, jsonStream));
+        Assert.That(target.Get(liveScore), Is.EqualTo(1234),
+            "A failed JSON restore must leave the target unmodified.");
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await _serializer.RestoreFromBinaryAsync(target, binaryStream));
+        Assert.That(target.Get(liveScore), Is.EqualTo(1234),
+            "A failed binary restore must leave the target unmodified.");
+    }
+
     // ── Mismatch matrix ──────────────────────────────────────────────────
 
     [Test]

--- a/NxGraph.Serialization.Tests/GraphSerializerTestsBinaryCodec.cs
+++ b/NxGraph.Serialization.Tests/GraphSerializerTestsBinaryCodec.cs
@@ -1,4 +1,5 @@
 ﻿using NxGraph.Authoring;
+using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
 
 namespace NxGraph.Serialization.Tests;
@@ -47,5 +48,32 @@ public class GraphSerializerTestsBinaryCodec
         s1.Position = 0;
         await _serializer.FromBinaryAsync(s1);
         Assert.DoesNotThrow(() => s1.WriteByte(0x01)); // still open
+    }
+
+    [Test]
+    public async Task Binary_codec_roundtrips_a_graph_with_a_subgraph()
+    {
+        // Regression: the nested-machine marker is written as a text node regardless of the
+        // configured codec, but the read side used to throw "no ILogicCodec<string>" before
+        // reaching the marker check — so a binary-codec serializer could write subgraph
+        // payloads it could not read back.
+        Graph child = GraphBuilder.StartWithAsync(new DummyState { Data = "child" }).Build();
+        Graph parent = GraphBuilder
+            .StartWithAsync(new DummyState { Data = "parent" })
+            .SubGraph(child)
+            .Build();
+
+        await using MemoryStream ms = new();
+        await _serializer.ToBinaryAsync(parent, ms);
+        ms.Position = 0;
+
+        Graph roundTripped = await _serializer.FromBinaryAsync(ms);
+        LogicNode owner = (LogicNode)roundTripped.GetNodeByIndex(1);
+        Assert.Multiple(() =>
+        {
+            Assert.That(roundTripped.NodeCount, Is.EqualTo(2));
+            Assert.That(owner.AsyncLogic, Is.InstanceOf<AsyncStateMachine>());
+            Assert.That(((AsyncStateMachine)owner.AsyncLogic).Graph.NodeCount, Is.EqualTo(1));
+        });
     }
 }

--- a/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
+++ b/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
@@ -196,4 +196,37 @@ public class GraphSerializerTestsTextCodec
         await _serializer.FromJsonAsync(s1);
         Assert.DoesNotThrow(() => s1.WriteByte(0x21)); // still open
     }
+
+    private sealed class RawStringCodec : ILogicTextCodec
+    {
+        public IAsyncLogic Deserialize(string s) => new DummyState { Data = s };
+        public string Serialize(IAsyncLogic data) => ((DummyState)data).Data;
+    }
+
+    [Test]
+    public async Task Logic_payload_equal_to_the_marker_string_is_not_misread_as_a_subgraph()
+    {
+        // Regression: subgraph owners were detected purely by comparing the node's logic
+        // string against the marker, so a codec legitimately emitting that string for
+        // ordinary logic produced an unreadable payload ("marked as a StateMachine but has
+        // no associated subgraph"). The marker is now honored only when a subgraph payload
+        // actually claims the node index.
+        GraphSerializer serializer = new(new RawStringCodec());
+        Graph graph = GraphBuilder
+            .StartWithAsync(new DummyState { Data = "Default" })
+            .ToAsync(new DummyState { Data = "StateMachine" })
+            .Build();
+
+        await using MemoryStream stream = new();
+        await serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+
+        Graph roundTripped = await serializer.FromJsonAsync(stream);
+        Assert.Multiple(() =>
+        {
+            Assert.That(((DummyState)((LogicNode)roundTripped.StartNode).AsyncLogic).Data, Is.EqualTo("Default"));
+            Assert.That(((DummyState)((LogicNode)roundTripped.GetNodeByIndex(1)).AsyncLogic).Data,
+                Is.EqualTo("StateMachine"));
+        });
+    }
 }

--- a/NxGraph.Serialization.Tests/NxGraph.Serialization.Tests.csproj
+++ b/NxGraph.Serialization.Tests/NxGraph.Serialization.Tests.csproj
@@ -22,7 +22,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="MessagePack" Version="3.1.4" />
+        <PackageReference Include="MessagePack" Version="3.1.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="NUnit" Version="3.14.0"/>
         <PackageReference Include="NUnit.Analyzers" Version="3.9.0"/>

--- a/NxGraph.Serialization/BlackboardDto.cs
+++ b/NxGraph.Serialization/BlackboardDto.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+
+namespace NxGraph.Serialization;
+
+/// <summary>One slot value: key name, value-type full name (verification only), and the value.</summary>
+internal sealed record BlackboardEntryDto(string Key, string Type, JsonElement Value);
+
+/// <summary>
+/// JSON payload shape for one <see cref="NxGraph.Blackboards.Blackboard"/>. Independent of
+/// <see cref="GraphDto"/> — the blackboard is its own durability artifact with its own
+/// payload version.
+/// </summary>
+internal sealed record BlackboardDto(BlackboardEntryDto[] Values, string? Schema, int Scope)
+{
+    public int Version { get; init; } = BlackboardSerializer.PayloadVersion;
+}

--- a/NxGraph.Serialization/BlackboardSerializer.cs
+++ b/NxGraph.Serialization/BlackboardSerializer.cs
@@ -1,0 +1,311 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using MessagePack;
+using NxGraph.Blackboards;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// Serializes a single <see cref="Blackboard"/> to JSON or MessagePack as an independent
+/// durability artifact: a saved flow is (graph payload, machine snapshot, one payload per
+/// bound board). Each scope's board serializes separately — a global board once per world,
+/// graph boards per entity.
+/// <para>
+/// Values are written per key via the schema's <see cref="BlackboardKeyDescriptor"/>s
+/// (boxing is fine off the hot path). Custom value types plug in through the
+/// caller-supplied <see cref="JsonSerializerOptions"/> / <see cref="MessagePackSerializerOptions"/>.
+/// </para>
+/// <para>
+/// Restore is restore-into: the schema is code and cannot be reconstructed from a payload,
+/// so the caller supplies a live board and the payload is applied over its defaults —
+/// post-state is always defaults + payload. The payload's type names are verification data
+/// only; they are never used to resolve a type.
+/// </para>
+/// </summary>
+public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboardBinarySerializer
+{
+    internal const int PayloadVersion = 1; // independent of SerializationVersion.Version (graph payloads)
+
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly MessagePackSerializerOptions _binaryOptions;
+
+    public BlackboardSerializer(JsonSerializerOptions? jsonOptions = null,
+        MessagePackSerializerOptions? binaryOptions = null)
+    {
+        _jsonOptions = jsonOptions ?? new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true
+        };
+        // UntrustedData hardening, matching GraphSerializer — blackboard payloads cross the
+        // same disk/network trust boundaries.
+        _binaryOptions = binaryOptions ?? MessagePackSerializerOptions.Standard
+            .WithSecurity(MessagePackSecurity.UntrustedData);
+    }
+
+    // ── JSON ────────────────────────────────────────────────────────────
+
+    public async ValueTask ToJsonAsync(Blackboard blackboard, Stream destination, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(blackboard);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        IReadOnlyList<BlackboardKeyDescriptor> keys = blackboard.Schema.Keys;
+        BlackboardEntryDto[] entries = new BlackboardEntryDto[keys.Count];
+        for (int i = 0; i < keys.Count; i++)
+        {
+            BlackboardKeyDescriptor descriptor = keys[i];
+            JsonElement value = JsonSerializer.SerializeToElement(
+                descriptor.GetValue(blackboard), descriptor.ValueType, _jsonOptions);
+            entries[i] = new BlackboardEntryDto(descriptor.Name, descriptor.ValueType.FullName!, value);
+        }
+
+        BlackboardDto dto = new(entries, blackboard.Schema.Name, (int)blackboard.Schema.Scope);
+
+        await using StreamWriter writer = new(destination, new UTF8Encoding(false), leaveOpen: true);
+        string json = JsonSerializer.Serialize(dto, _jsonOptions);
+        await writer.WriteAsync(json.AsMemory(), ct).ConfigureAwait(false);
+        await writer.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    public async ValueTask RestoreFromJsonAsync(Blackboard target, Stream source,
+        BlackboardMismatchPolicy policy = BlackboardMismatchPolicy.Strict, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(source);
+
+        using StreamReader reader = new(source, Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true);
+        string json = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+
+        BlackboardDto dto = JsonSerializer.Deserialize<BlackboardDto>(json, _jsonOptions) ??
+                            throw new InvalidOperationException("Failed to parse Blackboard JSON.");
+
+        if (dto.Version > PayloadVersion)
+        {
+            throw new InvalidOperationException(
+                $"BlackboardDto: payload version {dto.Version} is newer than serializer version {PayloadVersion}.");
+        }
+
+        if (!HeaderMatches(target, dto.Schema, dto.Scope, policy))
+        {
+            return; // Skip policy: header mismatch — leave the target untouched.
+        }
+
+        // Deterministic post-state: defaults + payload. Keys absent from the payload land on
+        // their registered defaults (schema evolution), and stale pre-restore values never leak.
+        target.ResetToDefaults();
+
+        foreach (BlackboardEntryDto entry in dto.Values)
+        {
+            if (!TryMatchEntry(target, entry.Key, entry.Type, policy, out BlackboardKeyDescriptor? descriptor))
+            {
+                continue;
+            }
+
+            object? value;
+            try
+            {
+                value = entry.Value.Deserialize(descriptor!.ValueType, _jsonOptions);
+            }
+            catch (Exception ex)
+            {
+                // Corrupt values throw under both policies — Skip is for schema evolution.
+                throw new InvalidOperationException(
+                    $"Failed to deserialize blackboard key '{entry.Key}' as {descriptor!.ValueType}.", ex);
+            }
+
+            descriptor.SetValue(target, value);
+        }
+    }
+
+    // ── MessagePack ─────────────────────────────────────────────────────
+    // Wire shape (hand-written, GraphDtoFormatter style):
+    //   [Version, SchemaName, Scope, Entries[]] — each entry [key, typeFullName, value].
+    // Extra elements in either array are skipped on read (forward compatibility).
+
+    public async ValueTask ToBinaryAsync(Blackboard blackboard, Stream destination, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(blackboard);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        // MessagePackWriter is a ref struct and cannot live in an async method.
+        ArrayBufferWriter<byte> buffer = new();
+        WriteToBuffer(blackboard, buffer);
+
+        await destination.WriteAsync(buffer.WrittenMemory, ct).ConfigureAwait(false);
+        await destination.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    private void WriteToBuffer(Blackboard blackboard, ArrayBufferWriter<byte> buffer)
+    {
+        MessagePackWriter writer = new(buffer);
+
+        writer.WriteArrayHeader(4);
+        writer.Write(PayloadVersion);
+        writer.Write(blackboard.Schema.Name);
+        writer.Write((int)blackboard.Schema.Scope);
+
+        IReadOnlyList<BlackboardKeyDescriptor> keys = blackboard.Schema.Keys;
+        writer.WriteArrayHeader(keys.Count);
+        foreach (BlackboardKeyDescriptor descriptor in keys)
+        {
+            writer.WriteArrayHeader(3);
+            writer.Write(descriptor.Name);
+            writer.Write(descriptor.ValueType.FullName);
+            MessagePackSerializer.Serialize(descriptor.ValueType, ref writer,
+                descriptor.GetValue(blackboard), _binaryOptions);
+        }
+
+        writer.Flush();
+    }
+
+    public async ValueTask RestoreFromBinaryAsync(Blackboard target, Stream source,
+        BlackboardMismatchPolicy policy = BlackboardMismatchPolicy.Strict, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(source);
+
+        using MemoryStream buffered = new();
+        await source.CopyToAsync(buffered, ct).ConfigureAwait(false);
+
+        RestoreFromBuffer(target, buffered.GetBuffer().AsMemory(0, (int)buffered.Length), policy);
+    }
+
+    private void RestoreFromBuffer(Blackboard target, ReadOnlyMemory<byte> payload, BlackboardMismatchPolicy policy)
+    {
+        MessagePackReader reader = new(payload);
+
+        int headerCount = reader.ReadArrayHeader();
+        if (headerCount < 4)
+        {
+            throw new InvalidOperationException(
+                $"BlackboardDto: expected at least 4 header elements, found {headerCount}.");
+        }
+
+        int version = reader.ReadInt32();
+        if (version > PayloadVersion)
+        {
+            throw new InvalidOperationException(
+                $"BlackboardDto: payload version {version} is newer than serializer version {PayloadVersion}.");
+        }
+
+        string? schemaName = reader.ReadString();
+        int scope = reader.ReadInt32();
+
+        if (!HeaderMatches(target, schemaName, scope, policy))
+        {
+            return; // Skip policy: header mismatch — leave the target untouched.
+        }
+
+        target.ResetToDefaults();
+
+        int entryCount = reader.ReadArrayHeader();
+        for (int i = 0; i < entryCount; i++)
+        {
+            int entryLength = reader.ReadArrayHeader();
+            if (entryLength < 3)
+            {
+                throw new InvalidOperationException(
+                    $"BlackboardDto: entry {i} has {entryLength} elements, expected at least 3.");
+            }
+
+            string key = reader.ReadString() ??
+                         throw new InvalidOperationException($"BlackboardDto: entry {i} has a null key.");
+            string? typeName = reader.ReadString();
+
+            if (!TryMatchEntry(target, key, typeName, policy, out BlackboardKeyDescriptor? descriptor))
+            {
+                reader.Skip(); // skip the unread value
+            }
+            else
+            {
+                object? value;
+                try
+                {
+                    value = MessagePackSerializer.Deserialize(descriptor!.ValueType, ref reader, _binaryOptions);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to deserialize blackboard key '{key}' as {descriptor!.ValueType}.", ex);
+                }
+
+                descriptor.SetValue(target, value);
+            }
+
+            for (int extra = 3; extra < entryLength; extra++)
+            {
+                reader.Skip(); // forward compatibility: ignore future per-entry elements
+            }
+        }
+
+        for (int extra = 4; extra < headerCount; extra++)
+        {
+            reader.Skip(); // forward compatibility: ignore future header elements
+        }
+    }
+
+    // ── Shared policy checks ────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies the payload header against the live schema. Returns <see langword="false"/>
+    /// to skip the whole restore (Skip policy); throws under Strict.
+    /// </summary>
+    private static bool HeaderMatches(Blackboard target, string? payloadSchemaName, int payloadScope,
+        BlackboardMismatchPolicy policy)
+    {
+        bool nameMismatch = payloadSchemaName is not null && target.Schema.Name is not null &&
+                            !string.Equals(payloadSchemaName, target.Schema.Name, StringComparison.Ordinal);
+        bool scopeMismatch = payloadScope != (int)target.Schema.Scope;
+
+        if (!nameMismatch && !scopeMismatch)
+        {
+            return true;
+        }
+
+        if (policy == BlackboardMismatchPolicy.Strict)
+        {
+            throw new InvalidOperationException(nameMismatch
+                ? $"Blackboard payload was saved from schema '{payloadSchemaName}' but the target uses " +
+                  $"schema '{target.Schema.Name}'."
+                : $"Blackboard payload scope {(BlackboardScope)payloadScope} does not match the target " +
+                  $"schema scope {target.Schema.Scope}.");
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Matches one payload entry to a live slot. Unknown keys and changed value types throw
+    /// under Strict and are skipped under Skip. The payload type name only verifies — the
+    /// schema dictates the deserialization target, so payloads cannot inject types.
+    /// </summary>
+    private static bool TryMatchEntry(Blackboard target, string key, string? payloadTypeName,
+        BlackboardMismatchPolicy policy, out BlackboardKeyDescriptor? descriptor)
+    {
+        if (!target.Schema.TryGetKey(key, out BlackboardKeyDescriptor found))
+        {
+            descriptor = null;
+            return policy == BlackboardMismatchPolicy.Strict
+                ? throw new InvalidOperationException(
+                    $"Blackboard payload contains unknown key '{key}' (schema '{target.Schema.Name ?? "<unnamed>"}').")
+                : false;
+        }
+
+        if (!string.Equals(payloadTypeName, found.ValueType.FullName, StringComparison.Ordinal))
+        {
+            descriptor = null;
+            return policy == BlackboardMismatchPolicy.Strict
+                ? throw new InvalidOperationException(
+                    $"Blackboard key '{key}' was saved as '{payloadTypeName}' but the schema now declares " +
+                    $"'{found.ValueType.FullName}'.")
+                : false;
+        }
+
+        descriptor = found;
+        return true;
+    }
+}

--- a/NxGraph.Serialization/BlackboardSerializer.cs
+++ b/NxGraph.Serialization/BlackboardSerializer.cs
@@ -59,7 +59,7 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
             BlackboardKeyDescriptor descriptor = keys[i];
             JsonElement value = JsonSerializer.SerializeToElement(
                 descriptor.GetValue(blackboard), descriptor.ValueType, _jsonOptions);
-            entries[i] = new BlackboardEntryDto(descriptor.Name, descriptor.ValueType.FullName!, value);
+            entries[i] = new BlackboardEntryDto(descriptor.Name, StableTypeName(descriptor.ValueType), value);
         }
 
         BlackboardDto dto = new(entries, blackboard.Schema.Name, (int)blackboard.Schema.Scope);
@@ -83,6 +83,13 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
         BlackboardDto dto = JsonSerializer.Deserialize<BlackboardDto>(json, _jsonOptions) ??
                             throw new InvalidOperationException("Failed to parse Blackboard JSON.");
 
+        // Records don't enforce non-nullable reference properties during deserialization;
+        // a payload missing "values" would otherwise surface as a NullReferenceException.
+        if (dto.Values is null)
+        {
+            throw new InvalidOperationException("Failed to parse Blackboard JSON.");
+        }
+
         if (dto.Version > PayloadVersion)
         {
             throw new InvalidOperationException(
@@ -94,12 +101,17 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
             return; // Skip policy: header mismatch — leave the target untouched.
         }
 
-        // Deterministic post-state: defaults + payload. Keys absent from the payload land on
-        // their registered defaults (schema evolution), and stale pre-restore values never leak.
-        target.ResetToDefaults();
-
+        // Two-phase restore: match and deserialize every entry before touching the board, so
+        // a Strict mismatch or corrupt value part-way through leaves the target unmodified —
+        // the documented post-state ("defaults + payload") holds even on the failure path.
+        List<(BlackboardKeyDescriptor Descriptor, object? Value)> staged = new(dto.Values.Length);
         foreach (BlackboardEntryDto entry in dto.Values)
         {
+            if (entry.Key is null)
+            {
+                throw new InvalidOperationException("Failed to parse Blackboard JSON.");
+            }
+
             if (!TryMatchEntry(target, entry.Key, entry.Type, policy, out BlackboardKeyDescriptor? descriptor))
             {
                 continue;
@@ -117,6 +129,14 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
                     $"Failed to deserialize blackboard key '{entry.Key}' as {descriptor!.ValueType}.", ex);
             }
 
+            staged.Add((descriptor!, value));
+        }
+
+        // Deterministic post-state: defaults + payload. Keys absent from the payload land on
+        // their registered defaults (schema evolution), and stale pre-restore values never leak.
+        target.ResetToDefaults();
+        foreach ((BlackboardKeyDescriptor descriptor, object? value) in staged)
+        {
             descriptor.SetValue(target, value);
         }
     }
@@ -154,7 +174,7 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
         {
             writer.WriteArrayHeader(3);
             writer.Write(descriptor.Name);
-            writer.Write(descriptor.ValueType.FullName);
+            writer.Write(StableTypeName(descriptor.ValueType));
             MessagePackSerializer.Serialize(descriptor.ValueType, ref writer,
                 descriptor.GetValue(blackboard), _binaryOptions);
         }
@@ -200,9 +220,10 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
             return; // Skip policy: header mismatch — leave the target untouched.
         }
 
-        target.ResetToDefaults();
-
+        // Two-phase restore, matching the JSON path: fully parse and stage every entry before
+        // mutating the board, so a mid-payload failure leaves the target unmodified.
         int entryCount = reader.ReadArrayHeader();
+        List<(BlackboardKeyDescriptor Descriptor, object? Value)> staged = new(entryCount);
         for (int i = 0; i < entryCount; i++)
         {
             int entryLength = reader.ReadArrayHeader();
@@ -233,7 +254,7 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
                         $"Failed to deserialize blackboard key '{key}' as {descriptor!.ValueType}.", ex);
                 }
 
-                descriptor.SetValue(target, value);
+                staged.Add((descriptor!, value));
             }
 
             for (int extra = 3; extra < entryLength; extra++)
@@ -245,6 +266,12 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
         for (int extra = 4; extra < headerCount; extra++)
         {
             reader.Skip(); // forward compatibility: ignore future header elements
+        }
+
+        target.ResetToDefaults();
+        foreach ((BlackboardKeyDescriptor descriptor, object? value) in staged)
+        {
+            descriptor.SetValue(target, value);
         }
     }
 
@@ -295,17 +322,55 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
                 : false;
         }
 
-        if (!string.Equals(payloadTypeName, found.ValueType.FullName, StringComparison.Ordinal))
+        // Match against the version-agnostic name; also accept the raw FullName for payloads
+        // written before the stable-name fix (FullName embeds core-lib assembly versions for
+        // constructed generics, so it breaks across runtime upgrades).
+        if (!string.Equals(payloadTypeName, StableTypeName(found.ValueType), StringComparison.Ordinal) &&
+            !string.Equals(payloadTypeName, found.ValueType.FullName, StringComparison.Ordinal))
         {
             descriptor = null;
             return policy == BlackboardMismatchPolicy.Strict
                 ? throw new InvalidOperationException(
                     $"Blackboard key '{key}' was saved as '{payloadTypeName}' but the schema now declares " +
-                    $"'{found.ValueType.FullName}'.")
+                    $"'{StableTypeName(found.ValueType)}'.")
                 : false;
         }
 
         descriptor = found;
         return true;
+    }
+
+    /// <summary>
+    /// Renders a runtime-stable type name for payload verification. <see cref="Type.FullName"/>
+    /// embeds assembly-qualified argument names (including core-lib version) for constructed
+    /// generics — e.g. <c>List`1[[System.Int32, System.Private.CoreLib, Version=8.0.0.0, ...]]</c> —
+    /// which breaks Strict restores (and silently drops values under Skip) after a runtime
+    /// upgrade. This renders <c>System.Collections.Generic.List`1[System.Int32]</c> instead.
+    /// </summary>
+    internal static string StableTypeName(Type type)
+    {
+        if (type.IsArray)
+        {
+            int rank = type.GetArrayRank();
+            return StableTypeName(type.GetElementType()!) + (rank == 1 ? "[]" : $"[{new string(',', rank - 1)}]");
+        }
+
+        if (!type.IsConstructedGenericType)
+        {
+            return type.FullName ?? type.Name;
+        }
+
+        Type definition = type.GetGenericTypeDefinition();
+        Type[] arguments = type.GetGenericArguments();
+        StringBuilder sb = new(definition.FullName ?? definition.Name);
+        sb.Append('[');
+        for (int i = 0; i < arguments.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append(StableTypeName(arguments[i]));
+        }
+
+        sb.Append(']');
+        return sb.ToString();
     }
 }

--- a/NxGraph.Serialization/Docs/readme.md
+++ b/NxGraph.Serialization/Docs/readme.md
@@ -1,3 +1,28 @@
 # NxGraph.Serialization
 
 This project provides serialization and deserialization functionalities for [NxGraph](https://github.com/Enzx/NxGraph) objects, allowing you to easily save and load graph structures.
+
+## Blackboard payloads
+
+A durable flow is shipped as separate artifacts, each with its own lifecycle:
+
+1. **Graph structure** — `GraphSerializer.ToJsonAsync`/`ToBinaryAsync` (node logic encoded via your `ILogicCodec`).
+2. **Machine position** — `StateMachineSnapshot`, a primitives-only record you serialize with any serializer.
+3. **One payload per blackboard** — `BlackboardSerializer.ToJsonAsync`/`ToBinaryAsync`; a global board saves once per world, graph boards per entity.
+
+Restore is *restore-into*: schemas are code and cannot be reconstructed from a payload, so you create a live `Blackboard` over the current schema and apply the payload over its defaults (`RestoreFromJsonAsync`/`RestoreFromBinaryAsync`). Post-state is always defaults + payload — keys added to the schema after the save keep their defaults, and stale pre-restore values never survive.
+
+Schema drift is handled by `BlackboardMismatchPolicy`:
+
+| Payload vs live schema | `Strict` (default) | `Skip` |
+| --- | --- | --- |
+| Schema name or scope differs | throws | whole restore is a no-op |
+| Payload key unknown to the schema | throws | entry ignored |
+| Key's value type changed | throws | entry ignored (slot keeps its default) |
+| Key missing from the payload | default | default |
+| Corrupt/undeserializable value | throws | throws (Skip is for schema evolution, not corruption) |
+| Payload version newer than the serializer | throws | throws |
+
+Custom value types plug in through the constructor options — supply `JsonSerializerOptions` converters and/or a `MessagePackSerializerOptions` resolver (e.g. `ContractlessStandardResolver`). Payload type names are verification data only and are never used to resolve a type.
+
+Note: graph payloads do **not** carry blackboard schema declarations (`GraphDto` is unchanged) — a deserialized `Graph` has `Schema == null` and binds boards permissively; the per-key schema check in `Blackboard` remains the runtime safety net.

--- a/NxGraph.Serialization/GraphDtoFormatter.cs
+++ b/NxGraph.Serialization/GraphDtoFormatter.cs
@@ -31,6 +31,12 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
 
     public override GraphDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
     {
+        // Depth accounting: GraphDto → SubGraphDto → GraphDto recursion is driven purely by
+        // payload content. Without DepthStep a crafted payload nesting thousands of subgraph
+        // levels overflows the stack (uncatchable) before GraphSerializer's own MaxSubGraphDepth
+        // check — which only runs after the DTO tree is fully materialized.
+        options.Security.DepthStep(ref reader);
+
         int count = reader.ReadArrayHeader();
 
         int version = reader.ReadInt32();
@@ -67,6 +73,8 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
             outcomeNames = options.Resolver.GetFormatterWithVerify<OutcomeNameDto[]>()
                 .Deserialize(ref reader, options);
         }
+
+        reader.Depth--;
 
         return new GraphDto(nodes, transitions, subGraphs, index, name, retryPolicies, outcomeCodes, outcomeNames)
             { Version = version };

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -17,6 +17,10 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
     // the cap an attacker can stack-overflow the deserializer with a deeply nested payload.
     internal const int MaxSubGraphDepth = 64;
 
+    // Pre-fix payloads wrote the nested-machine marker as "Default" (LogicNode.StateMachineMarker
+    // was constructed with NodeId.Default). Still accepted on read for back compatibility.
+    private const string LegacyStateMachineMarkerName = "Default";
+
     private readonly ILogicCodec _codec;
     private readonly MessagePackSerializerOptions _options;
 
@@ -173,6 +177,19 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                         break;
                     }
 
+                    // Other composites (history states, parallel states, custom containers)
+                    // carry child graphs a user codec structurally cannot serialize — only
+                    // GraphSerializer can recurse into them, and it doesn't yet. Fail with a
+                    // targeted error instead of handing the composite to the codec, which
+                    // would either throw an opaque cast error or silently drop the children.
+                    if (logicNode.AsyncLogic is ISubGraphProvider || logicNode.Logic is ISubGraphProvider)
+                    {
+                        throw new NotSupportedException(
+                            $"Node '{node.Id}' holds composite logic '{logicNode.AsyncLogic.GetType().Name}' " +
+                            "which is not serializable. Only plain nested state machines " +
+                            "(.SubGraph(child) without history) are supported by GraphSerializer.");
+                    }
+
                     // Unwrap SyncLogicAdapter so the codec receives the actual IAsyncLogic/ILogic,
                     // not the adapter wrapper. If the inner ILogic also implements IAsyncLogic, use it.
                     IAsyncLogic logicForCodec = logicNode.AsyncLogic;
@@ -189,12 +206,12 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                         _ => throw new InvalidOperationException("No ILogicCodec configured in GraphSerializer.")
                     };
                     break;
-                case Graph childGraph:
-                {
-                    GraphDto childDto = ToDto(childGraph, depth + 1);
-                    subGraphs.Add(new SubGraphDto(index, childDto));
-                    break;
-                }
+                default:
+                    // Raw Graph-as-node never comes out of GraphBuilder (it always wraps in
+                    // LogicNode); the old branch here emitted a SubGraphDto while leaving a
+                    // null slot in Nodes[], producing an unreadable payload.
+                    throw new NotSupportedException(
+                        $"Node at index {index} of type '{node.GetType().Name}' is not serializable.");
             }
         }
 
@@ -259,11 +276,28 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                 $"Subgraph nesting exceeded MaxSubGraphDepth ({MaxSubGraphDepth}) while deserializing.");
         }
 
+        // Version-gate every nesting level (the JSON entry point only checks the root DTO;
+        // the MessagePack formatter checks per-graph — this makes both formats consistent).
+        if (dto.Version > SerializationVersion.Version)
+        {
+            throw new InvalidOperationException(
+                $"GraphDto: payload version {dto.Version} is newer than serializer version {SerializationVersion.Version}.");
+        }
+
         int nodesLength = dto.Nodes.Length;
         if (nodesLength == 0) throw new InvalidOperationException("GraphDto must contain at least one node.");
 
         var binaryCodec = _codec as ILogicCodec<ReadOnlyMemory<byte>>;
         var textCodec = _codec as ILogicCodec<string>;
+
+        // Owner indices of subgraph payloads, resolved up front: a node is only treated as a
+        // nested-machine marker when a SubGraphDto actually claims it. This kills the in-band
+        // collision where a codec legitimately emits the marker string for ordinary logic.
+        HashSet<int>? subGraphOwners = null;
+        foreach (SubGraphDto subDto in dto.SubGraphs)
+        {
+            (subGraphOwners ??= []).Add(subDto.OwnerIndex);
+        }
 
         INode[] nodes = new INode[nodesLength];
         bool[] slotFilled = new bool[nodesLength];
@@ -280,16 +314,22 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             switch (nodeDto)
             {
                 case NodeTextDto textDto:
-                    if (textCodec is null)
-                        throw new InvalidOperationException(
-                            "GraphSerializer has no ILogicCodec<string> configured, cannot decode text nodes.");
-
-                    if (textDto.Logic == LogicNode.StateMachineMarker.Id.Name)
+                    // Marker check runs before the codec guard: the marker needs no codec, so a
+                    // binary-codec serializer can read back the subgraph payloads it wrote.
+                    // "Default" is the legacy marker string (pre-fix payloads); both are only
+                    // honored when a subgraph payload actually claims this node index.
+                    if ((textDto.Logic == LogicNode.StateMachineMarker.Id.Name ||
+                         textDto.Logic == LegacyStateMachineMarkerName) &&
+                        subGraphOwners is not null && subGraphOwners.Contains(nodeDto.Index))
                     {
                         // Keep a marker; we'll replace it after we rebuild subgraphs.
                         nodes[nodeDto.Index] = LogicNode.StateMachineMarker;
                         break;
                     }
+
+                    if (textCodec is null)
+                        throw new InvalidOperationException(
+                            "GraphSerializer has no ILogicCodec<string> configured, cannot decode text nodes.");
 
                 {
                     IAsyncLogic asyncLogic = textCodec.Deserialize(textDto.Logic);
@@ -333,15 +373,16 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                 throw new InvalidOperationException(
                     $"Subgraph DTO owner index {subDto.OwnerIndex} is out of range (0..{nodesLength - 1}).");
 
+            // A subgraph may only attach to a marker node. The old fallback installed the raw
+            // child Graph as the node itself — with the child graph's own (negative) NodeId —
+            // silently corrupting transition routing; a crafted payload could also use it to
+            // swap decoded logic for a nested machine.
+            if (nodes[subDto.OwnerIndex] != LogicNode.StateMachineMarker)
+                throw new InvalidOperationException(
+                    $"Subgraph DTO owner index {subDto.OwnerIndex} does not reference a state-machine marker node.");
+
             Graph childGraph = FromDto(subDto.Graph, depth + 1);
-            if (nodes[subDto.OwnerIndex] == LogicNode.StateMachineMarker)
-            {
-                ownerToSubGraph[subDto.OwnerIndex] = childGraph;
-            }
-            else
-            {
-                nodes[subDto.OwnerIndex] = childGraph;
-            }
+            ownerToSubGraph[subDto.OwnerIndex] = childGraph;
         }
 
         for (int i = 0; i < nodesLength; i++)

--- a/NxGraph.Serialization/NxGraph.Serialization.csproj
+++ b/NxGraph.Serialization/NxGraph.Serialization.csproj
@@ -4,20 +4,23 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Description>NxGraph Serialization (Json and Binary)</Description>
-        <Copyright>Moe Iraji</Copyright>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <Title>NxGraph.Serialization</Title>
+        <Authors>Moe Iraji</Authors>
+        <Description>JSON and MessagePack serialization for NxGraph: durable graph payloads, state-machine snapshots, and blackboard payloads with pluggable node-logic codecs.</Description>
         <PackageProjectUrl>https://github.com/Enzx/NxGraph</PackageProjectUrl>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/Enzx/NxGraph</RepositoryUrl>
-        <PackageTags>Statemachine, FSM, Serialization</PackageTags>
+        <PackageTags>statemachine fsm serialization messagepack json durability</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>Docs/readme.md</PackageReadmeFile>
 
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MessagePack" Version="3.1.4" />
+      <PackageReference Include="MessagePack" Version="3.1.7" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -239,6 +239,39 @@ public class AllocationGateTests
         await AssertZeroAllocAsync(parent.ToAsyncStateMachine());
     }
 
+    private static StateToken SyncChain(int length)
+    {
+        StateToken token = GraphBuilder.StartWith(() => Result.Success);
+        for (int i = 1; i < length; i++)
+        {
+            token = token.To(() => Result.Success);
+        }
+
+        return token;
+    }
+
+    [Test]
+    public void sync_parallel_regions_run_to_join_are_allocation_free()
+    {
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RunToJoin, SyncChain(3).Build(), SyncChain(2).Build())
+            .Build();
+
+        AssertZeroAlloc(parent.ToStateMachine());
+    }
+
+    [Test]
+    public void sync_parallel_regions_round_per_tick_are_allocation_free()
+    {
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick, SyncChain(3).Build(), SyncChain(2).Build())
+            .Build();
+
+        AssertZeroAlloc(parent.ToStateMachine());
+    }
+
     // ── Blackboards: dual-scope routing on the hot path ─────────────────
 
     private sealed class GateAgent

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -1,4 +1,5 @@
 using NxGraph.Authoring;
+using NxGraph.Blackboards;
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
@@ -236,6 +237,154 @@ public class AllocationGateTests
             .Build();
 
         await AssertZeroAllocAsync(parent.ToAsyncStateMachine());
+    }
+
+    // ── Blackboards: dual-scope routing on the hot path ─────────────────
+
+    private sealed class GateAgent
+    {
+        public int Runs;
+    }
+
+    private static (Blackboard world, Blackboard local,
+        BlackboardKey<bool> alarm, BlackboardKey<int> sightings, BlackboardKey<int> speed)
+        DualScopeBoards()
+    {
+        BlackboardSchema worldSchema = new("world", BlackboardScope.Global);
+        BlackboardKey<bool> alarm = worldSchema.Register<bool>("alarm");
+        BlackboardKey<int> sightings = worldSchema.Register<int>("sightings");
+
+        BlackboardSchema enemySchema = new("enemy");
+        BlackboardKey<int> speed = enemySchema.Register<int>("speed", 1);
+
+        return (new Blackboard(worldSchema), new Blackboard(enemySchema), alarm, sightings, speed);
+    }
+
+    [Test]
+    public async Task async_dual_scope_blackboard_produce_consume_is_allocation_free()
+    {
+        (Blackboard world, Blackboard local,
+            BlackboardKey<bool> alarm, BlackboardKey<int> sightings, BlackboardKey<int> speed) = DualScopeBoards();
+
+        Graph graph = GraphBuilder
+            .StartWithAsync(new AsyncRelayState<GateAgent>((agent, bb, _) =>
+            {
+                agent.Runs++;
+                bb.Set(speed, bb.Get(alarm) ? 5 : 2); // global read → graph write
+                return ResultHelpers.Success;
+            }))
+            .ToAsync<GateAgent>((agent, bb, _) =>
+            {
+                if (bb.Get(speed) > agent.Runs)
+                {
+                    bb.GetRef(sightings)++; // graph read → global write
+                }
+
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        AsyncStateMachine<GateAgent> machine = graph.ToAsyncStateMachine<GateAgent>()
+            .WithBlackboard(world)
+            .WithBlackboard(local)
+            .WithAgent(new GateAgent());
+
+        await AssertZeroAllocAsync(machine);
+    }
+
+    [Test]
+    public void sync_dual_scope_blackboard_produce_consume_is_allocation_free()
+    {
+        (Blackboard world, Blackboard local,
+            BlackboardKey<bool> alarm, BlackboardKey<int> sightings, BlackboardKey<int> speed) = DualScopeBoards();
+
+        Graph graph = GraphBuilder
+            .StartWith(new RelayState<GateAgent>((agent, bb) =>
+            {
+                agent.Runs++;
+                bb.Set(speed, bb.Get(alarm) ? 5 : 2);
+                return Result.Success;
+            }))
+            .To<GateAgent>((agent, bb) =>
+            {
+                if (bb.Get(speed) > agent.Runs)
+                {
+                    bb.GetRef(sightings)++;
+                }
+
+                return Result.Success;
+            })
+            .Build();
+
+        StateMachine<GateAgent> machine = graph.ToStateMachine<GateAgent>()
+            .WithBlackboard(world)
+            .WithBlackboard(local)
+            .WithAgent(new GateAgent());
+
+        AssertZeroAlloc(machine);
+    }
+
+    [Test]
+    public async Task async_blackboard_if_branch_is_allocation_free()
+    {
+        (Blackboard world, Blackboard local,
+            BlackboardKey<bool> alarm, BlackboardKey<int> _, BlackboardKey<int> speed) = DualScopeBoards();
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(alarm, !bb.Get(alarm)); // exercise both branches over the run set
+                return ResultHelpers.Success;
+            })
+            .If(bb => bb.Get(alarm))
+            .ThenAsync((bb, _) =>
+            {
+                bb.Set(speed, 5);
+                return ResultHelpers.Success;
+            })
+            .ElseAsync((bb, _) =>
+            {
+                bb.Set(speed, 2);
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine()
+            .WithBlackboard(world)
+            .WithBlackboard(local);
+
+        await AssertZeroAllocAsync(machine);
+    }
+
+    [Test]
+    public void sync_blackboard_if_branch_is_allocation_free()
+    {
+        (Blackboard world, Blackboard local,
+            BlackboardKey<bool> alarm, BlackboardKey<int> _, BlackboardKey<int> speed) = DualScopeBoards();
+
+        Graph graph = GraphBuilder
+            .StartWith(bb =>
+            {
+                bb.Set(alarm, !bb.Get(alarm));
+                return Result.Success;
+            })
+            .If(bb => bb.Get(alarm))
+            .Then(bb =>
+            {
+                bb.Set(speed, 5);
+                return Result.Success;
+            })
+            .Else(bb =>
+            {
+                bb.Set(speed, 2);
+                return Result.Success;
+            })
+            .To(bb => Result.Success)
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine()
+            .WithBlackboard(world)
+            .WithBlackboard(local));
     }
 
     [Test]

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -272,6 +272,57 @@ public class AllocationGateTests
         AssertZeroAlloc(parent.ToStateMachine());
     }
 
+    [Test]
+    public async Task async_dynamic_parallel_regions_are_allocation_free()
+    {
+        (Blackboard world, _, BlackboardKey<bool> alarm, _, _) = DualScopeBoards();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(
+                bb => bb.Get(alarm)
+                    ? RegionMask.Bit(0) | RegionMask.Bit(1)
+                    : RegionMask.Bit(0) | RegionMask.Bit(2),
+                AsyncChain(3).Build(), AsyncChain(2).Build(), AsyncChain(2).Build())
+            .Build();
+
+        await AssertZeroAllocAsync(parent.ToAsyncStateMachine().WithBlackboard(world));
+    }
+
+    [Test]
+    public void sync_dynamic_parallel_run_to_join_is_allocation_free()
+    {
+        (Blackboard world, _, BlackboardKey<bool> alarm, _, _) = DualScopeBoards();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RunToJoin,
+                bb => bb.Get(alarm)
+                    ? RegionMask.Bit(0) | RegionMask.Bit(1)
+                    : RegionMask.Bit(0) | RegionMask.Bit(2),
+                SyncChain(3).Build(), SyncChain(2).Build(), SyncChain(2).Build())
+            .Build();
+
+        AssertZeroAlloc(parent.ToStateMachine().WithBlackboard(world));
+    }
+
+    [Test]
+    public void sync_dynamic_parallel_round_per_tick_is_allocation_free()
+    {
+        (Blackboard world, _, BlackboardKey<bool> alarm, _, _) = DualScopeBoards();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick,
+                bb => bb.Get(alarm)
+                    ? RegionMask.Bit(0) | RegionMask.Bit(1)
+                    : RegionMask.Bit(0) | RegionMask.Bit(2),
+                SyncChain(3).Build(), SyncChain(2).Build(), SyncChain(2).Build())
+            .Build();
+
+        AssertZeroAlloc(parent.ToStateMachine().WithBlackboard(world));
+    }
+
     // ── Blackboards: dual-scope routing on the hot path ─────────────────
 
     private sealed class GateAgent

--- a/NxGraph.Tests/AsyncObserverTests.cs
+++ b/NxGraph.Tests/AsyncObserverTests.cs
@@ -191,9 +191,9 @@ public class AsyncObserverTests
             return default;
         }
 
-        public ValueTask OnStateFailed(NodeId id, Exception ex, CancellationToken ct = default)
+        public ValueTask OnStateFailed(NodeId id, Exception? ex, CancellationToken ct = default)
         {
-            FailedExceptions.Add(ex);
+            if (ex is not null) FailedExceptions.Add(ex);
             return default;
         }
 

--- a/NxGraph.Tests/Blackboards/BlackboardContextTests.cs
+++ b/NxGraph.Tests/Blackboards/BlackboardContextTests.cs
@@ -1,0 +1,160 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Tests.Blackboards;
+
+/// <summary>
+/// The routed context: scope routing, replace semantics, unbound-scope errors — no FSM involved.
+/// </summary>
+[TestFixture]
+public class BlackboardContextTests
+{
+    private static (BlackboardSchema world, BlackboardKey<bool> alarm) GlobalSchema()
+    {
+        BlackboardSchema world = new("world", BlackboardScope.Global);
+        BlackboardKey<bool> alarm = world.Register<bool>("AlarmRaised");
+        return (world, alarm);
+    }
+
+    private static (BlackboardSchema enemy, BlackboardKey<int> health) GraphSchema()
+    {
+        BlackboardSchema enemy = new("enemy");
+        BlackboardKey<int> health = enemy.Register<int>("health", 100);
+        return (enemy, health);
+    }
+
+    [Test]
+    public void routes_keys_by_their_schema_scope()
+    {
+        (BlackboardSchema world, BlackboardKey<bool> alarm) = GlobalSchema();
+        (BlackboardSchema enemy, BlackboardKey<int> health) = GraphSchema();
+
+        Blackboard worldBoard = new(world);
+        Blackboard enemyBoard = new(enemy);
+        BlackboardContext ctx = new(worldBoard, enemyBoard);
+
+        ctx.Set(alarm, true);
+        ctx.Set(health, 50);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ctx.Get(alarm), Is.True);
+            Assert.That(ctx.Get(health), Is.EqualTo(50));
+            Assert.That(worldBoard.Get(alarm), Is.True, "Global key must land on the global board.");
+            Assert.That(enemyBoard.Get(health), Is.EqualTo(50), "Graph key must land on the graph board.");
+        });
+    }
+
+    [Test]
+    public void with_routes_by_scope_and_replaces_on_rebind()
+    {
+        (BlackboardSchema world, BlackboardKey<bool> alarm) = GlobalSchema();
+        (BlackboardSchema enemy, BlackboardKey<int> health) = GraphSchema();
+
+        Blackboard worldBoard = new(world);
+        Blackboard enemyA = new(enemy);
+        Blackboard enemyB = new(enemy);
+
+        BlackboardContext ctx = default;
+        ctx = ctx.With(worldBoard).With(enemyA);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ctx.Global, Is.SameAs(worldBoard));
+            Assert.That(ctx.Graph, Is.SameAs(enemyA));
+        });
+
+        ctx = ctx.With(enemyB);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ctx.Graph, Is.SameAs(enemyB), "Rebinding a scope must replace the board.");
+            Assert.That(ctx.Global, Is.SameAs(worldBoard), "Rebinding one scope must not disturb the other.");
+            _ = alarm;
+            _ = health;
+        });
+    }
+
+    [Test]
+    public void empty_context_reports_and_throws_precisely()
+    {
+        (_, BlackboardKey<bool> alarm) = GlobalSchema();
+        (_, BlackboardKey<int> health) = GraphSchema();
+
+        BlackboardContext ctx = default;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ctx.IsEmpty, Is.True);
+            Assert.That(ctx.HasBoard(BlackboardScope.Global), Is.False);
+            Assert.That(ctx.HasBoard(BlackboardScope.Graph), Is.False);
+            Assert.That(ctx.Board(BlackboardScope.Global), Is.Null);
+            Assert.That(() => ctx.Get(alarm),
+                Throws.InvalidOperationException.With.Message
+                    .Contain("global key 'AlarmRaised'").And.Message.Contain("WithBlackboard"));
+            Assert.That(() => ctx.Get(health),
+                Throws.InvalidOperationException.With.Message.Contain("graph key 'health'"));
+            Assert.That(() => ctx.Set(health, 1), Throws.InvalidOperationException);
+        });
+    }
+
+    [Test]
+    public void try_get_is_false_for_unbound_scope_and_foreign_key()
+    {
+        (BlackboardSchema world, BlackboardKey<bool> alarm) = GlobalSchema();
+        (_, BlackboardKey<int> health) = GraphSchema();
+        BlackboardSchema otherEnemy = new("other-enemy");
+        BlackboardKey<int> foreignHealth = otherEnemy.Register<int>("health");
+
+        BlackboardContext ctx = new(new Blackboard(world), new Blackboard(otherEnemy));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ctx.TryGet(alarm, out bool alarmValue), Is.True);
+            Assert.That(alarmValue, Is.False);
+            Assert.That(ctx.TryGet(health, out _), Is.False, "Key from a different graph schema must not resolve.");
+            Assert.That(ctx.TryGet(foreignHealth, out int fh), Is.True);
+            Assert.That(fh, Is.EqualTo(0));
+            Assert.That(default(BlackboardContext).TryGet(alarm, out _), Is.False);
+            Assert.That(ctx.TryGet(default(BlackboardKey<int>), out _), Is.False);
+        });
+    }
+
+    [Test]
+    public void get_ref_routes_and_mutates_in_place()
+    {
+        (BlackboardSchema world, BlackboardKey<bool> _) = GlobalSchema();
+        (BlackboardSchema enemy, BlackboardKey<int> health) = GraphSchema();
+
+        BlackboardContext ctx = new(new Blackboard(world), new Blackboard(enemy));
+        ctx.GetRef(health) -= 30;
+
+        Assert.That(ctx.Get(health), Is.EqualTo(70));
+    }
+
+    [Test]
+    public void constructor_rejects_boards_in_the_wrong_slot()
+    {
+        (BlackboardSchema world, _) = GlobalSchema();
+        (BlackboardSchema enemy, _) = GraphSchema();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => new BlackboardContext(new Blackboard(enemy), null), Throws.ArgumentException);
+            Assert.That(() => new BlackboardContext(null, new Blackboard(world)), Throws.ArgumentException);
+        });
+    }
+
+    [Test]
+    public void unbound_scope_message_names_the_scope_and_key()
+    {
+        (_, BlackboardKey<bool> alarm) = GlobalSchema();
+        (BlackboardSchema enemy, _) = GraphSchema();
+
+        // Graph board bound, global missing — the error must point at the *global* gap.
+        BlackboardContext ctx = new(null, new Blackboard(enemy));
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(() => ctx.Get(alarm));
+        Assert.That(ex!.Message,
+            Does.Contain("global key 'AlarmRaised' used but no global blackboard bound"));
+    }
+}

--- a/NxGraph.Tests/Blackboards/BlackboardFsmIntegrationTests.cs
+++ b/NxGraph.Tests/Blackboards/BlackboardFsmIntegrationTests.cs
@@ -360,17 +360,24 @@ public class BlackboardFsmIntegrationTests
             "Graph.SetBlackboards must reach nodes inside nested machines.");
     }
 
-    private sealed class CustomComposite(Graph child) : IAsyncLogic, ISubGraphProvider
+    // Contract for user containers that wrap their own machines: implement ISubGraphProvider
+    // (agent stamping) AND IBlackboardSettable forwarding (blackboard stamping) — machines
+    // re-stamp their own context at every run start, so a container that doesn't forward
+    // would have its inner machine erase the parent's stamp with an empty context.
+    private sealed class CustomComposite(Graph child) : IAsyncLogic, ISubGraphProvider, IBlackboardSettable
     {
         private readonly AsyncStateMachine _machine = new(child);
 
         public IEnumerable<Graph> SubGraphs => [_machine.Graph];
 
+        void IBlackboardSettable.SetBlackboards(in BlackboardContext context) =>
+            ((IBlackboardSettable)_machine).SetBlackboards(in context);
+
         public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => _machine.ExecuteAsync(ct);
     }
 
     [Test]
-    public async Task user_defined_composite_receives_the_context_via_subgraph_provider()
+    public async Task user_defined_composite_receives_the_context_via_blackboard_forwarding()
     {
         BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out _);
 
@@ -390,6 +397,33 @@ public class BlackboardFsmIntegrationTests
         await outer.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
 
         Assert.That(board.Get(target), Is.EqualTo(11));
+    }
+
+    [Test]
+    public async Task board_less_machine_sharing_a_graph_gets_the_unbound_scope_throw_not_stale_boards()
+    {
+        // Regression: run-start re-stamping used to skip empty contexts, so a machine with
+        // no boards bound silently executed against whatever boards the previous machine
+        // stamped onto the shared graph — reading and corrupting another entity's state.
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out _);
+
+        Graph shared = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(target, bb.Get(target) + 1);
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Blackboard boardA = new(enemySchema);
+        await shared.ToAsyncStateMachine().WithBlackboard(boardA).ExecuteAsync();
+        Assert.That(boardA.Get(target), Is.EqualTo(0), "target defaults to -1; one increment lands on 0");
+
+        AsyncStateMachine boardless = shared.ToAsyncStateMachine();
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await boardless.ExecuteAsync(),
+            "A board-less machine must hit the unbound-scope error, not alias the previous machine's board.");
+        Assert.That(boardA.Get(target), Is.EqualTo(0),
+            "The board-less machine must not have written through the stale stamp.");
     }
 
     [Test]

--- a/NxGraph.Tests/Blackboards/BlackboardFsmIntegrationTests.cs
+++ b/NxGraph.Tests/Blackboards/BlackboardFsmIntegrationTests.cs
@@ -1,0 +1,579 @@
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Diagnostics.Validations;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests.Blackboards;
+
+/// <summary>
+/// The blackboard channel through the FSM runtimes: schema-on-graph declarations,
+/// per-machine binding via <c>WithBlackboard</c> (routed by schema scope), context stamping
+/// alongside the agent channel, and composite propagation.
+/// </summary>
+[TestFixture]
+public class BlackboardFsmIntegrationTests
+{
+    private sealed class Enemy
+    {
+        public string Name = "";
+        public int Health = 100;
+    }
+
+    private static BlackboardSchema NewWorldSchema(out BlackboardKey<bool> alarm, out BlackboardKey<int> sightings)
+    {
+        BlackboardSchema world = new("world", BlackboardScope.Global);
+        alarm = world.Register<bool>("AlarmRaised");
+        sightings = world.Register<int>("Sightings");
+        return world;
+    }
+
+    private static BlackboardSchema NewEnemySchema(out BlackboardKey<int> target, out BlackboardKey<int> speed)
+    {
+        BlackboardSchema enemy = new("enemy");
+        target = enemy.Register<int>("target", -1);
+        speed = enemy.Register<int>("speed", 1);
+        return enemy;
+    }
+
+    // ── Target API shape ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task async_machine_binds_boards_and_agent_in_any_order()
+    {
+        BlackboardSchema world = NewWorldSchema(out BlackboardKey<bool> alarm, out _);
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out _);
+
+        Graph graph = GraphBuilder
+            .StartWithAsync(new AsyncRelayState<Enemy>((enemy, bb, _) =>
+            {
+                bb.Set(alarm, true);
+                bb.Set(target, enemy.Health);
+                return ResultHelpers.Success;
+            }))
+            .WithSchema(enemySchema)
+            .WithSchema(world)
+            .Build();
+
+        Blackboard worldBb = new(world);
+        Blackboard enemyBb = new(enemySchema);
+        Enemy agent = new() { Health = 73 };
+
+        // The user-facing chain, verbatim.
+        AsyncStateMachine<Enemy> fsm = graph.ToAsyncStateMachine<Enemy>()
+            .WithBlackboard(worldBb)
+            .WithBlackboard(enemyBb)
+            .WithAgent(agent);
+
+        await fsm.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(worldBb.Get(alarm), Is.True);
+            Assert.That(enemyBb.Get(target), Is.EqualTo(73));
+        });
+
+        // And the reverse binding order on a fresh machine.
+        Blackboard enemyBb2 = new(enemySchema);
+        AsyncStateMachine<Enemy> fsm2 = graph.ToAsyncStateMachine<Enemy>()
+            .WithAgent(agent)
+            .WithBlackboard(enemyBb2)
+            .WithBlackboard(worldBb);
+
+        await fsm2.ExecuteAsync();
+        Assert.That(enemyBb2.Get(target), Is.EqualTo(73));
+    }
+
+    [Test]
+    public void sync_machine_binds_boards_and_agent()
+    {
+        BlackboardSchema world = NewWorldSchema(out BlackboardKey<bool> alarm, out _);
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out _);
+
+        Graph graph = GraphBuilder
+            .StartWith(new RelayState<Enemy>((enemy, bb) =>
+            {
+                bb.Set(alarm, true);
+                bb.Set(target, enemy.Health);
+                return Result.Success;
+            }))
+            .WithSchema(enemySchema)
+            .WithSchema(world)
+            .Build();
+
+        Blackboard worldBb = new(world);
+        Blackboard enemyBb = new(enemySchema);
+
+        StateMachine<Enemy> fsm = graph.ToStateMachine<Enemy>()
+            .WithBlackboard(worldBb)
+            .WithBlackboard(enemyBb)
+            .WithAgent(new Enemy { Health = 40 });
+
+        RunToCompletion(fsm);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(worldBb.Get(alarm), Is.True);
+            Assert.That(enemyBb.Get(target), Is.EqualTo(40));
+        });
+    }
+
+    // ── Global sharing, distinct graph boards ─────────────────────────────
+
+    [Test]
+    public async Task one_global_board_is_shared_across_machines_over_different_graphs()
+    {
+        BlackboardSchema world = NewWorldSchema(out BlackboardKey<bool> alarm, out BlackboardKey<int> sightings);
+
+        Graph writerGraph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(alarm, true);
+                bb.GetRef(sightings)++;
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        bool seen = false;
+        Graph readerGraph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                seen = bb.Get(alarm);
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Blackboard worldBb = new(world);
+        AsyncStateMachine writer = writerGraph.ToAsyncStateMachine().WithBlackboard(worldBb);
+        AsyncStateMachine reader = readerGraph.ToAsyncStateMachine().WithBlackboard(worldBb);
+
+        await writer.ExecuteAsync();
+        await reader.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(seen, Is.True, "A write through machine A's run must be visible in machine B's run.");
+            Assert.That(worldBb.Get(sightings), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task machines_over_one_graph_hold_distinct_graph_boards_but_one_global()
+    {
+        BlackboardSchema world = NewWorldSchema(out _, out BlackboardKey<int> sightings);
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out _);
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.GetRef(sightings)++;
+                bb.Set(target, bb.Get(sightings));
+                return ResultHelpers.Success;
+            })
+            .WithSchema(enemySchema)
+            .WithSchema(world)
+            .Build();
+
+        Blackboard worldBb = new(world);
+        Blackboard boardA = new(enemySchema);
+        Blackboard boardB = new(enemySchema);
+
+        AsyncStateMachine machineA = graph.ToAsyncStateMachine().WithBlackboard(worldBb).WithBlackboard(boardA);
+        AsyncStateMachine machineB = graph.ToAsyncStateMachine().WithBlackboard(worldBb).WithBlackboard(boardB);
+
+        await machineA.ExecuteAsync();
+        await machineB.ExecuteAsync();
+        await machineA.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(worldBb.Get(sightings), Is.EqualTo(3), "Global memory accumulates across all machines.");
+            Assert.That(boardA.Get(target), Is.EqualTo(3), "Machine A's board reflects its own last run.");
+            Assert.That(boardB.Get(target), Is.EqualTo(2), "Machine B's board is untouched by A's runs.");
+        });
+    }
+
+    [Test]
+    public async Task rebinding_a_scope_replaces_the_board_for_the_next_run()
+    {
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out _);
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(target, 42);
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Blackboard first = new(enemySchema);
+        Blackboard second = new(enemySchema);
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine().WithBlackboard(first);
+        await machine.ExecuteAsync();
+
+        machine.SetBlackboard(second); // pool-recycle: same machine, new entity board
+        await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Get(target), Is.EqualTo(42));
+            Assert.That(second.Get(target), Is.EqualTo(42));
+        });
+    }
+
+    // ── Declarations and validation ───────────────────────────────────────
+
+    [Test]
+    public void schema_mismatch_fails_fast_at_bind_time()
+    {
+        BlackboardSchema declared = NewEnemySchema(out _, out _);
+        BlackboardSchema other = NewEnemySchema(out _, out _);
+        BlackboardSchema world = NewWorldSchema(out _, out _);
+        BlackboardSchema otherWorld = NewWorldSchema(out _, out _);
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) => ResultHelpers.Success)
+            .WithSchema(declared)
+            .WithSchema(world)
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => machine.WithBlackboard(new Blackboard(other)),
+                Throws.InvalidOperationException.With.Message.Contain("does not match"),
+                "Graph-scope board over a different schema must be rejected.");
+            Assert.That(() => machine.WithBlackboard(new Blackboard(otherWorld)),
+                Throws.InvalidOperationException.With.Message.Contain("does not match"),
+                "Global-scope board over a different schema must be rejected.");
+            Assert.That(() => machine.WithBlackboard(new Blackboard(declared)), Throws.Nothing);
+            Assert.That(() => machine.WithBlackboard(new Blackboard(world)), Throws.Nothing);
+        });
+    }
+
+    [Test]
+    public void graphs_without_declarations_bind_permissively()
+    {
+        BlackboardSchema enemySchema = NewEnemySchema(out _, out _);
+        BlackboardSchema world = NewWorldSchema(out _, out _);
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) => ResultHelpers.Success)
+            .Build();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(graph.Schema, Is.Null);
+            Assert.That(graph.GlobalSchema, Is.Null);
+            Assert.That(() => graph.ToAsyncStateMachine()
+                    .WithBlackboard(new Blackboard(enemySchema))
+                    .WithBlackboard(new Blackboard(world)),
+                Throws.Nothing);
+        });
+    }
+
+    [Test]
+    public void declaring_the_same_scope_twice_throws()
+    {
+        BlackboardSchema first = NewEnemySchema(out _, out _);
+        BlackboardSchema second = NewEnemySchema(out _, out _);
+
+        Assert.That(() => GraphBuilder
+                .StartWithAsync((bb, _) => ResultHelpers.Success)
+                .WithSchema(first)
+                .WithSchema(second),
+            Throws.InvalidOperationException.With.Message.Contain("already been declared"));
+    }
+
+    [Test]
+    public async Task agentless_machine_uses_blackboards_only()
+    {
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out BlackboardKey<int> speed);
+
+        Graph graph = GraphBuilder
+            .StartWith(bb =>
+            {
+                bb.Set(target, bb.Get(speed) * 3);
+                return Result.Success;
+            })
+            .WithSchema(enemySchema)
+            .Build();
+
+        Blackboard board = new(enemySchema);
+        board.Set(speed, 5);
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine().WithBlackboard(board);
+        await machine.ExecuteAsync();
+
+        Assert.That(board.Get(target), Is.EqualTo(15));
+    }
+
+    [Test]
+    public void unbound_scope_key_access_throws_mid_run_with_guidance()
+    {
+        BlackboardSchema world = NewWorldSchema(out BlackboardKey<bool> alarm, out _);
+        _ = world;
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(alarm, true); // global scope — never bound below
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        InvalidOperationException? ex =
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await machine.ExecuteAsync());
+        Assert.That(ex!.Message, Does.Contain("no global blackboard bound").And.Contain("WithBlackboard"));
+    }
+
+    // ── Composite propagation ─────────────────────────────────────────────
+
+    [Test]
+    public async Task subgraph_nodes_receive_the_parent_context()
+    {
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out _);
+
+        Graph child = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(target, 7);
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Graph parent = GraphBuilder
+            .StartWithAsync((_, _) => ResultHelpers.Success)
+            .SubGraph(child)
+            .Build();
+
+        Blackboard board = new(enemySchema);
+        AsyncStateMachine machine = parent.ToAsyncStateMachine().WithBlackboard(board);
+        await machine.ExecuteAsync();
+
+        Assert.That(board.Get(target), Is.EqualTo(7),
+            "Graph.SetBlackboards must reach nodes inside nested machines.");
+    }
+
+    private sealed class CustomComposite(Graph child) : IAsyncLogic, ISubGraphProvider
+    {
+        private readonly AsyncStateMachine _machine = new(child);
+
+        public IEnumerable<Graph> SubGraphs => [_machine.Graph];
+
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => _machine.ExecuteAsync(ct);
+    }
+
+    [Test]
+    public async Task user_defined_composite_receives_the_context_via_subgraph_provider()
+    {
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out _);
+
+        Graph inner = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(target, 11);
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Graph outer = GraphBuilder
+            .StartWithAsync(new CustomComposite(inner))
+            .Build();
+
+        Blackboard board = new(enemySchema);
+        await outer.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.That(board.Get(target), Is.EqualTo(11));
+    }
+
+    [Test]
+    public async Task parallel_regions_share_the_parent_context()
+    {
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out BlackboardKey<int> speed);
+
+        Graph regionA = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(target, 1);
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Graph regionB = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(speed, 2);
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Graph parent = GraphBuilder.Start().Parallel(regionA, regionB).Build();
+
+        Blackboard board = new(enemySchema);
+        await parent.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(board.Get(target), Is.EqualTo(1));
+            Assert.That(board.Get(speed), Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void nested_machine_with_conflicting_schema_fails_loudly_at_stamp_time()
+    {
+        BlackboardSchema parentSchema = NewEnemySchema(out _, out _);
+        BlackboardSchema childSchema = NewEnemySchema(out _, out _);
+
+        Graph child = GraphBuilder
+            .StartWithAsync((bb, _) => ResultHelpers.Success)
+            .WithSchema(childSchema)
+            .Build();
+
+        Graph parent = GraphBuilder
+            .StartWithAsync((_, _) => ResultHelpers.Success)
+            .SubGraph(child)
+            .WithSchema(parentSchema)
+            .Build();
+
+        AsyncStateMachine machine = parent.ToAsyncStateMachine();
+
+        Assert.That(() => machine.WithBlackboard(new Blackboard(parentSchema)),
+            Throws.InvalidOperationException.With.Message.Contain("does not match"),
+            "The nested machine must reject a context whose board conflicts with its own declaration.");
+    }
+
+    // ── Blackboard-driven directors ───────────────────────────────────────
+
+    [Test]
+    public async Task async_if_branches_on_the_routed_context()
+    {
+        BlackboardSchema world = NewWorldSchema(out BlackboardKey<bool> alarm, out _);
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out _);
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((_, _) => ResultHelpers.Success)
+            .If(bb => bb.Get(alarm))
+            .ThenAsync((bb, _) =>
+            {
+                bb.Set(target, 100);
+                return ResultHelpers.Success;
+            })
+            .ElseAsync((bb, _) =>
+            {
+                bb.Set(target, -100);
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Blackboard worldBb = new(world);
+        Blackboard board = new(enemySchema);
+        AsyncStateMachine machine = graph.ToAsyncStateMachine().WithBlackboard(worldBb).WithBlackboard(board);
+
+        await machine.ExecuteAsync();
+        Assert.That(board.Get(target), Is.EqualTo(-100), "Alarm off — else branch.");
+
+        worldBb.Set(alarm, true);
+        await machine.ExecuteAsync();
+        Assert.That(board.Get(target), Is.EqualTo(100), "Alarm on — then branch.");
+    }
+
+    [Test]
+    public void sync_switch_selects_on_the_routed_context()
+    {
+        BlackboardSchema enemySchema = NewEnemySchema(out BlackboardKey<int> target, out BlackboardKey<int> speed);
+
+        Graph graph = GraphBuilder
+            .StartWith(bb => Result.Success)
+            .Switch(bb => bb.Get(speed))
+            .Case(1, bb =>
+            {
+                bb.Set(target, 10);
+                return Result.Success;
+            })
+            .Case(2, bb =>
+            {
+                bb.Set(target, 20);
+                return Result.Success;
+            })
+            .Default(bb =>
+            {
+                bb.Set(target, 0);
+                return Result.Success;
+            })
+            .End()
+            .Build();
+
+        Blackboard board = new(enemySchema);
+        board.Set(speed, 2);
+
+        StateMachine machine = graph.ToStateMachine().WithBlackboard(board);
+        RunToCompletion(machine);
+
+        Assert.That(board.Get(target), Is.EqualTo(20));
+    }
+
+    // ── Validator diagnostics ─────────────────────────────────────────────
+
+    [Test]
+    public void validator_reports_declared_schema_with_no_settable_nodes()
+    {
+        BlackboardSchema enemySchema = NewEnemySchema(out _, out _);
+
+        // Raw IAsyncLogic — not a State, accepts nothing.
+        Graph graph = GraphBuilder
+            .StartWithAsync(new RawLogic())
+            .WithSchema(enemySchema)
+            .Build();
+
+        GraphValidationResult result = graph.Validate();
+
+        Assert.That(result.Diagnostics.Any(d =>
+                d.Severity == Severity.Info && d.Message.Contains("IBlackboardSettable")),
+            Is.True, "Expected an Info diagnostic about unused schema declarations.");
+    }
+
+    [Test]
+    public void validator_warns_on_conflicting_child_schema()
+    {
+        BlackboardSchema parentSchema = NewEnemySchema(out _, out _);
+        BlackboardSchema childSchema = NewEnemySchema(out _, out _);
+
+        Graph child = GraphBuilder
+            .StartWithAsync((bb, _) => ResultHelpers.Success)
+            .WithSchema(childSchema)
+            .Build();
+
+        Graph parent = GraphBuilder
+            .StartWithAsync((_, _) => ResultHelpers.Success)
+            .SubGraph(child)
+            .WithSchema(parentSchema)
+            .Build();
+
+        GraphValidationResult result = parent.Validate();
+
+        Assert.That(result.Diagnostics.Any(d =>
+                d.Severity == Severity.Warning && d.Message.Contains("different Graph-scoped blackboard schema")),
+            Is.True, "Expected a Warning about the conflicting child schema.");
+    }
+
+    private sealed class RawLogic : IAsyncLogic
+    {
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => ResultHelpers.Success;
+    }
+
+    private static void RunToCompletion(StateMachine machine)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+    }
+}

--- a/NxGraph.Tests/Blackboards/BlackboardSchemaTests.cs
+++ b/NxGraph.Tests/Blackboards/BlackboardSchemaTests.cs
@@ -1,0 +1,116 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Tests.Blackboards;
+
+/// <summary>
+/// Schema registration, freezing, scope rules, and key identity.
+/// </summary>
+[TestFixture]
+public class BlackboardSchemaTests
+{
+    [Test]
+    public void register_returns_valid_keys_with_sequential_ordinals()
+    {
+        BlackboardSchema schema = new("test");
+        BlackboardKey<int> health = schema.Register<int>("health");
+        BlackboardKey<string> label = schema.Register<string>("label");
+        BlackboardKey<float> speed = schema.Register<float>("speed");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(health.IsValid, Is.True);
+            Assert.That(label.IsValid, Is.True);
+            Assert.That(speed.IsValid, Is.True);
+            Assert.That(schema.KeyCount, Is.EqualTo(3));
+            Assert.That(schema.Keys[0].Name, Is.EqualTo("health"));
+            Assert.That(schema.Keys[0].Ordinal, Is.EqualTo(0));
+            Assert.That(schema.Keys[1].Name, Is.EqualTo("label"));
+            Assert.That(schema.Keys[1].Ordinal, Is.EqualTo(1));
+            Assert.That(schema.Keys[2].Name, Is.EqualTo("speed"));
+            Assert.That(schema.Keys[2].Ordinal, Is.EqualTo(2));
+            Assert.That(schema.Keys[2].ValueType, Is.EqualTo(typeof(float)));
+        });
+    }
+
+    [Test]
+    public void duplicate_name_throws()
+    {
+        BlackboardSchema schema = new();
+        schema.Register<int>("health");
+
+        Assert.Throws<ArgumentException>(() => schema.Register<float>("health"));
+    }
+
+    [Test]
+    public void register_after_freeze_throws_with_guidance()
+    {
+        BlackboardSchema schema = new("frozen");
+        schema.Register<int>("health");
+        _ = new Blackboard(schema);
+
+        Assert.That(schema.IsFrozen, Is.True);
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(() => schema.Register<int>("late"));
+        Assert.That(ex!.Message, Does.Contain("frozen").And.Contain("before constructing"));
+    }
+
+    [Test]
+    public void try_get_key_finds_registered_names_only()
+    {
+        BlackboardSchema schema = new();
+        schema.Register<int>("health", 42);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(schema.TryGetKey("health", out BlackboardKeyDescriptor descriptor), Is.True);
+            Assert.That(descriptor.ValueType, Is.EqualTo(typeof(int)));
+            Assert.That(schema.TryGetKey("missing", out _), Is.False);
+        });
+    }
+
+    [Test]
+    public void key_equality_is_schema_reference_plus_ordinal()
+    {
+        BlackboardSchema schemaA = new("a");
+        BlackboardSchema schemaB = new("b");
+
+        BlackboardKey<int> first = schemaA.Register<int>("x");
+        BlackboardKey<int> copy = first;
+        BlackboardKey<int> second = schemaA.Register<int>("y");
+        BlackboardKey<int> foreign = schemaB.Register<int>("x");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo(copy));
+            Assert.That(first == copy, Is.True);
+            Assert.That(first, Is.Not.EqualTo(second));
+            Assert.That(first, Is.Not.EqualTo(foreign), "Same name/ordinal on another schema must not be equal.");
+            Assert.That(first, Is.Not.EqualTo(default(BlackboardKey<int>)));
+            Assert.That(default(BlackboardKey<int>).IsValid, Is.False);
+        });
+    }
+
+    [Test]
+    public void scope_defaults_to_graph_and_can_be_global()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(new BlackboardSchema().Scope, Is.EqualTo(BlackboardScope.Graph));
+            Assert.That(new BlackboardSchema("world", BlackboardScope.Global).Scope,
+                Is.EqualTo(BlackboardScope.Global));
+        });
+    }
+
+    [Test]
+    public void node_scope_is_reserved_and_rejected()
+    {
+        ArgumentOutOfRangeException? ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => _ = new BlackboardSchema("local", BlackboardScope.Node));
+        Assert.That(ex!.Message, Does.Contain("reserved"));
+    }
+
+    [Test]
+    public void undefined_scope_is_rejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = new BlackboardSchema("bad", (BlackboardScope)99));
+    }
+}

--- a/NxGraph.Tests/Blackboards/BlackboardTests.cs
+++ b/NxGraph.Tests/Blackboards/BlackboardTests.cs
@@ -1,0 +1,171 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Tests.Blackboards;
+
+/// <summary>
+/// Board semantics: defaults, typed round-trips, ref access, error cases, and
+/// instance independence over a shared schema.
+/// </summary>
+[TestFixture]
+public class BlackboardTests
+{
+    private readonly struct Vector2(float x, float y)
+    {
+        public readonly float X = x;
+        public readonly float Y = y;
+    }
+
+    [Test]
+    public void defaults_are_readable_before_any_set()
+    {
+        BlackboardSchema schema = new();
+        BlackboardKey<int> plain = schema.Register<int>("plain");
+        BlackboardKey<int> seeded = schema.Register<int>("seeded", 42);
+        BlackboardKey<string> label = schema.Register<string>("label", "hello");
+
+        Blackboard bb = new(schema);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(bb.Get(plain), Is.EqualTo(0));
+            Assert.That(bb.Get(seeded), Is.EqualTo(42));
+            Assert.That(bb.Get(label), Is.EqualTo("hello"));
+        });
+    }
+
+    [Test]
+    public void get_set_round_trips_value_types_strings_nullables_and_structs()
+    {
+        BlackboardSchema schema = new();
+        BlackboardKey<int> count = schema.Register<int>("count");
+        BlackboardKey<string?> name = schema.Register<string?>("name");
+        BlackboardKey<int?> maybe = schema.Register<int?>("maybe");
+        BlackboardKey<Vector2> pos = schema.Register<Vector2>("pos");
+
+        Blackboard bb = new(schema);
+        bb.Set(count, 7);
+        bb.Set(name, "enemy");
+        bb.Set(maybe, 3);
+        bb.Set(pos, new Vector2(1f, 2f));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(bb.Get(count), Is.EqualTo(7));
+            Assert.That(bb.Get(name), Is.EqualTo("enemy"));
+            Assert.That(bb.Get(maybe), Is.EqualTo(3));
+            Assert.That(bb.Get(pos).X, Is.EqualTo(1f));
+            Assert.That(bb.Get(pos).Y, Is.EqualTo(2f));
+        });
+    }
+
+    [Test]
+    public void get_ref_mutates_struct_slots_in_place()
+    {
+        BlackboardSchema schema = new();
+        BlackboardKey<int> counter = schema.Register<int>("counter");
+        Blackboard bb = new(schema);
+
+        bb.GetRef(counter)++;
+        bb.GetRef(counter)++;
+
+        Assert.That(bb.Get(counter), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void invalid_and_foreign_keys_throw_on_get_and_set()
+    {
+        BlackboardSchema mine = new("mine");
+        BlackboardSchema other = new("other");
+        mine.Register<int>("x");
+        BlackboardKey<int> foreign = other.Register<int>("x");
+
+        Blackboard bb = new(mine);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => bb.Get(default(BlackboardKey<int>)),
+                Throws.InvalidOperationException.With.Message.Contain("Uninitialized"));
+            Assert.That(() => bb.Set(default(BlackboardKey<int>), 1), Throws.InvalidOperationException);
+            Assert.That(() => bb.Get(foreign),
+                Throws.InvalidOperationException.With.Message.Contain("mine").And.Message.Contain("other"));
+            Assert.That(() => bb.Set(foreign, 1), Throws.InvalidOperationException);
+        });
+    }
+
+    [Test]
+    public void try_get_returns_false_instead_of_throwing()
+    {
+        BlackboardSchema mine = new("mine");
+        BlackboardSchema other = new("other");
+        BlackboardKey<int> valid = mine.Register<int>("x", 5);
+        BlackboardKey<int> foreign = other.Register<int>("x");
+
+        Blackboard bb = new(mine);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(bb.TryGet(valid, out int value), Is.True);
+            Assert.That(value, Is.EqualTo(5));
+            Assert.That(bb.TryGet(default(BlackboardKey<int>), out _), Is.False);
+            Assert.That(bb.TryGet(foreign, out _), Is.False);
+        });
+    }
+
+    [Test]
+    public void reset_to_defaults_restores_registered_defaults()
+    {
+        BlackboardSchema schema = new();
+        BlackboardKey<int> seeded = schema.Register<int>("seeded", 42);
+        BlackboardKey<string> label = schema.Register<string>("label", "initial");
+
+        Blackboard bb = new(schema);
+        bb.Set(seeded, -1);
+        bb.Set(label, "dirty");
+
+        bb.ResetToDefaults();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(bb.Get(seeded), Is.EqualTo(42));
+            Assert.That(bb.Get(label), Is.EqualTo("initial"));
+        });
+    }
+
+    [Test]
+    public void two_boards_over_one_schema_are_independent()
+    {
+        BlackboardSchema schema = new("shared");
+        BlackboardKey<int> value = schema.Register<int>("value", 10);
+
+        Blackboard first = new(schema);
+        Blackboard second = new(schema);
+
+        first.Set(value, 111);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Get(value), Is.EqualTo(111));
+            Assert.That(second.Get(value), Is.EqualTo(10), "Writes on one board must not leak into another.");
+        });
+    }
+
+    [Test]
+    public void descriptors_box_read_write_and_reset()
+    {
+        BlackboardSchema schema = new();
+        BlackboardKey<int> count = schema.Register<int>("count", 3);
+        Blackboard bb = new(schema);
+
+        Assert.That(schema.TryGetKey("count", out BlackboardKeyDescriptor descriptor), Is.True);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(descriptor.GetValue(bb), Is.EqualTo(3));
+            descriptor.SetValue(bb, 99);
+            Assert.That(bb.Get(count), Is.EqualTo(99));
+            descriptor.ResetValue(bb);
+            Assert.That(bb.Get(count), Is.EqualTo(3));
+            Assert.That(() => descriptor.SetValue(bb, "wrong type"), Throws.InstanceOf<InvalidCastException>());
+        });
+    }
+}

--- a/NxGraph.Tests/ChoiceStateTests.cs
+++ b/NxGraph.Tests/ChoiceStateTests.cs
@@ -39,4 +39,28 @@ public class ChoiceStateTests
         Result result = await fsm.ExecuteAsync();
         Assert.That(result, Is.EqualTo(Result.Success));
     }
+
+    [Test]
+    [Timeout(5000)]
+    public void start_if_graph_is_executable_by_the_sync_runtime()
+    {
+        // Regression: Start().If(predicate) used to wrap the sync predicate in an
+        // AsyncChoiceState, making the start node unexecutable by the sync StateMachine
+        // while every sibling If overload produced a sync ChoiceState.
+        const bool flag = true;
+
+        StateMachine fsm = GraphBuilder.Start()
+            .If(() => flag)
+            .Then(new RelayState(() => Result.Success))
+            .Else(new RelayState(() => Result.Failure))
+            .ToStateMachine();
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = fsm.Execute();
+        }
+
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
 }

--- a/NxGraph.Tests/DynamicParallelRegionsTests.cs
+++ b/NxGraph.Tests/DynamicParallelRegionsTests.cs
@@ -1,0 +1,416 @@
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Dynamic (some-of-many) parallel composites, both runtimes: entry-time region selection via
+/// a blackboard-driven <see cref="RegionMask"/> selector, vacuous empty join, loud invalid
+/// masks, and the context-forwarding contract (the stamping walk stops at the composite, which
+/// must hand the context to its region machines itself).
+/// </summary>
+[TestFixture]
+public class DynamicParallelRegionsTests
+{
+    private static readonly BlackboardSchema Schema = new("dyn-parallel");
+    private static readonly BlackboardKey<int> Pick = Schema.Register<int>("pick");
+    private static readonly BlackboardKey<int> RegionReads = Schema.Register<int>("regionReads");
+
+    private static Graph AsyncLoggingChain(List<string> log, string prefix, int length)
+    {
+        StateToken token = GraphBuilder.StartWithAsync(_ =>
+        {
+            log.Add($"{prefix}0");
+            return ResultHelpers.Success;
+        });
+
+        for (int i = 1; i < length; i++)
+        {
+            int step = i;
+            token = token.ToAsync(_ =>
+            {
+                log.Add($"{prefix}{step}");
+                return ResultHelpers.Success;
+            });
+        }
+
+        return token.Build();
+    }
+
+    private static Graph SyncLoggingChain(List<string> log, string prefix, int length)
+    {
+        StateToken token = GraphBuilder.StartWith(() =>
+        {
+            log.Add($"{prefix}0");
+            return Result.Success;
+        });
+
+        for (int i = 1; i < length; i++)
+        {
+            int step = i;
+            token = token.To(() =>
+            {
+                log.Add($"{prefix}{step}");
+                return Result.Success;
+            });
+        }
+
+        return token.Build();
+    }
+
+    // ── RegionMask ───────────────────────────────────────────────────────
+
+    [Test]
+    public void region_mask_basics()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(RegionMask.None.IsEmpty, Is.True);
+            Assert.That(RegionMask.None.Count, Is.Zero);
+            Assert.That(RegionMask.Of(0, 2).Count, Is.EqualTo(2));
+            Assert.That(RegionMask.Of(0, 2).Contains(0), Is.True);
+            Assert.That(RegionMask.Of(0, 2).Contains(1), Is.False);
+            Assert.That(RegionMask.Of(0, 2).Contains(2), Is.True);
+            Assert.That(RegionMask.All(64).Count, Is.EqualTo(64));
+            Assert.That(RegionMask.All(3), Is.EqualTo(RegionMask.Of(0, 1, 2)));
+            Assert.That(RegionMask.Bit(1) | RegionMask.Bit(3), Is.EqualTo(RegionMask.Of(1, 3)));
+            Assert.That(RegionMask.Bit(63).Contains(63), Is.True);
+        });
+    }
+
+    [Test]
+    public void region_mask_rejects_out_of_range_indices()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => RegionMask.Bit(64));
+            Assert.Throws<ArgumentOutOfRangeException>(() => RegionMask.Bit(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => RegionMask.Of(0, 64));
+            Assert.Throws<ArgumentOutOfRangeException>(() => RegionMask.All(65));
+        });
+    }
+
+    // ── Async composite ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task async_only_selected_regions_execute()
+    {
+        List<string> log = [];
+        Blackboard board = new(Schema);
+        board.Set(Pick, 0);
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(bb => RegionMask.Bit(bb.Get(Pick)),
+                AsyncLoggingChain(log, "a", 2), AsyncLoggingChain(log, "b", 2))
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "a0", "a1" }), "Region b was never stepped.");
+        });
+    }
+
+    [Test]
+    public async Task async_rerun_with_different_blackboard_value_selects_different_subset()
+    {
+        List<string> log = [];
+        Blackboard board = new(Schema);
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(bb => RegionMask.Bit(bb.Get(Pick)),
+                AsyncLoggingChain(log, "a", 2), AsyncLoggingChain(log, "b", 2))
+            .Build();
+
+        AsyncStateMachine machine = parent.ToAsyncStateMachine().WithBlackboard(board);
+
+        board.Set(Pick, 0);
+        await machine.ExecuteAsync();
+        board.Set(Pick, 1);
+        await machine.ExecuteAsync();
+        board.Set(Pick, 0);
+        await machine.ExecuteAsync();
+
+        Assert.That(log, Is.EqualTo(new[] { "a0", "a1", "b0", "b1", "a0", "a1" }),
+            "Selection follows the blackboard per run; re-selected regions restart cleanly.");
+    }
+
+    [Test]
+    public async Task async_empty_mask_is_a_vacuous_success()
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(_ => RegionMask.None, AsyncLoggingChain(log, "a", 2))
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.Empty, "Nothing was stepped.");
+        });
+    }
+
+    [Test]
+    public void async_out_of_range_mask_bits_fail_loudly()
+    {
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(_ => RegionMask.Of(0, 5), AsyncLoggingChain([], "a", 2), AsyncLoggingChain([], "b", 2))
+            .Build();
+
+        Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await parent.ToAsyncStateMachine().ExecuteAsync());
+    }
+
+    [Test]
+    public async Task async_selected_region_failure_routes_through_the_parent_failure_edge()
+    {
+        bool recovered = false;
+        Graph failing = GraphBuilder.StartWithAsync(_ => ResultHelpers.Failure).Build();
+        Graph healthy = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(_ => RegionMask.Of(0, 1), healthy, failing)
+            .OnErrorAsync(_ =>
+            {
+                recovered = true;
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(recovered, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task async_unselected_failing_region_does_not_fail_the_join()
+    {
+        Graph failing = GraphBuilder.StartWithAsync(_ => ResultHelpers.Failure).Build();
+        Graph healthy = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(_ => RegionMask.Bit(0), healthy, failing)
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.That(result, Is.EqualTo(Result.Success), "The failing region was not selected.");
+    }
+
+    [Test]
+    public async Task context_is_forwarded_to_selector_and_region_nodes()
+    {
+        // The stamping walk stops at the composite (IBlackboardSettable); this fails if the
+        // composite does not forward the context to its region machines.
+        Blackboard board = new(Schema);
+        board.Set(Pick, 1);
+
+        Graph regionA = GraphBuilder.StartWithAsync((bb, _) =>
+        {
+            bb.GetRef(RegionReads)++;
+            return ResultHelpers.Success;
+        }).Build();
+
+        Graph regionB = GraphBuilder.StartWithAsync((bb, _) =>
+        {
+            bb.GetRef(RegionReads)++;
+            return ResultHelpers.Success;
+        }).Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(bb => RegionMask.Bit(bb.Get(Pick)), regionA, regionB) // selector reads...
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(board.Get(RegionReads), Is.EqualTo(1), "...and the selected region node writes.");
+        });
+    }
+
+    [Test]
+    public async Task async_agent_injection_reaches_region_graphs()
+    {
+        List<string> log = [];
+        Graph region = GraphBuilder
+            .StartWithAsync(new AsyncRelayState<List<string>>((agent, _) =>
+            {
+                agent.Add("region-saw-agent");
+                return ResultHelpers.Success;
+            }))
+            .Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(_ => RegionMask.Bit(0), region)
+            .Build();
+
+        AsyncStateMachine<List<string>> machine = parent.ToAsyncStateMachine<List<string>>();
+        machine.SetAgent(log);
+        await machine.ExecuteAsync();
+
+        Assert.That(log, Is.EqualTo(new[] { "region-saw-agent" }));
+    }
+
+    [Test]
+    public void more_than_64_regions_are_rejected()
+    {
+        Graph[] regions = new Graph[65];
+        for (int i = 0; i < regions.Length; i++)
+        {
+            regions[i] = GraphBuilder.StartWith(() => Result.Success).Build();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentException>(() => _ = new AsyncDynamicParallelState(_ => RegionMask.None, regions));
+            Assert.Throws<ArgumentException>(() =>
+                _ = new DynamicParallelState(ParallelStepMode.RunToJoin, _ => RegionMask.None, regions));
+        });
+    }
+
+    // ── Sync composite ───────────────────────────────────────────────────
+
+    [Test]
+    public void sync_run_to_join_steps_only_the_selected_subset_in_one_tick()
+    {
+        List<string> log = [];
+        Blackboard board = new(Schema);
+        board.Set(Pick, 1);
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RunToJoin, bb => RegionMask.Bit(bb.Get(Pick)),
+                SyncLoggingChain(log, "a", 2), SyncLoggingChain(log, "b", 2))
+            .Build();
+
+        Result result = parent.ToStateMachine().WithBlackboard(board).Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "b0", "b1" }));
+        });
+    }
+
+    [Test]
+    public void sync_round_per_tick_selection_is_fixed_at_visit_entry()
+    {
+        List<string> log = [];
+        Blackboard board = new(Schema);
+        board.Set(Pick, 0);
+
+        // Selector picks {a, b} when Pick == 0, else {b} only.
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick,
+                bb => bb.Get(Pick) == 0 ? RegionMask.Of(0, 1) : RegionMask.Bit(1),
+                SyncLoggingChain(log, "a", 3), SyncLoggingChain(log, "b", 3))
+            .Build();
+
+        StateMachine machine = parent.ToStateMachine().WithBlackboard(board);
+
+        Assert.That(machine.Execute(), Is.EqualTo(Result.InProgress));
+        Assert.That(log, Is.EqualTo(new[] { "a0", "b0" }));
+
+        // Mid-run change must NOT re-select: region a keeps stepping until the join.
+        board.Set(Pick, 1);
+        Assert.That(machine.Execute(), Is.EqualTo(Result.InProgress));
+        Assert.That(log, Is.EqualTo(new[] { "a0", "b0", "a1", "b1" }),
+            "Selection is evaluated once per visit — a is still active after the mid-run change.");
+
+        Assert.That(machine.Execute(), Is.EqualTo(Result.Success));
+        Assert.That(log, Is.EqualTo(new[] { "a0", "b0", "a1", "b1", "a2", "b2" }));
+
+        // The next visit re-evaluates the selector and drops region a.
+        Result rerun = machine.Execute();
+        while (rerun == Result.InProgress)
+        {
+            rerun = machine.Execute();
+        }
+
+        Assert.That(log.Skip(6), Is.EqualTo(new[] { "b0", "b1", "b2" }),
+            "The new visit selected only region b.");
+    }
+
+    [Test]
+    public void sync_empty_mask_is_a_vacuous_success()
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick, _ => RegionMask.None, SyncLoggingChain(log, "a", 2))
+            .Build();
+
+        Result result = parent.ToStateMachine().Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void sync_out_of_range_mask_bits_fail_loudly()
+    {
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RunToJoin, _ => RegionMask.Bit(2),
+                SyncLoggingChain([], "a", 2), SyncLoggingChain([], "b", 2))
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() => parent.ToStateMachine().Execute());
+    }
+
+    [Test]
+    public void sync_selected_region_failure_routes_through_the_parent_failure_edge()
+    {
+        bool recovered = false;
+        Graph failing = GraphBuilder.StartWith(() => Result.Failure).Build();
+        Graph healthy = GraphBuilder.StartWith(() => Result.Success).Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick, _ => RegionMask.Of(0, 1), healthy, failing)
+            .OnError(() =>
+            {
+                recovered = true;
+                return Result.Success;
+            })
+            .Build();
+
+        StateMachine machine = parent.ToStateMachine();
+        Result result = machine.Execute();
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(recovered, Is.True);
+        });
+    }
+}

--- a/NxGraph.Tests/ObserverExceptionTests.cs
+++ b/NxGraph.Tests/ObserverExceptionTests.cs
@@ -80,4 +80,71 @@ public class ObserverExceptionTests
 
         Assert.ThrowsAsync<InvalidOperationException>(async () => await fsm.ExecuteAsync());
     }
+
+    private sealed class ThrowOnceOnStartedObserver : IAsyncStateMachineObserver
+    {
+        private bool _thrown;
+
+        public ValueTask OnStateMachineStarted(NodeId graphId, CancellationToken ct = default)
+        {
+            if (!_thrown)
+            {
+                _thrown = true;
+                throw new InvalidOperationException("observer started boom");
+            }
+
+            return default;
+        }
+    }
+
+    [Test]
+    public async Task observer_exception_at_run_start_does_not_permanently_lock_the_machine()
+    {
+        // Regression: an observer throwing during ExecuteAsync's run-start sequence escaped
+        // with the execute gate still held, so every later call threw "already executing"
+        // forever with no recovery API.
+        AsyncStateMachine fsm = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .ToAsyncStateMachine(new ThrowOnceOnStartedObserver());
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await fsm.ExecuteAsync());
+
+        Result result = await fsm.ExecuteAsync();
+        Assert.That(result, Is.EqualTo(Result.Success),
+            "The machine must stay usable after an observer throw at run start.");
+    }
+
+    private sealed class CompletionRecordingThrowingObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<Result> CompletedResults = [];
+
+        public ValueTask OnStateMachineCompleted(NodeId graphId, Result result, CancellationToken ct = default)
+        {
+            CompletedResults.Add(result);
+            throw new InvalidOperationException("observer completed boom");
+        }
+    }
+
+    [Test]
+    public void observer_exception_at_completion_does_not_refire_completed_or_flip_the_result()
+    {
+        // Regression: an observer throwing inside the Completed notification fell into the
+        // generic failure handler, which re-transitioned Completed -> Failed and fired a
+        // second OnStateMachineCompleted(Failure) for a run that actually succeeded.
+        CompletionRecordingThrowingObserver observer = new();
+        AsyncStateMachine fsm = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .ToAsyncStateMachine(observer);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await fsm.ExecuteAsync());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observer.CompletedResults, Is.EqualTo(new[] { Result.Success }),
+                "OnStateMachineCompleted must fire exactly once, with the run's true result.");
+            Assert.That(fsm.Status, Is.EqualTo(ExecutionStatus.Completed),
+                "A successful run must not be flipped to Failed by an observer throw.");
+        });
+    }
 }

--- a/NxGraph.Tests/PublicApi/NxGraph.Serialization.Abstraction.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.Serialization.Abstraction.approved.txt
@@ -1,3 +1,12 @@
+enum NxGraph.Serialization.Abstraction.BlackboardMismatchPolicy : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Skip = 1
+  Strict = 0
+interface NxGraph.Serialization.Abstraction.IBlackboardBinarySerializer
+  method System.Threading.Tasks.ValueTask RestoreFromBinaryAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, NxGraph.Serialization.Abstraction.BlackboardMismatchPolicy, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask ToBinaryAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, System.Threading.CancellationToken)
+interface NxGraph.Serialization.Abstraction.IBlackboardJsonSerializer
+  method System.Threading.Tasks.ValueTask RestoreFromJsonAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, NxGraph.Serialization.Abstraction.BlackboardMismatchPolicy, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask ToJsonAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, System.Threading.CancellationToken)
 interface NxGraph.Serialization.Abstraction.IGraphBinarySerializer : NxGraph.Serialization.Abstraction.IGraphSerializer
   method System.Threading.Tasks.ValueTask ToBinaryAsync(NxGraph.Graphs.Graph, System.IO.Stream, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.Graph] FromBinaryAsync(System.IO.Stream, System.Threading.CancellationToken)

--- a/NxGraph.Tests/PublicApi/NxGraph.Serialization.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.Serialization.approved.txt
@@ -1,3 +1,9 @@
+sealed class NxGraph.Serialization.BlackboardSerializer : NxGraph.Serialization.Abstraction.IBlackboardBinarySerializer, NxGraph.Serialization.Abstraction.IBlackboardJsonSerializer
+  ctor Void .ctor(System.Text.Json.JsonSerializerOptions, MessagePack.MessagePackSerializerOptions)
+  method System.Threading.Tasks.ValueTask RestoreFromBinaryAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, NxGraph.Serialization.Abstraction.BlackboardMismatchPolicy, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask RestoreFromJsonAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, NxGraph.Serialization.Abstraction.BlackboardMismatchPolicy, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask ToBinaryAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask ToJsonAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, System.Threading.CancellationToken)
 sealed class NxGraph.Serialization.GraphSerializer : NxGraph.Serialization.Abstraction.IGraphBinarySerializer, NxGraph.Serialization.Abstraction.IGraphJsonSerializer, NxGraph.Serialization.Abstraction.IGraphSerializer
   ctor Void .ctor(NxGraph.Serialization.Abstraction.ILogicCodec)
   method NxGraph.Serialization.Abstraction.IGraphBinarySerializer AsBinarySerializer()

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -6,13 +6,24 @@ static class NxGraph.Authoring.Dsl
   method AsyncSwitchBuilder`1 SwitchAsync[TKey](NxGraph.Authoring.StateToken, System.Func`1[System.Threading.Tasks.ValueTask`1[TKey]])
   method BranchBuilder SetName(BranchBuilder, System.String)
   method BranchBuilder Then(IfBuilder, System.Func`1[NxGraph.Result])
+  method BranchBuilder Then(IfBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method BranchBuilder ThenAsync(IfBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method BranchBuilder ThenAsync(IfBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method BranchBuilder To(BranchBuilder, System.Func`1[NxGraph.Result])
+  method BranchBuilder To(BranchBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method BranchBuilder ToAsync(BranchBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method BranchBuilder ToAsync(BranchBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method BranchBuilder WithSchema(BranchBuilder, NxGraph.Blackboards.BlackboardSchema)
   method BranchEnd Else(BranchBuilder, System.Func`1[NxGraph.Result])
+  method BranchEnd Else(BranchBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method BranchEnd ElseAsync(BranchBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method BranchEnd ElseAsync(BranchBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method BranchEnd SetName(BranchEnd, System.String)
+  method BranchEnd WithSchema(BranchEnd, NxGraph.Blackboards.BlackboardSchema)
+  method IfBuilder If(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Boolean])
   method IfBuilder If(NxGraph.Authoring.StateToken, System.Func`1[System.Boolean])
+  method IfBuilder If(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Boolean])
+  method NxGraph.Authoring.StartToken WithSchema(NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardSchema)
   method NxGraph.Authoring.StateToken OnError(NxGraph.Authoring.StateToken, System.Func`1[NxGraph.Result])
   method NxGraph.Authoring.StateToken OnErrorAsync(NxGraph.Authoring.StateToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, NxGraph.Graphs.Graph[])
@@ -22,16 +33,25 @@ static class NxGraph.Authoring.Dsl
   method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StartToken, NxGraph.Graphs.Graph, Boolean)
   method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StateToken, NxGraph.Graphs.Graph, Boolean)
   method NxGraph.Authoring.StateToken To(BranchEnd, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(BranchEnd, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StartToken, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method NxGraph.Authoring.StateToken ToAsync(BranchEnd, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(BranchEnd, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StartToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StateToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StateToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TAgent](NxGraph.Authoring.StateToken, System.Func`4[TAgent,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken To[TAgent](NxGraph.Authoring.StateToken, System.Func`3[TAgent,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method NxGraph.Authoring.StateToken WaitForAsync(NxGraph.Authoring.StartToken, System.TimeSpan)
   method NxGraph.Authoring.StateToken WaitForAsync(NxGraph.Authoring.StateToken, System.TimeSpan)
+  method NxGraph.Authoring.StateToken WithSchema(NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardSchema)
   method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(BranchBuilder, NxGraph.Fsm.IAsyncStateMachineObserver)
   method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Authoring.StartToken, NxGraph.Fsm.IAsyncStateMachineObserver)
   method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Authoring.StateToken, NxGraph.Fsm.IAsyncStateMachineObserver)
@@ -51,10 +71,16 @@ static class NxGraph.Authoring.Dsl
   method NxGraph.Graphs.Graph Build(BranchBuilder)
   method NxGraph.Graphs.Graph SetName(NxGraph.Graphs.Graph, System.String)
   method SwitchBuilder`1 CaseAsync[TKey](SwitchBuilder`1, TKey, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method SwitchBuilder`1 CaseAsync[TKey](SwitchBuilder`1, TKey, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method SwitchBuilder`1 Case[TKey](SwitchBuilder`1, TKey, System.Func`1[NxGraph.Result])
+  method SwitchBuilder`1 Case[TKey](SwitchBuilder`1, TKey, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method SwitchBuilder`1 DefaultAsync[TKey](SwitchBuilder`1, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method SwitchBuilder`1 DefaultAsync[TKey](SwitchBuilder`1, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method SwitchBuilder`1 Default[TKey](SwitchBuilder`1, System.Func`1[NxGraph.Result])
+  method SwitchBuilder`1 Default[TKey](SwitchBuilder`1, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method SwitchBuilder`1 Switch[TKey](NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,TKey])
   method SwitchBuilder`1 Switch[TKey](NxGraph.Authoring.StateToken, System.Func`1[TKey])
+  method SwitchBuilder`1 Switch[TKey](NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,TKey])
   method System.TimeSpan Days(Double)
   method System.TimeSpan Days(Int32)
   method System.TimeSpan Hours(Double)
@@ -65,6 +91,7 @@ static class NxGraph.Authoring.Dsl
   method System.TimeSpan Minutes(Int32)
   method System.TimeSpan Seconds(Double)
   method System.TimeSpan Seconds(Int32)
+  method T WithBlackboard[T](T, NxGraph.Blackboards.Blackboard)
 struct NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1
   method AsyncSwitchBuilder`1 Case(TKey, NxGraph.Graphs.ILogic)
   method AsyncSwitchBuilder`1 CaseAsync(TKey, NxGraph.Graphs.IAsyncLogic)
@@ -109,11 +136,14 @@ sealed class NxGraph.Authoring.GraphBuilder
   method NxGraph.Authoring.GraphBuilder SetExitAction(NxGraph.Graphs.NodeId, System.Action)
   method NxGraph.Authoring.GraphBuilder SetOutcome(NxGraph.Graphs.NodeId, Int32, System.String)
   method NxGraph.Authoring.GraphBuilder SetRetryPolicy(NxGraph.Graphs.NodeId, NxGraph.Fsm.RetryPolicy)
+  method NxGraph.Authoring.GraphBuilder WithSchema(NxGraph.Blackboards.BlackboardSchema)
   method NxGraph.Authoring.StartToken Start()
   method NxGraph.Authoring.StateToken StartWith(NxGraph.Graphs.ILogic)
   method NxGraph.Authoring.StateToken StartWith(System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken StartWith(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method NxGraph.Authoring.StateToken StartWithAsync(NxGraph.Graphs.IAsyncLogic)
   method NxGraph.Authoring.StateToken StartWithAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken StartWithAsync(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken TokenFor(NxGraph.Graphs.NodeId)
   method NxGraph.Diagnostics.Validations.GraphValidationResult Validate(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Validations.GraphValidationOptions)
   method NxGraph.Graphs.Graph Build(Boolean)
@@ -156,6 +186,60 @@ struct NxGraph.Authoring.StateToken
   method NxGraph.Graphs.Graph Build()
   property NxGraph.Authoring.GraphBuilder Builder { get; }
   property NxGraph.Graphs.NodeId Id { get; }
+sealed class NxGraph.Blackboards.Blackboard
+  ctor Void .ctor(NxGraph.Blackboards.BlackboardSchema)
+  method Boolean TryGet[T](NxGraph.Blackboards.BlackboardKey`1[T], T ByRef)
+  method T Get[T](NxGraph.Blackboards.BlackboardKey`1[T])
+  method T& GetRef[T](NxGraph.Blackboards.BlackboardKey`1[T])
+  method Void ResetToDefaults()
+  method Void Set[T](NxGraph.Blackboards.BlackboardKey`1[T], T)
+  property NxGraph.Blackboards.BlackboardSchema Schema { get; }
+struct NxGraph.Blackboards.BlackboardContext
+  ctor Void .ctor(NxGraph.Blackboards.Blackboard, NxGraph.Blackboards.Blackboard)
+  method Boolean HasBoard(NxGraph.Blackboards.BlackboardScope)
+  method Boolean TryGet[T](NxGraph.Blackboards.BlackboardKey`1[T], T ByRef)
+  method NxGraph.Blackboards.Blackboard Board(NxGraph.Blackboards.BlackboardScope)
+  method NxGraph.Blackboards.BlackboardContext With(NxGraph.Blackboards.Blackboard)
+  method T Get[T](NxGraph.Blackboards.BlackboardKey`1[T])
+  method T& GetRef[T](NxGraph.Blackboards.BlackboardKey`1[T])
+  method Void Set[T](NxGraph.Blackboards.BlackboardKey`1[T], T)
+  property Boolean IsEmpty { get; }
+  property NxGraph.Blackboards.Blackboard Global { get; }
+  property NxGraph.Blackboards.Blackboard Graph { get; }
+abstract class NxGraph.Blackboards.BlackboardKeyDescriptor
+  method System.Object GetValue(NxGraph.Blackboards.Blackboard)
+  method Void ResetValue(NxGraph.Blackboards.Blackboard)
+  method Void SetValue(NxGraph.Blackboards.Blackboard, System.Object)
+  property Int32 Ordinal { get; }
+  property System.String Name { get; }
+  property System.Type ValueType { get; }
+struct NxGraph.Blackboards.BlackboardKey`1 : IEquatable`1
+  method Boolean Equals(NxGraph.Blackboards.BlackboardKey`1[T])
+  method Boolean Equals(System.Object)
+  method Int32 GetHashCode()
+  method System.String ToString()
+  operator Boolean op_Equality(NxGraph.Blackboards.BlackboardKey`1[T], NxGraph.Blackboards.BlackboardKey`1[T])
+  operator Boolean op_Inequality(NxGraph.Blackboards.BlackboardKey`1[T], NxGraph.Blackboards.BlackboardKey`1[T])
+  property Boolean IsValid { get; }
+  property System.String Name { get; }
+sealed class NxGraph.Blackboards.BlackboardSchema
+  ctor Void .ctor(System.String, NxGraph.Blackboards.BlackboardScope)
+  method Boolean TryGetKey(System.String, NxGraph.Blackboards.BlackboardKeyDescriptor ByRef)
+  method NxGraph.Blackboards.BlackboardKey`1[T] Register[T](System.String)
+  method NxGraph.Blackboards.BlackboardKey`1[T] Register[T](System.String, T)
+  property Boolean IsFrozen { get; }
+  property Int32 KeyCount { get; }
+  property NxGraph.Blackboards.BlackboardScope Scope { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Blackboards.BlackboardKeyDescriptor] Keys { get; }
+  property System.String Name { get; }
+enum NxGraph.Blackboards.BlackboardScope : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Global = 0
+  Graph = 1
+  Node = 2
+interface NxGraph.Blackboards.IBlackboardBindable
+  method Void SetBlackboard(NxGraph.Blackboards.Blackboard)
+interface NxGraph.Blackboards.IBlackboardSettable
+  method Void SetBlackboards(NxGraph.Blackboards.BlackboardContext ByRef)
 class NxGraph.Diagnostics.Export.ExportOptions
   ctor Void .ctor()
 enum NxGraph.Diagnostics.Export.FlowDirection : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
@@ -254,12 +338,13 @@ enum NxGraph.Diagnostics.Validations.Severity : System.IComparable, System.IConv
   Error = 2
   Info = 0
   Warning = 1
-sealed class NxGraph.Fsm.Async.AsyncChoiceState : NxGraph.Fsm.IAsyncDirector, NxGraph.Graphs.IAsyncLogic
+sealed class NxGraph.Fsm.Async.AsyncChoiceState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.IAsyncDirector, NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor(System.Func`1[System.Threading.Tasks.ValueTask`1[System.Boolean]], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Threading.Tasks.ValueTask`1[System.Boolean]], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
   method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
   method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
-class NxGraph.Fsm.Async.AsyncCompositeState : NxGraph.Fsm.Async.AsyncState, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+class NxGraph.Fsm.Async.AsyncCompositeState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor(NxGraph.Graphs.IAsyncLogic)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
 sealed class NxGraph.Fsm.Async.AsyncHistoryState : NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
@@ -270,25 +355,28 @@ sealed class NxGraph.Fsm.Async.AsyncParallelState : NxGraph.Graphs.IAsyncLogic, 
   ctor Void .ctor(NxGraph.Graphs.Graph[])
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
   property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.Async.AsyncStateMachine] Regions { get; }
-sealed class NxGraph.Fsm.Async.AsyncRelayState : NxGraph.Fsm.Async.AsyncState, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+sealed class NxGraph.Fsm.Async.AsyncRelayState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  ctor Void .ctor(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
-sealed class NxGraph.Fsm.Async.AsyncRelayState`1 : AsyncState`1, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+sealed class NxGraph.Fsm.Async.AsyncRelayState`1 : AsyncState`1, IAgentSettable`1, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor(System.Func`3[TAgent,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[TAgent,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[TAgent,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  ctor Void .ctor(System.Func`4[TAgent,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`4[TAgent,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`4[TAgent,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
-abstract class NxGraph.Fsm.Async.AsyncState : NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+abstract class NxGraph.Fsm.Async.AsyncState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor()
   method System.Threading.Tasks.ValueTask LogAsync(System.String, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  property NxGraph.Blackboards.BlackboardContext Bb { get; }
   property System.Func`3[System.String,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask] LogReport { get; set; }
-class NxGraph.Fsm.Async.AsyncStateMachine : NxGraph.Fsm.Async.AsyncState, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+class NxGraph.Fsm.Async.AsyncStateMachine : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
   field readonly NxGraph.Graphs.Graph Graph
   method NxGraph.Fsm.StateMachineSnapshot Suspend()
@@ -299,19 +387,21 @@ class NxGraph.Fsm.Async.AsyncStateMachine : NxGraph.Fsm.Async.AsyncState, NxGrap
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] StepAsync(System.Threading.CancellationToken)
   method Void Resume(NxGraph.Fsm.StateMachineSnapshot)
   method Void SetAutoReset(Boolean)
+  method Void SetBlackboard(NxGraph.Blackboards.Blackboard)
   method Void SetRestartPolicy(NxGraph.Fsm.RestartPolicy)
   property Int32 LastOutcome { get; }
   property NxGraph.Fsm.ExecutionStatus Status { get; }
   property System.String LastOutcomeName { get; }
-class NxGraph.Fsm.Async.AsyncStateMachine`1 : NxGraph.Fsm.Async.AsyncStateMachine, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+class NxGraph.Fsm.Async.AsyncStateMachine`1 : NxGraph.Fsm.Async.AsyncStateMachine, IAgentSettable`1, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
   method Void SetAgent(TAgent)
-abstract class NxGraph.Fsm.Async.AsyncState`1 : NxGraph.Fsm.Async.AsyncState, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+abstract class NxGraph.Fsm.Async.AsyncState`1 : NxGraph.Fsm.Async.AsyncState, IAgentSettable`1, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor()
   field TAgent Agent
   method Void SetAgent(TAgent)
-sealed class NxGraph.Fsm.Async.AsyncSwitchState`1 : NxGraph.Fsm.IAsyncDirector, NxGraph.Graphs.IAsyncLogic
+sealed class NxGraph.Fsm.Async.AsyncSwitchState`1 : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.IAsyncDirector, NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor(System.Func`1[System.Threading.Tasks.ValueTask`1[TKey]], System.Collections.Generic.IReadOnlyDictionary`2[TKey,NxGraph.Graphs.NodeId], NxGraph.Graphs.NodeId)
+  ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Threading.Tasks.ValueTask`1[TKey]], System.Collections.Generic.IReadOnlyDictionary`2[TKey,NxGraph.Graphs.NodeId], NxGraph.Graphs.NodeId)
   method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
   method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
@@ -327,8 +417,9 @@ enum NxGraph.Fsm.BackoffKind : System.IComparable, System.IConvertible, System.I
   Exponential = 2
   Fixed = 0
   Linear = 1
-sealed class NxGraph.Fsm.ChoiceState : NxGraph.Fsm.IDirector, NxGraph.Graphs.ILogic
+sealed class NxGraph.Fsm.ChoiceState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.IDirector, NxGraph.Graphs.ILogic
   ctor Void .ctor(System.Func`1[System.Boolean], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Boolean], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
   method NxGraph.Graphs.NodeId SelectNext()
   method NxGraph.Result Execute()
   method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
@@ -389,13 +480,15 @@ sealed class NxGraph.Fsm.NodeStatusTrackingObserver : NxGraph.Fsm.IAsyncStateMac
   method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
-sealed class NxGraph.Fsm.RelayState : NxGraph.Fsm.State, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+sealed class NxGraph.Fsm.RelayState : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
   ctor Void .ctor(System.Func`1[NxGraph.Result], System.Action, System.Action)
+  ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result], System.Action`1[NxGraph.Blackboards.BlackboardContext], System.Action`1[NxGraph.Blackboards.BlackboardContext])
   method NxGraph.Result OnRun()
   method Void OnEnter()
   method Void OnExit()
-sealed class NxGraph.Fsm.RelayState`1 : State`1, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+sealed class NxGraph.Fsm.RelayState`1 : State`1, IAgentSettable`1, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
   ctor Void .ctor(System.Func`2[TAgent,NxGraph.Result], System.Action`1[TAgent], System.Action`1[TAgent])
+  ctor Void .ctor(System.Func`3[TAgent,NxGraph.Blackboards.BlackboardContext,NxGraph.Result], System.Action`2[TAgent,NxGraph.Blackboards.BlackboardContext], System.Action`2[TAgent,NxGraph.Blackboards.BlackboardContext])
   method NxGraph.Result OnRun()
   method Void OnEnter()
   method Void OnExit()
@@ -410,15 +503,16 @@ struct NxGraph.Fsm.RetryPolicy
   property Byte MaxAttempts { get; }
   property NxGraph.Fsm.BackoffKind BackoffKind { get; }
   property System.TimeSpan Backoff { get; }
-abstract class NxGraph.Fsm.State : NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+abstract class NxGraph.Fsm.State : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
   ctor Void .ctor()
   method NxGraph.Result Execute()
   method NxGraph.Result OnRun()
   method Void Log(System.String)
   method Void OnEnter()
   method Void OnExit()
+  property NxGraph.Blackboards.BlackboardContext Bb { get; }
   property System.Action`1[System.String] SyncLogReport { get; set; }
-class NxGraph.Fsm.StateMachine : NxGraph.Fsm.State, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+class NxGraph.Fsm.StateMachine : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
   field readonly NxGraph.Graphs.Graph Graph
   method NxGraph.Fsm.StateMachineSnapshot Suspend()
@@ -428,6 +522,7 @@ class NxGraph.Fsm.StateMachine : NxGraph.Fsm.State, NxGraph.Diagnostics.Replay.I
   method Void OnExit()
   method Void Resume(NxGraph.Fsm.StateMachineSnapshot)
   method Void SetAutoReset(Boolean)
+  method Void SetBlackboard(NxGraph.Blackboards.Blackboard)
   method Void SetResetPolicy(NxGraph.Fsm.RestartPolicy)
   property Int32 LastOutcome { get; }
   property NxGraph.Fsm.ExecutionStatus Status { get; }
@@ -448,15 +543,16 @@ sealed class NxGraph.Fsm.StateMachineSnapshot : System.IEquatable`1[[NxGraph.Fsm
   property Int32 CurrentNodeIndex { get; set; }
   property Int32 LastOutcome { get; set; }
   property NxGraph.Fsm.ExecutionStatus Status { get; set; }
-class NxGraph.Fsm.StateMachine`1 : NxGraph.Fsm.StateMachine, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+class NxGraph.Fsm.StateMachine`1 : NxGraph.Fsm.StateMachine, IAgentSettable`1, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
   method Void SetAgent(TAgent)
-abstract class NxGraph.Fsm.State`1 : NxGraph.Fsm.State, IAgentSettable`1, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+abstract class NxGraph.Fsm.State`1 : NxGraph.Fsm.State, IAgentSettable`1, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
   ctor Void .ctor()
   field TAgent Agent
   method Void SetAgent(TAgent)
-sealed class NxGraph.Fsm.SwitchState`1 : NxGraph.Fsm.IDirector, NxGraph.Graphs.ILogic
+sealed class NxGraph.Fsm.SwitchState`1 : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.IDirector, NxGraph.Graphs.ILogic
   ctor Void .ctor(System.Func`1[TKey], System.Collections.Generic.IReadOnlyDictionary`2[TKey,NxGraph.Graphs.NodeId], NxGraph.Graphs.NodeId)
+  ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,TKey], System.Collections.Generic.IReadOnlyDictionary`2[TKey,NxGraph.Graphs.NodeId], NxGraph.Graphs.NodeId)
   method NxGraph.Graphs.NodeId SelectNext()
   method NxGraph.Result Execute()
   method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
@@ -481,16 +577,19 @@ sealed class NxGraph.Graphs.EmptyLogic : NxGraph.Graphs.ILogic
   ctor Void .ctor()
   method NxGraph.Result Execute()
 sealed class NxGraph.Graphs.Graph : NxGraph.Graphs.IGraph, NxGraph.Graphs.INode
-  ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode[], NxGraph.Graphs.Transition[], NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.RetryPolicy[], Int32[], System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String])
+  ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode[], NxGraph.Graphs.Transition[], NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.RetryPolicy[], Int32[], System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String], NxGraph.Blackboards.BlackboardSchema, NxGraph.Blackboards.BlackboardSchema)
   method Boolean TryGetNode(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode ByRef)
   method Boolean TryGetNodeByIndex(Int32, NxGraph.Graphs.INode ByRef)
   method Boolean TryGetTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.Transition ByRef)
   method NxGraph.Graphs.INode GetNodeByIndex(Int32)
   method NxGraph.Graphs.Transition GetTransitionByIndex(Int32)
   method Void SetAgent[TAgent](TAgent)
+  method Void SetBlackboards(NxGraph.Blackboards.BlackboardContext ByRef)
   property Int32 NodeCount { get; }
   property Int32 TransitionCount { get; }
   property Int32[] OutcomeCodes { get; }
+  property NxGraph.Blackboards.BlackboardSchema GlobalSchema { get; }
+  property NxGraph.Blackboards.BlackboardSchema Schema { get; }
   property NxGraph.Fsm.RetryPolicy[] RetryPolicies { get; }
   property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
   property NxGraph.Graphs.ILogic Logic { get; }

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -26,7 +26,9 @@ static class NxGraph.Authoring.Dsl
   method NxGraph.Authoring.StartToken WithSchema(NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardSchema)
   method NxGraph.Authoring.StateToken OnError(NxGraph.Authoring.StateToken, System.Func`1[NxGraph.Result])
   method NxGraph.Authoring.StateToken OnErrorAsync(NxGraph.Authoring.StateToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph[])
   method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph[])
   method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, NxGraph.Graphs.Graph[])
   method NxGraph.Authoring.StateToken SetName(NxGraph.Authoring.StateToken, System.String)
   method NxGraph.Authoring.StateToken StartWithTimeoutAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
@@ -480,6 +482,14 @@ sealed class NxGraph.Fsm.NodeStatusTrackingObserver : NxGraph.Fsm.IAsyncStateMac
   method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.ParallelState : NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph[])
+  method NxGraph.Result Execute()
+  property NxGraph.Fsm.ParallelStepMode Mode { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.StateMachine] Regions { get; }
+enum NxGraph.Fsm.ParallelStepMode : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  RoundPerTick = 1
+  RunToJoin = 0
 sealed class NxGraph.Fsm.RelayState : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
   ctor Void .ctor(System.Func`1[NxGraph.Result], System.Action, System.Action)
   ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result], System.Action`1[NxGraph.Blackboards.BlackboardContext], System.Action`1[NxGraph.Blackboards.BlackboardContext])

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -350,18 +350,18 @@ sealed class NxGraph.Fsm.Async.AsyncChoiceState : NxGraph.Blackboards.IBlackboar
   method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
   method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
-class NxGraph.Fsm.Async.AsyncCompositeState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+class NxGraph.Fsm.Async.AsyncCompositeState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.IAsyncLogic)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
 sealed class NxGraph.Fsm.Async.AsyncDynamicParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
   property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.Async.AsyncStateMachine] Regions { get; }
-sealed class NxGraph.Fsm.Async.AsyncHistoryState : NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+sealed class NxGraph.Fsm.Async.AsyncHistoryState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
   property NxGraph.Fsm.Async.AsyncStateMachine Child { get; }
-sealed class NxGraph.Fsm.Async.AsyncParallelState : NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+sealed class NxGraph.Fsm.Async.AsyncParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph[])
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
   property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.Async.AsyncStateMachine] Regions { get; }
@@ -495,7 +495,7 @@ sealed class NxGraph.Fsm.NodeStatusTrackingObserver : NxGraph.Fsm.IAsyncStateMac
   method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
-sealed class NxGraph.Fsm.ParallelState : NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+sealed class NxGraph.Fsm.ParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph[])
   method NxGraph.Result Execute()
   property NxGraph.Fsm.ParallelStepMode Mode { get; }

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -27,9 +27,13 @@ static class NxGraph.Authoring.Dsl
   method NxGraph.Authoring.StateToken OnError(NxGraph.Authoring.StateToken, System.Func`1[NxGraph.Result])
   method NxGraph.Authoring.StateToken OnErrorAsync(NxGraph.Authoring.StateToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, NxGraph.Fsm.ParallelStepMode, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
   method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
   method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, NxGraph.Fsm.ParallelStepMode, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
   method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
   method NxGraph.Authoring.StateToken SetName(NxGraph.Authoring.StateToken, System.String)
   method NxGraph.Authoring.StateToken StartWithTimeoutAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StartToken, NxGraph.Graphs.Graph, Boolean)
@@ -349,6 +353,10 @@ sealed class NxGraph.Fsm.Async.AsyncChoiceState : NxGraph.Blackboards.IBlackboar
 class NxGraph.Fsm.Async.AsyncCompositeState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor(NxGraph.Graphs.IAsyncLogic)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.Async.AsyncDynamicParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.Async.AsyncStateMachine] Regions { get; }
 sealed class NxGraph.Fsm.Async.AsyncHistoryState : NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
@@ -425,6 +433,11 @@ sealed class NxGraph.Fsm.ChoiceState : NxGraph.Blackboards.IBlackboardSettable, 
   method NxGraph.Graphs.NodeId SelectNext()
   method NxGraph.Result Execute()
   method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+sealed class NxGraph.Fsm.DynamicParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Fsm.ParallelStepMode, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
+  method NxGraph.Result Execute()
+  property NxGraph.Fsm.ParallelStepMode Mode { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.StateMachine] Regions { get; }
 enum NxGraph.Fsm.ExecutionStatus : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
   Cancelled = 6
   Completed = 4
@@ -490,6 +503,21 @@ sealed class NxGraph.Fsm.ParallelState : NxGraph.Graphs.ILogic, NxGraph.Graphs.I
 enum NxGraph.Fsm.ParallelStepMode : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
   RoundPerTick = 1
   RunToJoin = 0
+struct NxGraph.Fsm.RegionMask : System.IEquatable`1[[NxGraph.Fsm.RegionMask, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+  method Boolean Contains(Int32)
+  method Boolean Equals(NxGraph.Fsm.RegionMask)
+  method Boolean Equals(System.Object)
+  method Int32 GetHashCode()
+  method NxGraph.Fsm.RegionMask All(Int32)
+  method NxGraph.Fsm.RegionMask Bit(Int32)
+  method NxGraph.Fsm.RegionMask Of(Int32[])
+  method System.String ToString()
+  operator Boolean op_Equality(NxGraph.Fsm.RegionMask, NxGraph.Fsm.RegionMask)
+  operator Boolean op_Inequality(NxGraph.Fsm.RegionMask, NxGraph.Fsm.RegionMask)
+  operator NxGraph.Fsm.RegionMask op_BitwiseOr(NxGraph.Fsm.RegionMask, NxGraph.Fsm.RegionMask)
+  property Boolean IsEmpty { get; }
+  property Int32 Count { get; }
+  property NxGraph.Fsm.RegionMask None { get; }
 sealed class NxGraph.Fsm.RelayState : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
   ctor Void .ctor(System.Func`1[NxGraph.Result], System.Action, System.Action)
   ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result], System.Action`1[NxGraph.Blackboards.BlackboardContext], System.Action`1[NxGraph.Blackboards.BlackboardContext])

--- a/NxGraph.Tests/ReplayTests.cs
+++ b/NxGraph.Tests/ReplayTests.cs
@@ -386,6 +386,49 @@ public class ReplayTests
     }
 
     [Test]
+    public async Task Recorder_survives_a_failure_edge_and_records_the_result_failure()
+    {
+        // Regression: the failure-edge path passes a null Exception to OnStateFailed;
+        // ReplayRecorder used to call ex.ToString() unconditionally and crash the run with
+        // a NullReferenceException — on exactly the path it exists to diagnose.
+        ReplayRecorder recorder = new();
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Failure)
+            .OnErrorAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine(recorder).ExecuteAsync();
+
+        ReplayEvent failed = recorder.GetEvents().ToArray().Single(e => e.Type == EventType.StateFailed);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(failed.Message, Is.EqualTo("node returned Failure"));
+        });
+    }
+
+    [Test]
+    public void Sync_recorder_survives_a_failure_edge_and_records_the_result_failure()
+    {
+        ReplayRecorder recorder = new();
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Failure)
+            .OnError(() => Result.Success)
+            .Build();
+
+        StateMachine fsm = graph.ToStateMachine(recorder);
+        Result result;
+        do { result = fsm.Execute(); } while (result == Result.InProgress);
+
+        ReplayEvent failed = recorder.GetEvents().ToArray().Single(e => e.Type == EventType.StateFailed);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(failed.Message, Is.EqualTo("node returned Failure"));
+        });
+    }
+
+    [Test]
     public void Deserialize_rejects_payload_with_unknown_event_type_byte()
     {
         using MemoryStream ms = new();

--- a/NxGraph.Tests/StateMachineTests.cs
+++ b/NxGraph.Tests/StateMachineTests.cs
@@ -650,7 +650,10 @@ public class StateMachineTests
     private sealed class FailRecordingObserver : IStateMachineObserver
     {
         public readonly List<Exception> FailedExceptions = [];
-        public void OnStateFailed(NodeId id, Exception ex) => FailedExceptions.Add(ex);
+        public void OnStateFailed(NodeId id, Exception? ex)
+        {
+            if (ex is not null) FailedExceptions.Add(ex);
+        }
     }
 
     private sealed class ExplosiveSyncObserver : IStateMachineObserver

--- a/NxGraph.Tests/SuspendResumeTests.cs
+++ b/NxGraph.Tests/SuspendResumeTests.cs
@@ -141,4 +141,29 @@ public class SuspendResumeTests
             Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }));
         });
     }
+
+    [Test]
+    public async Task resumed_failed_snapshot_under_ignore_policy_reports_failure()
+    {
+        // Regression: _terminalResult was not reconstructed on Resume, so a machine restored
+        // from a Failed snapshot under RestartPolicy.Ignore returned the field initializer's
+        // Success — contradicting its own restored status.
+        Graph graph = GraphBuilder.StartWithAsync(_ => ResultHelpers.Failure).Build();
+
+        AsyncStateMachine first = graph.ToAsyncStateMachine();
+        first.SetRestartPolicy(RestartPolicy.Manual); // keep the terminal status for Suspend
+        Result firstRun = await first.ExecuteAsync();
+        Assert.That(firstRun, Is.EqualTo(Result.Failure));
+
+        StateMachineSnapshot snapshot = first.Suspend();
+        Assert.That(snapshot.Status, Is.EqualTo(ExecutionStatus.Failed));
+
+        AsyncStateMachine second = graph.ToAsyncStateMachine();
+        second.SetRestartPolicy(RestartPolicy.Ignore);
+        second.Resume(snapshot);
+
+        Result ignored = await second.ExecuteAsync();
+        Assert.That(ignored, Is.EqualTo(Result.Failure),
+            "Ignore policy must report the restored run's true terminal result.");
+    }
 }

--- a/NxGraph.Tests/SyncParallelRegionsTests.cs
+++ b/NxGraph.Tests/SyncParallelRegionsTests.cs
@@ -1,0 +1,265 @@
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Sync twin of <see cref="ParallelRegionsTests"/> (runtime parity): same join semantics,
+/// plus the <see cref="ParallelStepMode"/> split the sync runtime adds — whole join in one
+/// tick (<see cref="ParallelStepMode.RunToJoin"/>) or one round per tick
+/// (<see cref="ParallelStepMode.RoundPerTick"/>).
+/// </summary>
+[TestFixture]
+public class SyncParallelRegionsTests
+{
+    private static Graph LoggingChain(List<string> log, string prefix, int length)
+    {
+        StateToken token = GraphBuilder.StartWith(() =>
+        {
+            log.Add($"{prefix}0");
+            return Result.Success;
+        });
+
+        for (int i = 1; i < length; i++)
+        {
+            int step = i;
+            token = token.To(() =>
+            {
+                log.Add($"{prefix}{step}");
+                return Result.Success;
+            });
+        }
+
+        return token.Build();
+    }
+
+    [Test]
+    public void run_to_join_completes_in_one_tick_with_interleaved_order()
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RunToJoin, LoggingChain(log, "a", 3), LoggingChain(log, "b", 2))
+            .Build();
+
+        Result result = parent.ToStateMachine().Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success), "The whole join costs a single tick.");
+            Assert.That(log, Is.EqualTo(new[] { "a0", "b0", "a1", "b1", "a2" }),
+                "One node per region per round; the shorter region joins early.");
+        });
+    }
+
+    [Test]
+    public void round_per_tick_advances_one_round_per_execute()
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick, LoggingChain(log, "a", 3), LoggingChain(log, "b", 2))
+            .Build();
+
+        StateMachine machine = parent.ToStateMachine();
+
+        Result tick1 = machine.Execute();
+        Assert.Multiple(() =>
+        {
+            Assert.That(tick1, Is.EqualTo(Result.InProgress));
+            Assert.That(log, Is.EqualTo(new[] { "a0", "b0" }), "First tick = first round only.");
+        });
+
+        Result tick2 = machine.Execute();
+        Assert.Multiple(() =>
+        {
+            Assert.That(tick2, Is.EqualTo(Result.InProgress));
+            Assert.That(log, Is.EqualTo(new[] { "a0", "b0", "a1", "b1" }), "Second round; region b joins.");
+        });
+
+        Result tick3 = machine.Execute();
+        Assert.Multiple(() =>
+        {
+            Assert.That(tick3, Is.EqualTo(Result.Success), "Join result lands on the final round's tick.");
+            Assert.That(log, Is.EqualTo(new[] { "a0", "b0", "a1", "b1", "a2" }));
+        });
+    }
+
+    [Test]
+    public void join_fails_when_any_region_fails_but_others_still_finish()
+    {
+        List<string> log = [];
+        Graph failing = GraphBuilder
+            .StartWith(() =>
+            {
+                log.Add("f0");
+                return Result.Failure;
+            })
+            .Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RunToJoin, LoggingChain(log, "a", 3), failing)
+            .Build();
+
+        Result result = parent.ToStateMachine().Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(log, Does.Contain("a2"), "The healthy region ran to completion before the join.");
+        });
+    }
+
+    [Test]
+    public void failed_join_routes_through_the_parent_failure_edge()
+    {
+        bool recovered = false;
+        Graph failing = GraphBuilder.StartWith(() => Result.Failure).Build();
+        Graph healthy = GraphBuilder.StartWith(() => Result.Success).Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick, healthy, failing)
+            .OnError(() =>
+            {
+                recovered = true;
+                return Result.Success;
+            })
+            .Build();
+
+        StateMachine machine = parent.ToStateMachine();
+        Result result = machine.Execute();
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(recovered, Is.True);
+        });
+    }
+
+    [TestCase(ParallelStepMode.RunToJoin)]
+    [TestCase(ParallelStepMode.RoundPerTick)]
+    public void composite_can_run_repeatedly(ParallelStepMode mode)
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(mode, LoggingChain(log, "a", 2), LoggingChain(log, "b", 2))
+            .Build();
+
+        StateMachine machine = parent.ToStateMachine();
+        for (int run = 0; run < 2; run++)
+        {
+            Result result = machine.Execute();
+            while (result == Result.InProgress)
+            {
+                result = machine.Execute();
+            }
+        }
+
+        Assert.That(log, Has.Count.EqualTo(8), "Both regions restart cleanly on the next run.");
+    }
+
+    [Test]
+    public void empty_region_list_is_rejected()
+    {
+        Assert.Throws<ArgumentException>(() => _ = new ParallelState(ParallelStepMode.RunToJoin));
+    }
+
+    [Test]
+    public void agent_injection_reaches_region_graphs()
+    {
+        List<string> log = [];
+        Graph region = GraphBuilder
+            .StartWith(new RelayState<List<string>>((agent, _) =>
+            {
+                agent.Add("region-saw-agent");
+                return Result.Success;
+            }))
+            .Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RunToJoin, region)
+            .Build();
+
+        StateMachine<List<string>> machine = parent.ToStateMachine<List<string>>();
+        machine.SetAgent(log);
+        machine.Execute();
+
+        Assert.That(log, Is.EqualTo(new[] { "region-saw-agent" }));
+    }
+
+    [Test]
+    public void blackboard_stamping_reaches_region_graphs()
+    {
+        BlackboardSchema schema = new("parallel-test");
+        BlackboardKey<int> counter = schema.Register<int>("counter");
+        Blackboard board = new(schema);
+
+        Graph regionA = GraphBuilder.StartWith(bb =>
+        {
+            bb.GetRef(counter)++;
+            return Result.Success;
+        }).Build();
+
+        Graph regionB = GraphBuilder.StartWith(bb =>
+        {
+            bb.GetRef(counter)++;
+            return Result.Success;
+        }).Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick, regionA, regionB)
+            .Build();
+
+        StateMachine machine = parent.ToStateMachine().WithBlackboard(board);
+        Result result = machine.Execute();
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.That(board.Get(counter), Is.EqualTo(2), "Both region nodes saw the machine-bound board.");
+    }
+
+    [Test]
+    public async Task run_to_join_composite_works_under_the_async_runtime()
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RunToJoin, LoggingChain(log, "a", 2), LoggingChain(log, "b", 2))
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success),
+                "RunToJoin is a plain sync node, so the async machine runs it via the adapter.");
+            Assert.That(log, Is.EqualTo(new[] { "a0", "b0", "a1", "b1" }));
+        });
+    }
+
+    [Test]
+    public void round_per_tick_is_rejected_by_the_async_runtime()
+    {
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick, LoggingChain([], "a", 2))
+            .Build();
+
+        Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await parent.ToAsyncStateMachine().ExecuteAsync(),
+            "Node-level InProgress is reserved in the async runtime — RoundPerTick is sync-only.");
+    }
+}

--- a/NxGraph.Tests/SyncSuspendResumeTests.cs
+++ b/NxGraph.Tests/SyncSuspendResumeTests.cs
@@ -162,7 +162,7 @@ public class SyncSuspendResumeTests
     }
 
     [Test]
-    public void snapshot_taken_by_async_machine_resumes_on_sync_machine()
+    public void sync_snapshot_survives_a_resume_suspend_roundtrip_through_the_async_machine()
     {
         // Same graph shape, sync-executable nodes: the snapshot format is runtime-agnostic.
         List<int> executed = [];
@@ -185,6 +185,63 @@ public class SyncSuspendResumeTests
         {
             Assert.That(result, Is.EqualTo(Result.Success));
             Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }));
+        });
+    }
+
+    [Test]
+    public async Task async_mid_run_snapshot_completes_on_the_sync_machine()
+    {
+        // True cross-runtime interchange: nodes execute under the async runtime, the run is
+        // suspended mid-flight, and the sync runtime finishes it.
+        List<int> executed = [];
+        Graph graph = CountingChain(executed);
+
+        Fsm.Async.AsyncStateMachine first = graph.ToAsyncStateMachine();
+        Result tick = await first.StepAsync();
+        Assert.That(tick, Is.EqualTo(Result.InProgress));
+
+        StateMachineSnapshot snapshot = first.Suspend();
+
+        StateMachine second = graph.ToStateMachine();
+        second.Resume(snapshot);
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }),
+                "Node 0 ran under the async machine; the sync machine continued at node 1.");
+        });
+    }
+
+    [Test]
+    public async Task sync_mid_run_snapshot_completes_on_the_async_machine()
+    {
+        // The mirror direction: nodes execute under the sync runtime, the async runtime
+        // finishes the run via StepAsync.
+        List<int> executed = [];
+        Graph graph = CountingChain(executed);
+
+        StateMachine first = graph.ToStateMachine();
+        Result tick = first.Execute();
+        Assert.That(tick, Is.EqualTo(Result.InProgress));
+
+        StateMachineSnapshot snapshot = first.Suspend();
+
+        Fsm.Async.AsyncStateMachine second = graph.ToAsyncStateMachine();
+        second.Resume(snapshot);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await second.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }),
+                "Node 0 ran under the sync machine; the async machine continued at node 1.");
         });
     }
 }

--- a/NxGraph/Authoring/Dsl.Blackboard.cs
+++ b/NxGraph/Authoring/Dsl.Blackboard.cs
@@ -1,0 +1,257 @@
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+
+namespace NxGraph.Authoring;
+
+public static partial class Dsl
+{
+    // ── Schema declaration (routed by the schema's scope) ────────────────
+
+    /// <summary>
+    /// Declares a blackboard schema on the graph being built, routed by the schema's scope:
+    /// Graph-scoped schemas become the graph's own declaration, Global-scoped schemas record
+    /// the global board the graph requires. Machines validate bound boards against these
+    /// declarations at <c>WithBlackboard(...)</c> time.
+    /// </summary>
+    public static StartToken WithSchema(this StartToken token, BlackboardSchema schema)
+    {
+        token.Builder.WithSchema(schema);
+        return token;
+    }
+
+    /// <inheritdoc cref="WithSchema(StartToken, BlackboardSchema)"/>
+    public static StateToken WithSchema(this StateToken prev, BlackboardSchema schema)
+    {
+        prev.Builder.WithSchema(schema);
+        return prev;
+    }
+
+    /// <inheritdoc cref="WithSchema(StartToken, BlackboardSchema)"/>
+    public static BranchBuilder WithSchema(this BranchBuilder branch, BlackboardSchema schema)
+    {
+        branch.Builder.WithSchema(schema);
+        return branch;
+    }
+
+    /// <inheritdoc cref="WithSchema(StartToken, BlackboardSchema)"/>
+    public static BranchEnd WithSchema(this BranchEnd branchEnd, BlackboardSchema schema)
+    {
+        branchEnd.Builder.WithSchema(schema);
+        return branchEnd;
+    }
+
+    // ── Machine binding ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Binds a blackboard to the machine, routed into the scope slot its schema declares.
+    /// Call once per scope; rebinding a scope replaces the board. Chainable in any order
+    /// with <c>WithAgent</c>:
+    /// <c>graph.ToAsyncStateMachine&lt;Enemy&gt;().WithBlackboard(worldBb).WithBlackboard(enemyBb).WithAgent(enemy)</c>.
+    /// </summary>
+    public static T WithBlackboard<T>(this T target, Blackboard blackboard) where T : class, IBlackboardBindable
+    {
+        Guard.NotNull(target, nameof(target));
+        target.SetBlackboard(blackboard);
+        return target;
+    }
+
+    // ── Start / chain relays receiving the routed context ────────────────
+
+    /// <summary>
+    /// Adds the first (start) node executing <paramref name="run"/> synchronously with the
+    /// machine-bound routed blackboard context.
+    /// </summary>
+    public static StateToken To(this StartToken token, Func<BlackboardContext, Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return token.To(new RelayState(run));
+    }
+
+    /// <summary>
+    /// Adds the first (start) node executing <paramref name="run"/> asynchronously with the
+    /// machine-bound routed blackboard context.
+    /// </summary>
+    public static StateToken ToAsync(this StartToken token,
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return token.ToAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>
+    /// Chains a synchronous state whose lambda receives the machine-bound routed blackboard
+    /// context — no closure capture, so one graph template serves N machines with distinct boards.
+    /// </summary>
+    public static StateToken To(this StateToken prev, Func<BlackboardContext, Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return prev.To(new RelayState(run));
+    }
+
+    /// <summary>
+    /// Chains an asynchronous state whose lambda receives the machine-bound routed blackboard context.
+    /// </summary>
+    public static StateToken ToAsync(this StateToken prev,
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return prev.ToAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>
+    /// Chains a synchronous state whose lambda receives both the stamped agent and the
+    /// routed blackboard context. The agent type cannot be inferred from the lambda alone —
+    /// supply it explicitly: <c>.To&lt;Enemy&gt;((enemy, bb) =&gt; ...)</c>.
+    /// </summary>
+    public static StateToken To<TAgent>(this StateToken prev, Func<TAgent, BlackboardContext, Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return prev.To(new RelayState<TAgent>(run));
+    }
+
+    /// <summary>
+    /// Chains an asynchronous state whose lambda receives both the stamped agent and the
+    /// routed blackboard context: <c>.ToAsync&lt;Enemy&gt;((enemy, bb, ct) =&gt; ...)</c>.
+    /// </summary>
+    public static StateToken ToAsync<TAgent>(this StateToken prev,
+        Func<TAgent, BlackboardContext, CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return prev.ToAsync(new AsyncRelayState<TAgent>(run));
+    }
+
+    // ── Blackboard-driven conditions ──────────────────────────────────────
+
+    /// <summary>
+    /// Creates a conditional branch whose predicate reads the routed blackboard context:
+    /// <c>.If(bb =&gt; bb.Get(Keys.Health) &gt; 50).Then(chase).Else(flee)</c>.
+    /// </summary>
+    public static IfBuilder If(this StateToken prev, Func<BlackboardContext, bool> predicate)
+    {
+        Guard.NotNull(predicate, nameof(predicate));
+        return new IfBuilder(prev, predicate);
+    }
+
+    /// <inheritdoc cref="If(StateToken, Func{BlackboardContext, bool})"/>
+    public static IfBuilder If(this StartToken root, Func<BlackboardContext, bool> predicate)
+    {
+        Guard.NotNull(predicate, nameof(predicate));
+        return new IfBuilder(root, predicate);
+    }
+
+    /// <summary>
+    /// Creates a switch whose key selector reads the routed blackboard context.
+    /// </summary>
+    public static SwitchBuilder<TKey> Switch<TKey>(this StateToken prev,
+        Func<BlackboardContext, TKey> selector)
+        where TKey : notnull
+    {
+        Guard.NotNull(selector, nameof(selector));
+        return new SwitchBuilder<TKey>(prev, selector);
+    }
+
+    /// <inheritdoc cref="Switch{TKey}(StateToken, Func{BlackboardContext, TKey})"/>
+    public static SwitchBuilder<TKey> Switch<TKey>(this StartToken root,
+        Func<BlackboardContext, TKey> selector)
+        where TKey : notnull
+    {
+        Guard.NotNull(selector, nameof(selector));
+        return new SwitchBuilder<TKey>(root, selector);
+    }
+
+    // ── Branch bodies receiving the routed context ────────────────────────
+
+    /// <summary>Creates a "then" branch with a synchronous context lambda.</summary>
+    public static BranchBuilder Then(this IfBuilder ifBuilder, Func<BlackboardContext, Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return ifBuilder.Then(new RelayState(run));
+    }
+
+    /// <summary>Creates a "then" branch with an asynchronous context lambda.</summary>
+    public static BranchBuilder ThenAsync(this IfBuilder ifBuilder,
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return ifBuilder.ThenAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>Creates an "else" branch with a synchronous context lambda.</summary>
+    public static BranchEnd Else(this BranchBuilder branch, Func<BlackboardContext, Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return branch.Else(new RelayState(run));
+    }
+
+    /// <summary>Creates an "else" branch with an asynchronous context lambda.</summary>
+    public static BranchEnd ElseAsync(this BranchBuilder branch,
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return branch.ElseAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>Chains a synchronous context lambda onto the "then" branch.</summary>
+    public static BranchBuilder To(this BranchBuilder branch, Func<BlackboardContext, Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return branch.To(new RelayState(run));
+    }
+
+    /// <summary>Chains an asynchronous context lambda onto the "then" branch.</summary>
+    public static BranchBuilder ToAsync(this BranchBuilder branch,
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return branch.ToAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>Chains a synchronous context lambda after the "else" branch.</summary>
+    public static StateToken To(this BranchEnd branchEnd, Func<BlackboardContext, Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return branchEnd.To(new RelayState(run));
+    }
+
+    /// <summary>Chains an asynchronous context lambda after the "else" branch.</summary>
+    public static StateToken ToAsync(this BranchEnd branchEnd,
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return branchEnd.ToAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>Adds a case with a synchronous context lambda.</summary>
+    public static SwitchBuilder<TKey> Case<TKey>(this SwitchBuilder<TKey> switchBuilder, TKey key,
+        Func<BlackboardContext, Result> run) where TKey : notnull
+    {
+        Guard.NotNull(run, nameof(run));
+        return switchBuilder.Case(key, new RelayState(run));
+    }
+
+    /// <summary>Adds a case with an asynchronous context lambda.</summary>
+    public static SwitchBuilder<TKey> CaseAsync<TKey>(this SwitchBuilder<TKey> switchBuilder, TKey key,
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>> run) where TKey : notnull
+    {
+        Guard.NotNull(run, nameof(run));
+        return switchBuilder.CaseAsync(key, new AsyncRelayState(run));
+    }
+
+    /// <summary>Adds a default case with a synchronous context lambda.</summary>
+    public static SwitchBuilder<TKey> Default<TKey>(this SwitchBuilder<TKey> switchBuilder,
+        Func<BlackboardContext, Result> run) where TKey : notnull
+    {
+        Guard.NotNull(run, nameof(run));
+        return switchBuilder.Default(new RelayState(run));
+    }
+
+    /// <summary>Adds a default case with an asynchronous context lambda.</summary>
+    public static SwitchBuilder<TKey> DefaultAsync<TKey>(this SwitchBuilder<TKey> switchBuilder,
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>> run) where TKey : notnull
+    {
+        Guard.NotNull(run, nameof(run));
+        return switchBuilder.DefaultAsync(new AsyncRelayState(run));
+    }
+}

--- a/NxGraph/Authoring/Dsl.IfBuilder.cs
+++ b/NxGraph/Authoring/Dsl.IfBuilder.cs
@@ -30,7 +30,10 @@ public static partial class Dsl
             _builder = root.Builder;
             _truePad = _builder.AddNode(new EmptyLogic());
             _falsePad = _builder.AddNode(new EmptyLogic());
-            _builder.AddNode(new AsyncChoiceState(() => new ValueTask<bool>(predicate()), _truePad, _falsePad), true);
+            // Sync ChoiceState, matching every sibling overload: it runs on both runtimes
+            // (the async loop routes sync directors), whereas an AsyncChoiceState start node
+            // would make the graph unexecutable by the sync StateMachine.
+            _builder.AddNode(new ChoiceState(predicate, _truePad, _falsePad), true);
         }
 
         internal IfBuilder(StateToken prev, Func<BlackboardContext, bool> predicate)

--- a/NxGraph/Authoring/Dsl.IfBuilder.cs
+++ b/NxGraph/Authoring/Dsl.IfBuilder.cs
@@ -1,4 +1,5 @@
-﻿using NxGraph.Fsm;
+﻿using NxGraph.Blackboards;
+using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
 
@@ -30,6 +31,23 @@ public static partial class Dsl
             _truePad = _builder.AddNode(new EmptyLogic());
             _falsePad = _builder.AddNode(new EmptyLogic());
             _builder.AddNode(new AsyncChoiceState(() => new ValueTask<bool>(predicate()), _truePad, _falsePad), true);
+        }
+
+        internal IfBuilder(StateToken prev, Func<BlackboardContext, bool> predicate)
+        {
+            _builder = prev.Builder;
+            _truePad = _builder.AddNode(new EmptyLogic());
+            _falsePad = _builder.AddNode(new EmptyLogic());
+            NodeId choiceId = _builder.AddNode(new ChoiceState(predicate, _truePad, _falsePad));
+            _builder.AddTransition(prev.Id, choiceId);
+        }
+
+        internal IfBuilder(StartToken root, Func<BlackboardContext, bool> predicate)
+        {
+            _builder = root.Builder;
+            _truePad = _builder.AddNode(new EmptyLogic());
+            _falsePad = _builder.AddNode(new EmptyLogic());
+            _builder.AddNode(new ChoiceState(predicate, _truePad, _falsePad), true);
         }
 
         /// <summary>Adds an async "then" branch.</summary>

--- a/NxGraph/Authoring/Dsl.SwitchBuilder.cs
+++ b/NxGraph/Authoring/Dsl.SwitchBuilder.cs
@@ -1,4 +1,5 @@
-﻿using NxGraph.Fsm;
+﻿using NxGraph.Blackboards;
+using NxGraph.Fsm;
 using NxGraph.Graphs;
 
 namespace NxGraph.Authoring;
@@ -26,6 +27,22 @@ public static partial class Dsl
         }
 
         internal SwitchBuilder(StartToken start, Func<TKey> selector)
+        {
+            _prev = new StateToken(NodeId.Default, start.Builder);
+            _builder = start.Builder;
+            _isStart = true;
+            _switchNode = new SwitchState<TKey>(selector, _map);
+        }
+
+        internal SwitchBuilder(StateToken prev, Func<BlackboardContext, TKey> selector)
+        {
+            _prev = prev;
+            _builder = prev.Builder;
+            _isStart = false;
+            _switchNode = new SwitchState<TKey>(selector, _map);
+        }
+
+        internal SwitchBuilder(StartToken start, Func<BlackboardContext, TKey> selector)
         {
             _prev = new StateToken(NodeId.Default, start.Builder);
             _builder = start.Builder;

--- a/NxGraph/Authoring/Dsl.cs
+++ b/NxGraph/Authoring/Dsl.cs
@@ -1,4 +1,5 @@
-﻿using NxGraph.Compatibility;
+﻿using NxGraph.Blackboards;
+using NxGraph.Compatibility;
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
@@ -81,6 +82,48 @@ public static partial class Dsl
     public static StateToken Parallel(this StartToken root, ParallelStepMode mode, params Graph[] regions)
     {
         return root.To(new ParallelState(mode, regions));
+    }
+
+    /// <summary>
+    /// Adds a <b>dynamic</b> orthogonal-regions composite: at entry <paramref name="selector"/>
+    /// reads the machine-bound blackboard context and returns the <see cref="RegionMask"/> of
+    /// regions to run this execution (see <see cref="AsyncDynamicParallelState"/>). An empty
+    /// mask succeeds immediately as a vacuous join.
+    /// </summary>
+    public static StateToken Parallel(this StateToken prev, Func<BlackboardContext, RegionMask> selector,
+        params Graph[] regions)
+    {
+        return prev.ToAsync(new AsyncDynamicParallelState(selector, regions));
+    }
+
+    /// <summary>
+    /// Starts the graph with a dynamic orthogonal-regions composite as its first state
+    /// (see <see cref="AsyncDynamicParallelState"/>).
+    /// </summary>
+    public static StateToken Parallel(this StartToken root, Func<BlackboardContext, RegionMask> selector,
+        params Graph[] regions)
+    {
+        return root.ToAsync(new AsyncDynamicParallelState(selector, regions));
+    }
+
+    /// <summary>
+    /// Adds a <b>sync</b> dynamic orthogonal-regions composite — the runtime-parity twin of the
+    /// selector overload (see <see cref="DynamicParallelState"/> and <see cref="ParallelStepMode"/>).
+    /// </summary>
+    public static StateToken Parallel(this StateToken prev, ParallelStepMode mode,
+        Func<BlackboardContext, RegionMask> selector, params Graph[] regions)
+    {
+        return prev.To(new DynamicParallelState(mode, selector, regions));
+    }
+
+    /// <summary>
+    /// Starts the graph with a sync dynamic orthogonal-regions composite as its first state
+    /// (see <see cref="DynamicParallelState"/>).
+    /// </summary>
+    public static StateToken Parallel(this StartToken root, ParallelStepMode mode,
+        Func<BlackboardContext, RegionMask> selector, params Graph[] regions)
+    {
+        return root.To(new DynamicParallelState(mode, selector, regions));
     }
 
     /// <summary>

--- a/NxGraph/Authoring/Dsl.cs
+++ b/NxGraph/Authoring/Dsl.cs
@@ -63,6 +63,27 @@ public static partial class Dsl
     }
 
     /// <summary>
+    /// Adds a <b>sync</b> orthogonal-regions composite and wires a transition to it — the
+    /// runtime-parity twin of the async overload (see <see cref="ParallelState"/>).
+    /// <paramref name="mode"/> decides whether the join completes within one tick
+    /// (<see cref="ParallelStepMode.RunToJoin"/>) or spreads one round per tick across frames
+    /// (<see cref="ParallelStepMode.RoundPerTick"/>, sync runtime only).
+    /// </summary>
+    public static StateToken Parallel(this StateToken prev, ParallelStepMode mode, params Graph[] regions)
+    {
+        return prev.To(new ParallelState(mode, regions));
+    }
+
+    /// <summary>
+    /// Starts the graph with a sync orthogonal-regions composite as its first state
+    /// (see <see cref="ParallelState"/>).
+    /// </summary>
+    public static StateToken Parallel(this StartToken root, ParallelStepMode mode, params Graph[] regions)
+    {
+        return root.To(new ParallelState(mode, regions));
+    }
+
+    /// <summary>
     /// Routes this state's <c>Failure</c> outcome to a new sync handler state defined by a lambda.
     /// </summary>
     public static StateToken OnError(this StateToken prev, Func<Result> handler)

--- a/NxGraph/Authoring/GraphBuilder.cs
+++ b/NxGraph/Authoring/GraphBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using NxGraph.Blackboards;
 using NxGraph.Compatibility;
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
@@ -24,6 +25,40 @@ public sealed partial class GraphBuilder
     private readonly Dictionary<int, Action> _exitActions = new(); // sparse; attached to LogicNodes at Build()
     private readonly Dictionary<int, int> _outcomeCodes = new(); // sparse; materialized at Build()
     private readonly Dictionary<int, string> _outcomeNames = new(); // code -> display name
+    private BlackboardSchema? _graphSchema; // Graph-scoped declaration, baked into the Graph at Build()
+    private BlackboardSchema? _globalSchema; // required Global-scoped schema, baked into the Graph at Build()
+
+    /// <summary>
+    /// Declares a blackboard schema on the graph, routed by the schema's scope: a
+    /// Graph-scoped schema becomes the graph's own declaration, a Global-scoped schema
+    /// records the global board the graph requires. Declaring the same scope twice throws —
+    /// declaration is one-time authoring intent (runtime rebinding is a machine concern).
+    /// </summary>
+    public GraphBuilder WithSchema(BlackboardSchema schema)
+    {
+        Guard.NotNull(schema, nameof(schema));
+
+        if (schema.Scope == BlackboardScope.Global)
+        {
+            if (_globalSchema is not null)
+            {
+                throw new InvalidOperationException("A Global-scoped schema has already been declared on this graph.");
+            }
+
+            _globalSchema = schema;
+        }
+        else
+        {
+            if (_graphSchema is not null)
+            {
+                throw new InvalidOperationException("A Graph-scoped schema has already been declared on this graph.");
+            }
+
+            _graphSchema = schema;
+        }
+
+        return this;
+    }
 
     /// <summary>Add a node. If <paramref name="isStart"/> is true, this becomes the Start node (index 0).</summary>
     public NodeId AddNode(IAsyncLogic asyncLogic, bool isStart = false)
@@ -314,7 +349,8 @@ public sealed partial class GraphBuilder
             _outcomeNames.Count > 0 ? new Dictionary<int, string>(_outcomeNames) : null;
 
         NodeId graphId = _next.Next();
-        return new Graph(graphId, nodes, edges, logic: null, retries, outcomes, outcomeNames);
+        return new Graph(graphId, nodes, edges, logic: null, retries, outcomes, outcomeNames,
+            _graphSchema, _globalSchema);
     }
 
 
@@ -359,6 +395,30 @@ public sealed partial class GraphBuilder
     /// <param name="run">The synchronous function to execute in the start state.</param>
     /// <returns>A <see cref="StateToken"/> pointing at the start node.</returns>
     public static StateToken StartWith(Func<Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return StartWith(new RelayState(run));
+    }
+
+    /// <summary>
+    /// Creates a new graph whose first (start) node executes <paramref name="run"/>
+    /// asynchronously, receiving the machine-bound routed blackboard context.
+    /// </summary>
+    /// <param name="run">The async function to execute in the start state.</param>
+    /// <returns>A <see cref="StateToken"/> pointing at the start node.</returns>
+    public static StateToken StartWithAsync(Func<BlackboardContext, CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return StartWithAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>
+    /// Creates a new graph whose first (start) node executes <paramref name="run"/>
+    /// synchronously, receiving the machine-bound routed blackboard context.
+    /// </summary>
+    /// <param name="run">The synchronous function to execute in the start state.</param>
+    /// <returns>A <see cref="StateToken"/> pointing at the start node.</returns>
+    public static StateToken StartWith(Func<BlackboardContext, Result> run)
     {
         Guard.NotNull(run, nameof(run));
         return StartWith(new RelayState(run));

--- a/NxGraph/Blackboards/Blackboard.cs
+++ b/NxGraph/Blackboards/Blackboard.cs
@@ -1,0 +1,113 @@
+using System.Runtime.CompilerServices;
+using NxGraph.Compatibility;
+
+namespace NxGraph.Blackboards;
+
+/// <summary>
+/// Batteries-included typed-key context store. Construction allocates all slot storage up
+/// front; <see cref="Get{T}"/>/<see cref="Set{T}"/>/<see cref="TryGet{T}"/>/<see cref="GetRef{T}"/>
+/// are zero-allocation and zero-boxing thereafter — including first use.
+/// <para>
+/// Owned by a single runner at a time (not thread-safe), like the state machines.
+/// </para>
+/// <para>
+/// Anti-pattern: do <b>not</b> reach for <c>Dictionary&lt;string, object&gt;</c> as a context —
+/// that costs string hashing plus boxing on every access. A <see cref="BlackboardKey{T}"/>
+/// slot is a schema-checked array read instead.
+/// </para>
+/// </summary>
+public sealed class Blackboard
+{
+    private readonly BlackboardSchema _schema;
+    private readonly ValueStorage[] _storages;
+
+    /// <summary>
+    /// Creates a board over <paramref name="schema"/>, freezing the schema and eagerly
+    /// materializing every slot with its registered default.
+    /// </summary>
+    public Blackboard(BlackboardSchema schema)
+    {
+        _schema = Guard.NotNull(schema, nameof(schema));
+        schema.Freeze();
+        _storages = schema.CreateStorages();
+    }
+
+    /// <summary>The frozen schema this board was created from.</summary>
+    public BlackboardSchema Schema => _schema;
+
+    /// <summary>Reads the slot for <paramref name="key"/>. Throws for an invalid or foreign-schema key.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public T Get<T>(BlackboardKey<T> key)
+    {
+        ValidateKey(key);
+        return ((ValueStorage<T>)_storages[key.StorageIndex]).Values[key.SlotIndex];
+    }
+
+    /// <summary>Writes the slot for <paramref name="key"/>. Throws for an invalid or foreign-schema key.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Set<T>(BlackboardKey<T> key, T value)
+    {
+        ValidateKey(key);
+        ((ValueStorage<T>)_storages[key.StorageIndex]).Values[key.SlotIndex] = value;
+    }
+
+    /// <summary>
+    /// Returns a reference into the slot array for in-place mutation of struct values.
+    /// Throws for an invalid or foreign-schema key.
+    /// </summary>
+    public ref T GetRef<T>(BlackboardKey<T> key)
+    {
+        ValidateKey(key);
+        return ref ((ValueStorage<T>)_storages[key.StorageIndex]).Values[key.SlotIndex];
+    }
+
+    /// <summary>
+    /// Reads the slot for <paramref name="key"/>; returns <see langword="false"/> (instead of
+    /// throwing) for a default-constructed key or a key from another schema.
+    /// </summary>
+    public bool TryGet<T>(BlackboardKey<T> key, out T value)
+    {
+        if (!ReferenceEquals(key.Schema, _schema) || key.Schema is null)
+        {
+            value = default!;
+            return false;
+        }
+
+        value = ((ValueStorage<T>)_storages[key.StorageIndex]).Values[key.SlotIndex];
+        return true;
+    }
+
+    /// <summary>Resets every slot back to its registered default. Explicit non-loop operation.</summary>
+    public void ResetToDefaults()
+    {
+        foreach (ValueStorage storage in _storages)
+        {
+            storage.ResetToDefaults();
+        }
+    }
+
+    // ── Key validation (throw paths never inline into the hot path) ────
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ValidateKey<T>(in BlackboardKey<T> key)
+    {
+        if (!ReferenceEquals(key.Schema, _schema))
+        {
+            ThrowInvalidKey(key.Schema, key.Name, _schema);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowInvalidKey(BlackboardSchema? keySchema, string? keyName, BlackboardSchema boardSchema)
+    {
+        if (keySchema is null)
+        {
+            throw new InvalidOperationException(
+                "Uninitialized blackboard key — obtain keys via BlackboardSchema.Register<T>(...).");
+        }
+
+        throw new InvalidOperationException(
+            $"Key '{keyName}' belongs to schema '{keySchema.Name ?? "<unnamed>"}' but this blackboard " +
+            $"uses schema '{boardSchema.Name ?? "<unnamed>"}'.");
+    }
+}

--- a/NxGraph/Blackboards/BlackboardContext.cs
+++ b/NxGraph/Blackboards/BlackboardContext.cs
@@ -1,0 +1,137 @@
+using System.Runtime.CompilerServices;
+using NxGraph.Compatibility;
+
+namespace NxGraph.Blackboards;
+
+/// <summary>
+/// The per-machine set of scope-bound boards, stamped onto nodes as one unit.
+/// <see cref="Get{T}"/>/<see cref="Set{T}"/> route by the key's schema scope in O(1) —
+/// no fall-through chain, no allocation.
+/// <para>
+/// A default-constructed context is valid and empty: any key access throws a precise
+/// "no board bound for scope" error, so consumers never need their own null guards.
+/// </para>
+/// </summary>
+public readonly struct BlackboardContext
+{
+    // Node scope (reserved) will add a third slot here; the layout is private and
+    // invisible to the public API baseline.
+    private readonly Blackboard? _global;
+    private readonly Blackboard? _graph;
+
+    /// <summary>
+    /// Creates a context from explicit per-scope boards. Each board's schema scope must
+    /// match the slot it is passed for.
+    /// </summary>
+    public BlackboardContext(Blackboard? global, Blackboard? graph)
+    {
+        if (global is not null && global.Schema.Scope != BlackboardScope.Global)
+        {
+            throw new ArgumentException(
+                $"Board over schema '{global.Schema.Name ?? "<unnamed>"}' is {global.Schema.Scope}-scoped " +
+                "and cannot occupy the Global slot.", nameof(global));
+        }
+
+        if (graph is not null && graph.Schema.Scope != BlackboardScope.Graph)
+        {
+            throw new ArgumentException(
+                $"Board over schema '{graph.Schema.Name ?? "<unnamed>"}' is {graph.Schema.Scope}-scoped " +
+                "and cannot occupy the Graph slot.", nameof(graph));
+        }
+
+        _global = global;
+        _graph = graph;
+    }
+
+    /// <summary><see langword="true"/> when no board is bound for any scope.</summary>
+    public bool IsEmpty => _global is null && _graph is null;
+
+    /// <summary>The Global-scoped board, or <see langword="null"/> when unbound. Escape hatch for bulk ops and serialization.</summary>
+    public Blackboard? Global => _global;
+
+    /// <summary>The Graph-scoped board, or <see langword="null"/> when unbound. Escape hatch for bulk ops and serialization.</summary>
+    public Blackboard? Graph => _graph;
+
+    /// <summary>The board bound for <paramref name="scope"/>, or <see langword="null"/> when unbound.</summary>
+    public Blackboard? Board(BlackboardScope scope) => scope switch
+    {
+        BlackboardScope.Global => _global,
+        BlackboardScope.Graph => _graph,
+        _ => null,
+    };
+
+    /// <summary><see langword="true"/> when a board is bound for <paramref name="scope"/>.</summary>
+    public bool HasBoard(BlackboardScope scope) => Board(scope) is not null;
+
+    /// <summary>
+    /// Returns a copy with <paramref name="board"/> occupying its schema's scope slot
+    /// (replace semantics — rebinding a scope swaps the board).
+    /// </summary>
+    public BlackboardContext With(Blackboard board)
+    {
+        Guard.NotNull(board, nameof(board));
+        return board.Schema.Scope == BlackboardScope.Global
+            ? new BlackboardContext(board, _graph)
+            : new BlackboardContext(_global, board);
+    }
+
+    /// <summary>Reads <paramref name="key"/> from the board its schema scope routes to.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public T Get<T>(BlackboardKey<T> key) => Route(key).Get(key);
+
+    /// <summary>Writes <paramref name="key"/> on the board its schema scope routes to.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Set<T>(BlackboardKey<T> key, T value) => Route(key).Set(key, value);
+
+    /// <summary>Returns a reference into the routed board's slot array for in-place struct mutation.</summary>
+    public ref T GetRef<T>(BlackboardKey<T> key) => ref Route(key).GetRef(key);
+
+    /// <summary>
+    /// Reads <paramref name="key"/> from its routed board; returns <see langword="false"/>
+    /// (instead of throwing) when the scope is unbound or the key is invalid/foreign.
+    /// </summary>
+    public bool TryGet<T>(BlackboardKey<T> key, out T value)
+    {
+        if (key.Schema is not null &&
+            Board(key.Schema.Scope) is { } board)
+        {
+            return board.TryGet(key, out value);
+        }
+
+        value = default!;
+        return false;
+    }
+
+    // ── Routing ─────────────────────────────────────────────────────────
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private Blackboard Route<T>(in BlackboardKey<T> key)
+    {
+        if (key.Schema is null)
+        {
+            ThrowUninitializedKey();
+        }
+
+        Blackboard? board = key.Schema!.Scope == BlackboardScope.Global ? _global : _graph;
+        if (board is null)
+        {
+            ThrowUnboundScope(key.Schema.Scope, key.Name);
+        }
+
+        return board!;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowUninitializedKey() =>
+        throw new InvalidOperationException(
+            "Uninitialized blackboard key — obtain keys via BlackboardSchema.Register<T>(...).");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowUnboundScope(BlackboardScope scope, string keyName)
+    {
+        string scopeWord = scope == BlackboardScope.Global ? "global" : "graph";
+        throw new InvalidOperationException(
+            $"{scopeWord} key '{keyName}' used but no {scopeWord} blackboard bound — " +
+            "bind one via WithBlackboard(...).");
+    }
+}

--- a/NxGraph/Blackboards/BlackboardKey.cs
+++ b/NxGraph/Blackboards/BlackboardKey.cs
@@ -1,0 +1,52 @@
+namespace NxGraph.Blackboards;
+
+/// <summary>
+/// Typed handle to one slot in a <see cref="BlackboardSchema"/>. Obtain via
+/// <see cref="BlackboardSchema.Register{T}(string)"/>; a default-constructed key is invalid
+/// and any access through it throws.
+/// <para>
+/// Identity is the owning schema (by reference) plus the registration ordinal; the
+/// <see cref="Name"/> is carried for diagnostics and serialization only.
+/// </para>
+/// </summary>
+public readonly struct BlackboardKey<T> : IEquatable<BlackboardKey<T>>
+{
+    internal readonly BlackboardSchema? Schema;
+    internal readonly int StorageIndex;
+    internal readonly int SlotIndex;
+    internal readonly int Ordinal;
+
+    internal BlackboardKey(BlackboardSchema schema, string name, int storageIndex, int slotIndex, int ordinal)
+    {
+        Schema = schema;
+        Name = name;
+        StorageIndex = storageIndex;
+        SlotIndex = slotIndex;
+        Ordinal = ordinal;
+    }
+
+    /// <summary>The name the key was registered under (diagnostics/serialization identity).</summary>
+    public string Name { get; }
+
+    /// <summary><see langword="false"/> for a default-constructed key.</summary>
+    public bool IsValid => Schema is not null;
+
+    /// <inheritdoc />
+    public bool Equals(BlackboardKey<T> other) =>
+        ReferenceEquals(Schema, other.Schema) && Ordinal == other.Ordinal;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is BlackboardKey<T> other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() =>
+        Schema is null ? Ordinal : (Schema.GetHashCode() * 397) ^ Ordinal;
+
+    public static bool operator ==(BlackboardKey<T> left, BlackboardKey<T> right) => left.Equals(right);
+
+    public static bool operator !=(BlackboardKey<T> left, BlackboardKey<T> right) => !left.Equals(right);
+
+    /// <summary>Diagnostics only — "name:Type".</summary>
+    public override string ToString() =>
+        Schema is null ? $"<invalid>:{typeof(T).Name}" : $"{Name}:{typeof(T).Name}";
+}

--- a/NxGraph/Blackboards/BlackboardKeyDescriptor.cs
+++ b/NxGraph/Blackboards/BlackboardKeyDescriptor.cs
@@ -1,0 +1,58 @@
+namespace NxGraph.Blackboards;
+
+/// <summary>
+/// Type-erased view of one schema slot, exposed via <see cref="BlackboardSchema.Keys"/>.
+/// This is the serialization contract: serializers enumerate the descriptors and use the
+/// boxed accessors — boxing is fine here because save/restore are explicit non-loop
+/// operations (same rule as <c>StateMachineSnapshot</c>).
+/// </summary>
+public abstract class BlackboardKeyDescriptor
+{
+    private protected BlackboardKeyDescriptor(string name, Type valueType, int ordinal)
+    {
+        Name = name;
+        ValueType = valueType;
+        Ordinal = ordinal;
+    }
+
+    /// <summary>The name the key was registered under.</summary>
+    public string Name { get; }
+
+    /// <summary>The slot's value type.</summary>
+    public Type ValueType { get; }
+
+    /// <summary>Registration order across the whole schema.</summary>
+    public int Ordinal { get; }
+
+    /// <summary>Reads the slot's current value from <paramref name="blackboard"/> (boxes value types).</summary>
+    public abstract object? GetValue(Blackboard blackboard);
+
+    /// <summary>
+    /// Writes <paramref name="value"/> into the slot on <paramref name="blackboard"/>.
+    /// Throws <see cref="InvalidCastException"/> when the value is not of <see cref="ValueType"/>.
+    /// </summary>
+    public abstract void SetValue(Blackboard blackboard, object? value);
+
+    /// <summary>Resets the slot on <paramref name="blackboard"/> back to its registered default.</summary>
+    public abstract void ResetValue(Blackboard blackboard);
+}
+
+/// <summary>Concrete descriptor bound to a typed key.</summary>
+internal sealed class SlotDefinition<T> : BlackboardKeyDescriptor
+{
+    private readonly BlackboardKey<T> _key;
+    private readonly T _defaultValue;
+
+    internal SlotDefinition(BlackboardKey<T> key, T defaultValue)
+        : base(key.Name, typeof(T), key.Ordinal)
+    {
+        _key = key;
+        _defaultValue = defaultValue;
+    }
+
+    public override object? GetValue(Blackboard blackboard) => blackboard.Get(_key);
+
+    public override void SetValue(Blackboard blackboard, object? value) => blackboard.Set(_key, (T)value!);
+
+    public override void ResetValue(Blackboard blackboard) => blackboard.Set(_key, _defaultValue);
+}

--- a/NxGraph/Blackboards/BlackboardSchema.cs
+++ b/NxGraph/Blackboards/BlackboardSchema.cs
@@ -1,0 +1,146 @@
+using NxGraph.Compatibility;
+
+namespace NxGraph.Blackboards;
+
+/// <summary>
+/// Reusable, immutable-after-freeze layout of typed slots. Register all keys up front
+/// (typically in static initializers); the schema freezes when the first
+/// <see cref="Blackboard"/> is constructed from it. One schema can back any number of
+/// independent blackboards — the sanctioned "one graph template, N entities" pattern.
+/// <para>
+/// Registration is not thread-safe; do it from a single thread during setup.
+/// </para>
+/// </summary>
+public sealed class BlackboardSchema
+{
+    private readonly Dictionary<Type, int> _storageIndexByType = new();
+    private readonly List<StorageBuilder> _storageBuilders = [];
+    private readonly Dictionary<string, int> _ordinalByName = new(StringComparer.Ordinal);
+    private readonly List<BlackboardKeyDescriptor> _descriptors = [];
+
+    /// <summary>
+    /// Creates a schema. <paramref name="scope"/> decides which <see cref="BlackboardContext"/>
+    /// slot the schema's keys route to; <see cref="BlackboardScope.Node"/> is reserved and rejected.
+    /// </summary>
+    public BlackboardSchema(string? name = null, BlackboardScope scope = BlackboardScope.Graph)
+    {
+        if (scope == BlackboardScope.Node)
+        {
+            throw new ArgumentOutOfRangeException(nameof(scope), scope,
+                "BlackboardScope.Node is reserved for transient per-node keys and is not yet implemented.");
+        }
+
+        if (scope is not (BlackboardScope.Global or BlackboardScope.Graph))
+        {
+            throw new ArgumentOutOfRangeException(nameof(scope), scope, "Undefined blackboard scope.");
+        }
+
+        Name = name;
+        Scope = scope;
+    }
+
+    /// <summary>Optional display name, used in diagnostics and serialization payloads.</summary>
+    public string? Name { get; }
+
+    /// <summary>The binding slot this schema's keys route to.</summary>
+    public BlackboardScope Scope { get; }
+
+    /// <summary><see langword="true"/> once the first <see cref="Blackboard"/> has been constructed.</summary>
+    public bool IsFrozen { get; private set; }
+
+    /// <summary>Number of registered keys.</summary>
+    public int KeyCount => _descriptors.Count;
+
+    /// <summary>All registered slots in registration order (index == ordinal).</summary>
+    public IReadOnlyList<BlackboardKeyDescriptor> Keys => _descriptors;
+
+    /// <summary>Registers a slot whose default value is <c>default(T)</c>.</summary>
+    public BlackboardKey<T> Register<T>(string name) => Register<T>(name, default!);
+
+    /// <summary>Registers a slot with an explicit default value. Names must be unique per schema.</summary>
+    public BlackboardKey<T> Register<T>(string name, T defaultValue)
+    {
+        Guard.NotNull(name, nameof(name));
+
+        if (IsFrozen)
+        {
+            throw new InvalidOperationException(
+                $"Schema '{Name ?? "<unnamed>"}' is frozen — register all keys before constructing the first " +
+                "Blackboard. Evolve schemas by adding keys in code; old payloads restore with defaults for new keys.");
+        }
+
+        if (_ordinalByName.ContainsKey(name))
+        {
+            throw new ArgumentException($"Key '{name}' is already registered on schema '{Name ?? "<unnamed>"}'.",
+                nameof(name));
+        }
+
+        if (!_storageIndexByType.TryGetValue(typeof(T), out int storageIndex))
+        {
+            storageIndex = _storageBuilders.Count;
+            _storageBuilders.Add(new StorageBuilder<T>());
+            _storageIndexByType.Add(typeof(T), storageIndex);
+        }
+
+        StorageBuilder<T> builder = (StorageBuilder<T>)_storageBuilders[storageIndex];
+        int slotIndex = builder.Add(defaultValue);
+        int ordinal = _descriptors.Count;
+
+        BlackboardKey<T> key = new(this, name, storageIndex, slotIndex, ordinal);
+        _ordinalByName.Add(name, ordinal);
+        _descriptors.Add(new SlotDefinition<T>(key, defaultValue));
+        return key;
+    }
+
+    /// <summary>Looks up a slot descriptor by registered name.</summary>
+    public bool TryGetKey(string name, out BlackboardKeyDescriptor descriptor)
+    {
+        if (_ordinalByName.TryGetValue(name, out int ordinal))
+        {
+            descriptor = _descriptors[ordinal];
+            return true;
+        }
+
+        descriptor = null!;
+        return false;
+    }
+
+    internal void Freeze() => IsFrozen = true;
+
+    /// <summary>Produces a fresh, independent storage set for one <see cref="Blackboard"/>.</summary>
+    internal ValueStorage[] CreateStorages()
+    {
+        ValueStorage[] storages = new ValueStorage[_storageBuilders.Count];
+        for (int i = 0; i < storages.Length; i++)
+        {
+            storages[i] = _storageBuilders[i].CreateStorage();
+        }
+
+        return storages;
+    }
+
+    // ── Per-type default templates ──────────────────────────────────────
+
+    private abstract class StorageBuilder
+    {
+        internal abstract ValueStorage CreateStorage();
+    }
+
+    private sealed class StorageBuilder<T> : StorageBuilder
+    {
+        private readonly List<T> _defaults = [];
+        private T[]? _template;
+
+        internal int Add(T defaultValue)
+        {
+            _defaults.Add(defaultValue);
+            return _defaults.Count - 1;
+        }
+
+        internal override ValueStorage CreateStorage()
+        {
+            _template ??= _defaults.ToArray();
+            return new ValueStorage<T>(_template);
+        }
+    }
+}

--- a/NxGraph/Blackboards/BlackboardScope.cs
+++ b/NxGraph/Blackboards/BlackboardScope.cs
@@ -1,0 +1,25 @@
+namespace NxGraph.Blackboards;
+
+/// <summary>
+/// Which binding slot a schema's keys route to. Scope is a property of the
+/// <see cref="BlackboardSchema"/>; every key registered on a schema inherits it.
+/// </summary>
+public enum BlackboardScope
+{
+    /// <summary>
+    /// One user-owned board shared across graphs/machines. There is no global registry —
+    /// the caller owns the instance and binds it to each machine that needs it.
+    /// </summary>
+    Global = 0,
+
+    /// <summary>
+    /// The default: one board per machine/entity, validated against the graph's declared schema.
+    /// </summary>
+    Graph = 1,
+
+    /// <summary>
+    /// Reserved for transient per-node keys reset at transition boundaries.
+    /// Not yet implemented: <see cref="BlackboardSchema"/> rejects it at construction.
+    /// </summary>
+    Node = 2,
+}

--- a/NxGraph/Blackboards/IBlackboardSettable.cs
+++ b/NxGraph/Blackboards/IBlackboardSettable.cs
@@ -1,0 +1,24 @@
+namespace NxGraph.Blackboards;
+
+/// <summary>
+/// Stamping channel: receives the machine's routed <see cref="BlackboardContext"/>.
+/// Implemented by the state base classes, blackboard-driven directors, and the state
+/// machines themselves (so composite/nested machines forward the context into their
+/// child graphs). Runners re-stamp at every run start.
+/// </summary>
+public interface IBlackboardSettable
+{
+    /// <summary>Receives the routed context. Called at bind time and re-stamped at run start.</summary>
+    void SetBlackboards(in BlackboardContext context);
+}
+
+/// <summary>
+/// Binding surface: accepts one board and routes it into the receiver's context by the
+/// board's schema scope. Implemented by the state-machine bases; the target of the
+/// <c>WithBlackboard(...)</c> fluent extension.
+/// </summary>
+public interface IBlackboardBindable
+{
+    /// <summary>Binds <paramref name="blackboard"/> into the scope slot its schema declares (replace semantics).</summary>
+    void SetBlackboard(Blackboard blackboard);
+}

--- a/NxGraph/Blackboards/ValueStorage.cs
+++ b/NxGraph/Blackboards/ValueStorage.cs
@@ -1,0 +1,30 @@
+namespace NxGraph.Blackboards;
+
+/// <summary>
+/// Non-generic base for the per-type slot arrays backing a <see cref="Blackboard"/>.
+/// </summary>
+internal abstract class ValueStorage
+{
+    /// <summary>Copies the schema's default template back into the live slots.</summary>
+    internal abstract void ResetToDefaults();
+}
+
+/// <summary>
+/// Slot array for all keys of value type <typeparamref name="T"/> registered on a schema.
+/// The live <see cref="Values"/> array is per-blackboard; the defaults template is shared
+/// with the schema.
+/// </summary>
+internal sealed class ValueStorage<T> : ValueStorage
+{
+    internal readonly T[] Values;
+    private readonly T[] _defaults;
+
+    internal ValueStorage(T[] defaults)
+    {
+        _defaults = defaults;
+        Values = new T[defaults.Length];
+        Array.Copy(defaults, Values, defaults.Length);
+    }
+
+    internal override void ResetToDefaults() => Array.Copy(_defaults, Values, Values.Length);
+}

--- a/NxGraph/Diagnostics/Replay/ReplayRecorder.cs
+++ b/NxGraph/Diagnostics/Replay/ReplayRecorder.cs
@@ -112,9 +112,10 @@ public sealed class ReplayRecorder(int capacity = 256) : IAsyncStateMachineObser
         return ResultHelpers.CompletedTask;
     }
 
-    public ValueTask OnStateFailed(NodeId id, Exception ex, CancellationToken ct = default)
+    public ValueTask OnStateFailed(NodeId id, Exception? ex, CancellationToken ct = default)
     {
-        Record(new ReplayEvent(EventType.StateFailed, id, null, ex.ToString(), CurrentTimestamp));
+        Record(new ReplayEvent(EventType.StateFailed, id, null, ex?.ToString() ?? "node returned Failure",
+            CurrentTimestamp));
         return ResultHelpers.CompletedTask;
     }
 
@@ -168,8 +169,9 @@ public sealed class ReplayRecorder(int capacity = 256) : IAsyncStateMachineObser
     void IStateMachineObserver.OnTransition(NodeId from, NodeId to)
         => Record(new ReplayEvent(EventType.Transition, from, to, timestamp: CurrentTimestamp));
 
-    void IStateMachineObserver.OnStateFailed(NodeId id, Exception ex)
-        => Record(new ReplayEvent(EventType.StateFailed, id, null, ex.ToString(), CurrentTimestamp));
+    void IStateMachineObserver.OnStateFailed(NodeId id, Exception? ex)
+        => Record(new ReplayEvent(EventType.StateFailed, id, null, ex?.ToString() ?? "node returned Failure",
+            CurrentTimestamp));
 
     void IStateMachineObserver.OnStateMachineReset(NodeId graphId)
         => Record(new ReplayEvent(EventType.StateMachineReset, graphId, timestamp: CurrentTimestamp));

--- a/NxGraph/Diagnostics/Validations/GraphValidator.cs
+++ b/NxGraph/Diagnostics/Validations/GraphValidator.cs
@@ -1,4 +1,5 @@
-﻿using NxGraph.Compatibility;
+﻿using NxGraph.Blackboards;
+using NxGraph.Compatibility;
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
@@ -216,6 +217,99 @@ public static class GraphValidator
                 NodeId.Default);
         }
 
+        // 6) Blackboard schema declarations: lint-only — binding stays permissive at runtime.
+        ValidateBlackboardDeclarations(graph, result);
+
         return result;
+    }
+
+    private static void ValidateBlackboardDeclarations(Graph graph, GraphValidationResult result)
+    {
+        if ((graph.Schema is not null || graph.GlobalSchema is not null) &&
+            !AnyBlackboardSettable(graph))
+        {
+            result.Add(Severity.Info,
+                "A blackboard schema is declared but no node implements IBlackboardSettable — " +
+                "bound boards will never reach any logic.", graph.Id);
+        }
+
+        WarnOnConflictingChildSchemas(graph, graph, result);
+    }
+
+    private static bool AnyBlackboardSettable(Graph graph)
+    {
+        for (int i = 0; i < graph.NodeCount; i++)
+        {
+            if (!graph.TryGetNodeByIndex(i, out INode? node) || node is not LogicNode logicNode)
+            {
+                continue;
+            }
+
+            if (logicNode.AsyncLogic is IBlackboardSettable || logicNode.Logic is IBlackboardSettable)
+            {
+                return true;
+            }
+
+            ISubGraphProvider? provider =
+                logicNode.AsyncLogic as ISubGraphProvider ?? logicNode.Logic as ISubGraphProvider;
+            if (provider is null)
+            {
+                continue;
+            }
+
+            foreach (Graph nested in provider.SubGraphs)
+            {
+                if (!ReferenceEquals(nested, graph) && AnyBlackboardSettable(nested))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void WarnOnConflictingChildSchemas(Graph root, Graph current, GraphValidationResult result)
+    {
+        for (int i = 0; i < current.NodeCount; i++)
+        {
+            if (!current.TryGetNodeByIndex(i, out INode? node) || node is not LogicNode logicNode)
+            {
+                continue;
+            }
+
+            ISubGraphProvider? provider =
+                logicNode.AsyncLogic as ISubGraphProvider ?? logicNode.Logic as ISubGraphProvider;
+            if (provider is null)
+            {
+                continue;
+            }
+
+            foreach (Graph nested in provider.SubGraphs)
+            {
+                if (ReferenceEquals(nested, current))
+                {
+                    continue;
+                }
+
+                if (nested.Schema is not null && root.Schema is not null &&
+                    !ReferenceEquals(nested.Schema, root.Schema))
+                {
+                    result.Add(Severity.Warning,
+                        $"Subgraph '{nested.Id}' declares a different Graph-scoped blackboard schema than its " +
+                        "parent — binding a board to the parent machine will fail at stamp time.", node.Id);
+                }
+
+                if (nested.GlobalSchema is not null && root.GlobalSchema is not null &&
+                    !ReferenceEquals(nested.GlobalSchema, root.GlobalSchema))
+                {
+                    result.Add(Severity.Warning,
+                        $"Subgraph '{nested.Id}' requires a different Global-scoped blackboard schema than its " +
+                        "parent — binding a board to the parent machine will fail at stamp time.", node.Id);
+                }
+
+                WarnOnConflictingChildSchemas(root, nested, result);
+            }
+        }
     }
 }

--- a/NxGraph/Docs/readme.md
+++ b/NxGraph/Docs/readme.md
@@ -159,6 +159,44 @@ var sm = g.ToAsyncStateMachine<AppAgent>();
 sm.SetAgent(new AppAgent { Log = logger });
 ```
 
+### Blackboards (scoped shared memory)
+
+Orthogonal to the agent: typed-key working memory with **Global** (one board shared across machines) and **Graph** (one board per machine) scopes. Keys live on a `BlackboardSchema`; nodes access everything through the routed `Bb` context on the state bases — zero-boxing, zero-allocation reads/writes. Avoid `Dictionary<string, object>` contexts (string hashing + boxing per access).
+
+```csharp
+static class Keys
+{
+    public static readonly BlackboardSchema World = new("world", BlackboardScope.Global);
+    public static readonly BlackboardKey<bool> Alarm = World.Register<bool>("Alarm");
+
+    public static readonly BlackboardSchema Enemy = new("enemy"); // Graph scope
+    public static readonly BlackboardKey<int> Distance = Enemy.Register<int>("Distance", 10);
+}
+
+sealed class ChaseState : AsyncState
+{
+    protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        if (Bb.Get(Keys.Alarm)) Bb.GetRef(Keys.Distance)--; // routed by schema scope
+        return ResultHelpers.Success;
+    }
+}
+
+Graph graph = GraphBuilder
+    .StartWithAsync(new ChaseState())
+    .If(bb => bb.Get(Keys.Alarm)).ThenAsync((bb, ct) => ResultHelpers.Success)
+                                 .ElseAsync((bb, ct) => ResultHelpers.Success)
+    .WithSchema(Keys.Enemy).WithSchema(Keys.World)   // opt-in bind-time validation
+    .Build();
+
+Blackboard world = new(Keys.World);                  // shared by every machine
+var sm = graph.ToAsyncStateMachine()
+    .WithBlackboard(world)
+    .WithBlackboard(new Blackboard(Keys.Enemy));     // this machine's own memory
+```
+
+Boards serialize independently via `BlackboardSerializer` (`NxGraph.Serialization`) — one payload per board, restored into a live board over the same schema.
+
 ---
 
 ## Execution

--- a/NxGraph/Fsm/Async/AsyncChoiceState.cs
+++ b/NxGraph/Fsm/Async/AsyncChoiceState.cs
@@ -1,15 +1,44 @@
-﻿using NxGraph.Graphs;
+using NxGraph.Blackboards;
+using NxGraph.Graphs;
 
 namespace NxGraph.Fsm.Async;
 
-public sealed class AsyncChoiceState(Func<ValueTask<bool>> predicate, NodeId trueNode, NodeId falseNode) : IAsyncLogic, IAsyncDirector
+/// <summary>
+/// Async director that picks between two destinations via a predicate. The
+/// blackboard-context overload receives the machine-bound routed context (see
+/// <see cref="BlackboardContext"/>), so branching can read shared memory instead of
+/// closing over ad-hoc state.
+/// </summary>
+public sealed class AsyncChoiceState : IAsyncLogic, IAsyncDirector, IBlackboardSettable
 {
-    private readonly Func<ValueTask<bool>> _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
-    
+    private readonly Func<ValueTask<bool>>? _predicate;
+    private readonly Func<BlackboardContext, ValueTask<bool>>? _bbPredicate;
+    private readonly NodeId _trueNode;
+    private readonly NodeId _falseNode;
+    private BlackboardContext _blackboards;
+
+    public AsyncChoiceState(Func<ValueTask<bool>> predicate, NodeId trueNode, NodeId falseNode)
+    {
+        _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+        _trueNode = trueNode;
+        _falseNode = falseNode;
+    }
+
+    public AsyncChoiceState(Func<BlackboardContext, ValueTask<bool>> predicate, NodeId trueNode, NodeId falseNode)
+    {
+        _bbPredicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+        _trueNode = trueNode;
+        _falseNode = falseNode;
+    }
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context) => _blackboards = context;
+
     public async ValueTask<NodeId> SelectNextAsync(CancellationToken ct = default)
     {
-        bool result = await _predicate().ConfigureAwait(false);
-        return result ? trueNode : falseNode;
+        bool result = _bbPredicate is not null
+            ? await _bbPredicate(_blackboards).ConfigureAwait(false)
+            : await _predicate!().ConfigureAwait(false);
+        return result ? _trueNode : _falseNode;
     }
 
     public ValueTask<Result> ExecuteAsync(CancellationToken ct = default)
@@ -20,7 +49,7 @@ public sealed class AsyncChoiceState(Func<ValueTask<bool>> predicate, NodeId tru
     /// <inheritdoc />
     public IEnumerable<NodeId> EnumerateStaticTargets()
     {
-        yield return trueNode;
-        yield return falseNode;
+        yield return _trueNode;
+        yield return _falseNode;
     }
 }

--- a/NxGraph/Fsm/Async/AsyncCompositeState.cs
+++ b/NxGraph/Fsm/Async/AsyncCompositeState.cs
@@ -1,13 +1,27 @@
-﻿using NxGraph.Graphs;
+using NxGraph.Blackboards;
+using NxGraph.Graphs;
 
 namespace NxGraph.Fsm.Async;
 
 /// <summary>
-/// A composite state that contains a single child node.
+/// A composite state that contains a single child node. Surfaces the child's sub-graphs via
+/// <see cref="ISubGraphProvider"/> and forwards the blackboard context, so agent and
+/// blackboard stamping reach wrapped machines instead of stopping at this wrapper.
 /// </summary>
 /// <param name="child">The child node to execute.</param>
-public class AsyncCompositeState(IAsyncLogic child) : AsyncState
+public class AsyncCompositeState(IAsyncLogic child) : AsyncState, ISubGraphProvider, IBlackboardSettable
 {
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs =>
+        child is ISubGraphProvider provider ? provider.SubGraphs : [];
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        if (child is IBlackboardSettable settable)
+        {
+            settable.SetBlackboards(in context);
+        }
+    }
+
     protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
     {
         return child.ExecuteAsync(ct);

--- a/NxGraph/Fsm/Async/AsyncDynamicParallelState.cs
+++ b/NxGraph/Fsm/Async/AsyncDynamicParallelState.cs
@@ -1,0 +1,144 @@
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
+using NxGraph.Graphs;
+
+namespace NxGraph.Fsm.Async;
+
+/// <summary>
+/// Dynamic (some-of-many) variant of <see cref="AsyncParallelState"/>: at composite entry a
+/// selector reads the machine-bound <see cref="BlackboardContext"/> and returns a
+/// <see cref="RegionMask"/> deciding which region graphs run this execution. Only the selected
+/// regions are round-robin stepped (one node per region per round) until all of them reach a
+/// terminal result — unselected regions are never stepped and never reset. Join semantics
+/// match the static composite: <see cref="Result.Success"/> only when every selected region
+/// succeeded, else <see cref="Result.Failure"/> through the parent's unified fault model.
+/// <para>
+/// The selector runs <b>once per execution, at entry</b> — the selected set is fixed for the
+/// run (a region that must stop early should terminate via its own graph logic). An empty mask
+/// is a vacuous join: the composite returns <see cref="Result.Success"/> without stepping
+/// anything. Mask bits at or above the region count fail loudly at entry. Selectors run once
+/// per composite execution, so they must stay allocation-free (compose masks with
+/// <see cref="RegionMask.Bit"/> and <c>|</c>, or precompute them at setup).
+/// </para>
+/// <para>
+/// Implements <see cref="IBlackboardSettable"/> because the selector needs the context; the
+/// stamping walk stops at settable nodes, so this composite forwards the received context to
+/// every region machine itself. Agent stamping still reaches regions via
+/// <see cref="ISubGraphProvider"/>.
+/// </para>
+/// </summary>
+public sealed class AsyncDynamicParallelState : IAsyncLogic, ISubGraphProvider, IBlackboardSettable
+{
+    private readonly Func<BlackboardContext, RegionMask> _selector;
+    private readonly AsyncStateMachine[] _regions;
+    private readonly bool[] _done;
+    private BlackboardContext _blackboards;
+
+    /// <summary>The region machines (selected or not).</summary>
+    public IReadOnlyList<AsyncStateMachine> Regions => _regions;
+
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs
+    {
+        get
+        {
+            foreach (AsyncStateMachine region in _regions)
+            {
+                yield return region.Graph;
+            }
+        }
+    }
+
+    public AsyncDynamicParallelState(Func<BlackboardContext, RegionMask> selector, params Graph[] regions)
+    {
+        _selector = Guard.NotNull(selector, nameof(selector));
+        Guard.NotNull(regions, nameof(regions));
+        if (regions.Length == 0)
+        {
+            throw new ArgumentException("At least one region is required.", nameof(regions));
+        }
+
+        if (regions.Length > 64)
+        {
+            throw new ArgumentException(
+                $"Dynamic parallel composites support at most 64 regions ({regions.Length} given) — " +
+                "the selection mask is a single ulong.", nameof(regions));
+        }
+
+        _regions = new AsyncStateMachine[regions.Length];
+        for (int i = 0; i < regions.Length; i++)
+        {
+            _regions[i] = new AsyncStateMachine(regions[i]);
+        }
+
+        _done = new bool[regions.Length];
+    }
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        // The recursive stamping walk stops at IBlackboardSettable nodes — forward to the
+        // region machines ourselves (each validates against its own graph's declarations).
+        _blackboards = context;
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            ((IBlackboardSettable)_regions[i]).SetBlackboards(in context);
+        }
+    }
+
+    public async ValueTask<Result> ExecuteAsync(CancellationToken ct = default)
+    {
+        RegionMask selected = _selector(_blackboards);
+        ValidateMask(selected);
+
+        int remaining = 0;
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            bool isSelected = selected.Contains(i);
+            _done[i] = !isSelected; // unselected regions are "done" before the first round
+            if (isSelected)
+            {
+                remaining++;
+            }
+        }
+
+        if (remaining == 0)
+        {
+            return Result.Success; // vacuous join
+        }
+
+        bool anyFailed = false;
+        while (remaining > 0)
+        {
+            for (int i = 0; i < _regions.Length; i++)
+            {
+                if (_done[i])
+                {
+                    continue;
+                }
+
+                Result step = await _regions[i].StepAsync(ct).ConfigureAwait(false);
+                if (!step.IsCompleted)
+                {
+                    continue;
+                }
+
+                _done[i] = true;
+                remaining--;
+                if (step.IsFailure)
+                {
+                    anyFailed = true;
+                }
+            }
+        }
+
+        return anyFailed ? Result.Failure : Result.Success;
+    }
+
+    private void ValidateMask(RegionMask mask)
+    {
+        if (_regions.Length < 64 && mask.Bits >> _regions.Length != 0)
+        {
+            throw new InvalidOperationException(
+                $"Selector returned {mask} with bits at or above the region count ({_regions.Length}).");
+        }
+    }
+}

--- a/NxGraph/Fsm/Async/AsyncHistoryState.cs
+++ b/NxGraph/Fsm/Async/AsyncHistoryState.cs
@@ -1,3 +1,4 @@
+using NxGraph.Blackboards;
 using NxGraph.Compatibility;
 using NxGraph.Graphs;
 
@@ -18,12 +19,20 @@ namespace NxGraph.Fsm.Async;
 /// only on the failure-recovery path, which is off the hot loop by definition.
 /// </para>
 /// </summary>
-public sealed class AsyncHistoryState : IAsyncLogic, ISubGraphProvider
+public sealed class AsyncHistoryState : IAsyncLogic, ISubGraphProvider, IBlackboardSettable
 {
     /// <summary>The wrapped child machine.</summary>
     public AsyncStateMachine Child { get; }
 
     IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Child.Graph];
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        // The recursive stamping walk stops at IBlackboardSettable nodes — forward to the
+        // child machine so it validates against its own graph's declarations at stamp time
+        // (uniform with plain .SubGraph nesting and the dynamic parallel composite).
+        ((IBlackboardSettable)Child).SetBlackboards(in context);
+    }
 
     public AsyncHistoryState(Graph child)
     {

--- a/NxGraph/Fsm/Async/AsyncParallelState.cs
+++ b/NxGraph/Fsm/Async/AsyncParallelState.cs
@@ -1,3 +1,4 @@
+using NxGraph.Blackboards;
 using NxGraph.Compatibility;
 using NxGraph.Graphs;
 
@@ -18,10 +19,21 @@ namespace NxGraph.Fsm.Async;
 /// library targets; run truly CPU-parallel work inside a single node instead.
 /// </para>
 /// </summary>
-public sealed class AsyncParallelState : IAsyncLogic, ISubGraphProvider
+public sealed class AsyncParallelState : IAsyncLogic, ISubGraphProvider, IBlackboardSettable
 {
     private readonly AsyncStateMachine[] _regions;
     private readonly bool[] _done;
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        // The recursive stamping walk stops at IBlackboardSettable nodes — forward to the
+        // region machines ourselves (each validates against its own graph's declarations),
+        // matching AsyncDynamicParallelState.
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            ((IBlackboardSettable)_regions[i]).SetBlackboards(in context);
+        }
+    }
 
     /// <summary>The region machines.</summary>
     public IReadOnlyList<AsyncStateMachine> Regions => _regions;

--- a/NxGraph/Fsm/Async/AsyncRelayState.cs
+++ b/NxGraph/Fsm/Async/AsyncRelayState.cs
@@ -1,62 +1,127 @@
+using NxGraph.Blackboards;
+
 namespace NxGraph.Fsm.Async;
 
 /// <summary>
 /// AsyncRelayState is a state that can be used to encapsulate a function that returns a Result.
+/// The blackboard-context overload receives the machine-bound routed context (see
+/// <see cref="BlackboardContext"/>) instead of relying on closure capture, so one graph
+/// template can serve N machines with distinct boards.
 /// </summary>
-/// <param name="run">The function to run when the state is executed. It should return a <see cref="Result"/>.</param>
-/// <param name="onEnter">Optional function to run when the state is entered. It can be used for initialization or setup.</param>
-/// <param name="onExit">Optional function to run when the state is exited. It can be used for cleanup or finalization.</param>
-public sealed class AsyncRelayState(
-    Func<CancellationToken, ValueTask<Result>> run,
-    Func<CancellationToken, ValueTask<Result>>? onEnter = null,
-    Func<CancellationToken, ValueTask<Result>>? onExit = null)
-    : AsyncState
+public sealed class AsyncRelayState : AsyncState
 {
-    private readonly Func<CancellationToken, ValueTask<Result>> _run = run ?? throw new ArgumentNullException(nameof(run));
+    private readonly Func<CancellationToken, ValueTask<Result>>? _run;
+    private readonly Func<CancellationToken, ValueTask<Result>>? _onEnter;
+    private readonly Func<CancellationToken, ValueTask<Result>>? _onExit;
 
-    protected override  ValueTask<Result> OnEnterAsync(CancellationToken ct)
+    private readonly Func<BlackboardContext, CancellationToken, ValueTask<Result>>? _bbRun;
+    private readonly Func<BlackboardContext, CancellationToken, ValueTask<Result>>? _bbOnEnter;
+    private readonly Func<BlackboardContext, CancellationToken, ValueTask<Result>>? _bbOnExit;
+
+    /// <param name="run">The function to run when the state is executed. It should return a <see cref="Result"/>.</param>
+    /// <param name="onEnter">Optional function to run when the state is entered. It can be used for initialization or setup.</param>
+    /// <param name="onExit">Optional function to run when the state is exited. It can be used for cleanup or finalization.</param>
+    public AsyncRelayState(
+        Func<CancellationToken, ValueTask<Result>> run,
+        Func<CancellationToken, ValueTask<Result>>? onEnter = null,
+        Func<CancellationToken, ValueTask<Result>>? onExit = null)
     {
-        return onEnter?.Invoke(ct) ?? ResultHelpers.InProgress;
+        _run = run ?? throw new ArgumentNullException(nameof(run));
+        _onEnter = onEnter;
+        _onExit = onExit;
+    }
+
+    /// <param name="run">The function to run when the state is executed, receiving the routed blackboard context.</param>
+    /// <param name="onEnter">Optional enter hook receiving the routed blackboard context.</param>
+    /// <param name="onExit">Optional exit hook receiving the routed blackboard context.</param>
+    public AsyncRelayState(
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>> run,
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>>? onEnter = null,
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>>? onExit = null)
+    {
+        _bbRun = run ?? throw new ArgumentNullException(nameof(run));
+        _bbOnEnter = onEnter;
+        _bbOnExit = onExit;
+    }
+
+    protected override ValueTask<Result> OnEnterAsync(CancellationToken ct)
+    {
+        return _bbRun is not null
+            ? _bbOnEnter?.Invoke(Bb, ct) ?? ResultHelpers.InProgress
+            : _onEnter?.Invoke(ct) ?? ResultHelpers.InProgress;
     }
 
     protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
     {
-        return _run(ct);
+        return _bbRun is not null ? _bbRun(Bb, ct) : _run!(ct);
     }
 
     protected override ValueTask<Result> OnExitAsync(CancellationToken ct)
     {
-        return onExit?.Invoke(ct) ?? ResultHelpers.Success;
+        return _bbRun is not null
+            ? _bbOnExit?.Invoke(Bb, ct) ?? ResultHelpers.Success
+            : _onExit?.Invoke(ct) ?? ResultHelpers.Success;
     }
 }
 
 /// <summary>
 /// RelayState is a state that can be used to encapsulate a function that returns a Result.
+/// The combined overload hands the delegate both the stamped agent and the routed
+/// blackboard context.
 /// </summary>
-/// <param name="run">The function to run when the state is executed. It should return a <see cref="Result"/>.</param>
-/// <param name="onEnter">Optional function to run when the state is entered. It can be used for initialization or setup.</param>
-/// <param name="onExit">Optional function to run when the state is exited. It can be used for cleanup or finalization.</param>
 /// <typeparam name="TAgent">The type of the agent that this state operates on.</typeparam>
-public sealed class AsyncRelayState<TAgent>(
-    Func<TAgent, CancellationToken, ValueTask<Result>> run,
-    Func<TAgent, CancellationToken, ValueTask<Result>>? onEnter = null,
-    Func<TAgent, CancellationToken, ValueTask<Result>>? onExit = null)
-    : AsyncState<TAgent>
+public sealed class AsyncRelayState<TAgent> : AsyncState<TAgent>
 {
-    private readonly Func<TAgent, CancellationToken, ValueTask<Result>> _run = run ?? throw new ArgumentNullException(nameof(run));
+    private readonly Func<TAgent, CancellationToken, ValueTask<Result>>? _run;
+    private readonly Func<TAgent, CancellationToken, ValueTask<Result>>? _onEnter;
+    private readonly Func<TAgent, CancellationToken, ValueTask<Result>>? _onExit;
+
+    private readonly Func<TAgent, BlackboardContext, CancellationToken, ValueTask<Result>>? _bbRun;
+    private readonly Func<TAgent, BlackboardContext, CancellationToken, ValueTask<Result>>? _bbOnEnter;
+    private readonly Func<TAgent, BlackboardContext, CancellationToken, ValueTask<Result>>? _bbOnExit;
+
+    /// <param name="run">The function to run when the state is executed. It should return a <see cref="Result"/>.</param>
+    /// <param name="onEnter">Optional function to run when the state is entered. It can be used for initialization or setup.</param>
+    /// <param name="onExit">Optional function to run when the state is exited. It can be used for cleanup or finalization.</param>
+    public AsyncRelayState(
+        Func<TAgent, CancellationToken, ValueTask<Result>> run,
+        Func<TAgent, CancellationToken, ValueTask<Result>>? onEnter = null,
+        Func<TAgent, CancellationToken, ValueTask<Result>>? onExit = null)
+    {
+        _run = run ?? throw new ArgumentNullException(nameof(run));
+        _onEnter = onEnter;
+        _onExit = onExit;
+    }
+
+    /// <param name="run">The function to run when the state is executed, receiving the agent and the routed blackboard context.</param>
+    /// <param name="onEnter">Optional enter hook receiving the agent and the routed blackboard context.</param>
+    /// <param name="onExit">Optional exit hook receiving the agent and the routed blackboard context.</param>
+    public AsyncRelayState(
+        Func<TAgent, BlackboardContext, CancellationToken, ValueTask<Result>> run,
+        Func<TAgent, BlackboardContext, CancellationToken, ValueTask<Result>>? onEnter = null,
+        Func<TAgent, BlackboardContext, CancellationToken, ValueTask<Result>>? onExit = null)
+    {
+        _bbRun = run ?? throw new ArgumentNullException(nameof(run));
+        _bbOnEnter = onEnter;
+        _bbOnExit = onExit;
+    }
 
     protected override ValueTask<Result> OnEnterAsync(CancellationToken ct)
     {
-        return onEnter?.Invoke(Agent, ct) ?? ResultHelpers.InProgress;
+        return _bbRun is not null
+            ? _bbOnEnter?.Invoke(Agent, Bb, ct) ?? ResultHelpers.InProgress
+            : _onEnter?.Invoke(Agent, ct) ?? ResultHelpers.InProgress;
     }
 
     protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
     {
-        return _run(Agent, ct);
+        return _bbRun is not null ? _bbRun(Agent, Bb, ct) : _run!(Agent, ct);
     }
 
     protected override ValueTask<Result> OnExitAsync(CancellationToken ct)
     {
-        return onExit?.Invoke(Agent, ct) ?? ResultHelpers.Success;
+        return _bbRun is not null
+            ? _bbOnExit?.Invoke(Agent, Bb, ct) ?? ResultHelpers.Success
+            : _onExit?.Invoke(Agent, ct) ?? ResultHelpers.Success;
     }
 }

--- a/NxGraph/Fsm/Async/AsyncState.cs
+++ b/NxGraph/Fsm/Async/AsyncState.cs
@@ -44,7 +44,7 @@ public abstract class AsyncState : IAsyncLogic, ILogReporter, IBlackboardSettabl
     {
         if (LogReport != null)
         {
-            await LogReport(message, ct);
+            await LogReport(message, ct).ConfigureAwait(false);
         }
     }
 

--- a/NxGraph/Fsm/Async/AsyncState.cs
+++ b/NxGraph/Fsm/Async/AsyncState.cs
@@ -1,3 +1,4 @@
+using NxGraph.Blackboards;
 using NxGraph.Diagnostics.Replay;
 using NxGraph.Graphs;
 
@@ -6,8 +7,17 @@ namespace NxGraph.Fsm.Async;
 /// <summary>
 /// Base class for all async states in a finite state machine.
 /// </summary>
-public abstract class AsyncState : IAsyncLogic, ILogReporter
+public abstract class AsyncState : IAsyncLogic, ILogReporter, IBlackboardSettable
 {
+    /// <summary>
+    /// Routed blackboard access (see <see cref="BlackboardContext"/>). Non-nullable: when the
+    /// machine has no boards bound, the empty context makes any key access throw a precise
+    /// unbound-scope error. Stamped at bind time and re-stamped at every run start.
+    /// </summary>
+    protected BlackboardContext Bb { get; private set; }
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context) => Bb = context;
+
     /// <summary>
     /// Executes the state asynchronously, entering and exiting the state as needed.
     /// </summary>

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
 using NxGraph.Diagnostics.Replay;
 using NxGraph.Graphs;
 
@@ -28,6 +30,7 @@ public class AsyncStateMachine<TAgent>(Graph graph, IAsyncStateMachineObserver? 
 
     private protected override void ApplyExecutionContext()
     {
+        base.ApplyExecutionContext(); // blackboards first, then the agent
         if (_hasAgent)
         {
             Graph.SetAgent(_agent!);
@@ -38,9 +41,10 @@ public class AsyncStateMachine<TAgent>(Graph graph, IAsyncStateMachineObserver? 
 /// <summary>
 /// Non-generic AsyncStateMachine.
 /// </summary>
-public class AsyncStateMachine : AsyncState, ISubGraphProvider
+public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBindable, IBlackboardSettable
 {
     public readonly Graph Graph;
+    private BlackboardContext _blackboards;
 
     IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Graph];
     private readonly IAsyncStateMachineObserver? _observer;
@@ -94,9 +98,63 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider
     /// <summary>
     /// Hook for derived machines to (re)apply per-machine execution context (e.g. the typed
     /// agent) to the graph's nodes. Runs under the execute gate, right before Starting.
+    /// The base implementation re-stamps the bound blackboard context.
     /// </summary>
     private protected virtual void ApplyExecutionContext()
     {
+        if (!_blackboards.IsEmpty)
+        {
+            Graph.SetBlackboards(in _blackboards);
+        }
+    }
+
+    /// <summary>
+    /// Binds a blackboard into the scope slot its schema declares (replace semantics — like
+    /// <c>SetAgent</c>, rebinding swaps the board, which enables machine pooling). Applied to
+    /// the graph's nodes immediately and re-applied at the start of every execution.
+    /// Validated against the graph's schema declarations when present.
+    /// </summary>
+    public void SetBlackboard(Blackboard blackboard)
+    {
+        Guard.NotNull(blackboard, nameof(blackboard));
+        ValidateBoardAgainstDeclarations(blackboard);
+        _blackboards = _blackboards.With(blackboard);
+        Graph.SetBlackboards(in _blackboards);
+    }
+
+    /// <summary>
+    /// Receives the whole context from a parent machine's stamping walk (nested composite
+    /// path). Validates against this machine's own graph declarations, so a conflicting
+    /// child schema fails loudly at stamp time.
+    /// </summary>
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        if (context.Graph is { } graphBoard)
+        {
+            ValidateBoardAgainstDeclarations(graphBoard);
+        }
+
+        if (context.Global is { } globalBoard)
+        {
+            ValidateBoardAgainstDeclarations(globalBoard);
+        }
+
+        _blackboards = context;
+        Graph.SetBlackboards(in context);
+    }
+
+    private void ValidateBoardAgainstDeclarations(Blackboard blackboard)
+    {
+        BlackboardSchema? declared = blackboard.Schema.Scope == BlackboardScope.Global
+            ? Graph.GlobalSchema
+            : Graph.Schema;
+
+        if (declared is not null && !ReferenceEquals(declared, blackboard.Schema))
+        {
+            throw new InvalidOperationException(
+                $"Blackboard schema '{blackboard.Schema.Name ?? "<unnamed>"}' does not match the " +
+                $"{blackboard.Schema.Scope} schema '{declared.Name ?? "<unnamed>"}' declared on graph '{Graph.Id}'.");
+        }
     }
 
     private int OutcomeOf(NodeId id) => _outcomeCodes is null ? 0 : _outcomeCodes[id.Index];
@@ -581,6 +639,18 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider
                     if (logic.AsyncLogic is IAsyncDirector director)
                     {
                         next = await director.SelectNextAsync(ct).ConfigureAwait(false);
+                        if (next.Equals(NodeId.Default))
+                        {
+                            LastOutcome = OutcomeOf(_current);
+                            return Result.Success;
+                        }
+                    }
+                    // Sync directors (ChoiceState/SwitchState behind a SyncLogicAdapter) route
+                    // here too — mirroring the sync runtime's `Logic is IDirector` check, and
+                    // matching the validator/exporter, which already probe both logic slots.
+                    else if (logic.Logic is IDirector syncDirector)
+                    {
+                        next = syncDirector.SelectNext();
                         if (next.Equals(NodeId.Default))
                         {
                             LastOutcome = OutcomeOf(_current);

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -102,10 +102,12 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
     /// </summary>
     private protected virtual void ApplyExecutionContext()
     {
-        if (!_blackboards.IsEmpty)
-        {
-            Graph.SetBlackboards(in _blackboards);
-        }
+        // Unconditional re-stamp, empty context included. Skipping the empty case let a
+        // board-less machine sharing a Graph silently execute against the boards a previous
+        // machine stamped — it must get the unbound-scope throw instead. Composite children
+        // receive their context through IBlackboardSettable forwarding, so the empty re-stamp
+        // no longer erases a parent's stamp.
+        Graph.SetBlackboards(in _blackboards);
     }
 
     /// <summary>
@@ -268,55 +270,84 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             throw new InvalidOperationException("AsyncStateMachine is already executing.");
         }
 
-        if (_stepping)
+        // Everything after the gate acquisition can throw (observer callbacks fire from
+        // ResetCore/TransitionTo/OnStateEntered, and observer exceptions bubble by design).
+        // OnExitAsync does not run when OnEnterAsync throws, so the gate must be released
+        // here or the machine is permanently locked. Mirrors sync StateMachine.Finalise.
+        try
         {
-            Volatile.Write(ref _executeGate, 0);
-            throw new InvalidOperationException(
-                "A stepped run is in progress. Finish it with StepAsync or Reset() before calling ExecuteAsync.");
-        }
-
-        // If we're terminal, apply reset policy.
-        ExecutionStatus status = Status;
-        if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
-        {
-            switch (_restartPolicy)
+            if (_stepping)
             {
-                case RestartPolicy.Ignore:
-                    // Ignore further execution attempts until a manual Reset() occurs.
-                    // Keep the gate held so a concurrent caller cannot enter while this
-                    // ExecuteAsync is still on its way to OnRunAsync (which returns the
-                    // cached terminal result) and OnExitAsync (which releases the gate).
-                    return Result.InProgress;
-                case RestartPolicy.Manual:
-                    Volatile.Write(ref _executeGate, 0); // Release the gate before throwing.
-                    throw new InvalidOperationException(
-                        $"AsyncStateMachine is in terminal state '{status}'. Call Reset() before executing again.");
-                default:
-                    // Auto: tolerate unexpected terminal state by resetting on entry.
-                    // ResetCore (not Reset) because OnEnterAsync already holds the gate.
-                    await ResetCore(ct).ConfigureAwait(false);
-                    break;
+                throw new InvalidOperationException(
+                    "A stepped run is in progress. Finish it with StepAsync or Reset() before calling ExecuteAsync.");
             }
+
+            // If we're terminal, apply reset policy.
+            ExecutionStatus status = Status;
+            if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+            {
+                switch (_restartPolicy)
+                {
+                    case RestartPolicy.Ignore:
+                        // Ignore further execution attempts until a manual Reset() occurs.
+                        // Keep the gate held so a concurrent caller cannot enter while this
+                        // ExecuteAsync is still on its way to OnRunAsync (which returns the
+                        // cached terminal result) and OnExitAsync (which releases the gate).
+                        return Result.InProgress;
+                    case RestartPolicy.Manual:
+                        throw new InvalidOperationException(
+                            $"AsyncStateMachine is in terminal state '{status}'. Call Reset() before executing again.");
+                    default:
+                        // Auto: tolerate unexpected terminal state by resetting on entry.
+                        // ResetCore (not Reset) because OnEnterAsync already holds the gate.
+                        await ResetCore(ct).ConfigureAwait(false);
+                        break;
+                }
+            }
+
+            // Re-stamp this machine's context onto the (potentially shared) graph before running.
+            ApplyExecutionContext();
+
+            // First entry or re-entry after Ready: Starting -> (enter first node) -> Running
+            await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
+            _current = _initial;
+            _attempts = 0;
+            _nodeEntered = false;
+            LastOutcome = 0;
+            if (_observer is not null)
+            {
+                await _observer.OnStateEntered(_current, ct).ConfigureAwait(false);
+            }
+
+            await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
+
+            return Result.InProgress;
         }
-
-        // Re-stamp this machine's context onto the (potentially shared) graph before running.
-        ApplyExecutionContext();
-
-        // First entry or re-entry after Ready: Starting -> (enter first node) -> Running
-        await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
-        _current = _initial;
-        _attempts = 0;
-        _nodeEntered = false;
-        LastOutcome = 0;
-        if (_observer is not null)
+        catch
         {
-            await _observer.OnStateEntered(_current, ct).ConfigureAwait(false);
+            RepairTransientStatus();
+            Volatile.Write(ref _executeGate, 0);
+            throw;
         }
-
-        await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
-        
-        return Result.InProgress;
     }
+
+    /// <summary>
+    /// If an observer threw while the machine was in a transient status (Starting/Resetting/
+    /// Transitioning), restore Ready without notifications so the machine stays usable —
+    /// Suspend/Reset reject transient statuses and a redundant re-transition would trip the
+    /// debug assert in <see cref="TransitionTo"/>.
+    /// </summary>
+    private void RepairTransientStatus()
+    {
+        ExecutionStatus status = Status;
+        if (status is ExecutionStatus.Starting or ExecutionStatus.Resetting or ExecutionStatus.Transitioning)
+        {
+            Volatile.Write(ref _statusInt, (int)ExecutionStatus.Ready);
+        }
+    }
+
+    private bool IsTerminal => Status is ExecutionStatus.Completed or ExecutionStatus.Failed
+        or ExecutionStatus.Cancelled;
 
     protected override async ValueTask<Result> OnRunAsync(CancellationToken ct)
     {
@@ -348,35 +379,46 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
         }
         catch (OperationCanceledException)
         {
-            // TransitionTo(Cancelled) already fires OnStateMachineCancelled via NotifyMachineStatusChangeAsync.
-            await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
-
-            _terminalResult = Result.Failure;
-
-            if (_restartPolicy == RestartPolicy.Auto)
+            // Skip the terminal cascade when the run already reached a terminal status —
+            // e.g. an observer threw inside the Completed notification. Re-transitioning
+            // would fire OnStateMachineCompleted twice and flip a successful run to
+            // Cancelled/Failed. Mirrors sync StateMachine.Finalise's idempotence guard.
+            if (!IsTerminal)
             {
-                // CancellationToken.None: ct is already cancelled; passing it would make
-                // any cancellable await inside the reset throw, stranding status at Resetting.
-                await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                // TransitionTo(Cancelled) already fires OnStateMachineCancelled via NotifyMachineStatusChangeAsync.
+                await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
+
+                _terminalResult = Result.Failure;
+
+                if (_restartPolicy == RestartPolicy.Auto)
+                {
+                    // CancellationToken.None: ct is already cancelled; passing it would make
+                    // any cancellable await inside the reset throw, stranding status at Resetting.
+                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                }
             }
 
             throw;
         }
         catch (Exception ex)
         {
-            // Unexpected error outside node execution (node failures are returned as Failure below)
-            if (_observer is not null)
-                await _observer.OnStateFailed(_current, ex, ct).ConfigureAwait(false);
-
-            // TransitionTo(Failed) already fires OnStateMachineCompleted(Failure) via NotifyMachineStatusChangeAsync.
-            await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
-
-            _terminalResult = Result.Failure;
-
-            if (_restartPolicy == RestartPolicy.Auto)
+            // Same idempotence guard as the cancellation path above.
+            if (!IsTerminal)
             {
-                // CancellationToken.None: ct may already be cancelled/faulted; reset must complete cleanly.
-                await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                // Unexpected error outside node execution (node failures are returned as Failure below)
+                if (_observer is not null)
+                    await _observer.OnStateFailed(_current, ex, ct).ConfigureAwait(false);
+
+                // TransitionTo(Failed) already fires OnStateMachineCompleted(Failure) via NotifyMachineStatusChangeAsync.
+                await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
+
+                _terminalResult = Result.Failure;
+
+                if (_restartPolicy == RestartPolicy.Auto)
+                {
+                    // CancellationToken.None: ct may already be cancelled/faulted; reset must complete cleanly.
+                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                }
             }
 
             throw;
@@ -461,6 +503,11 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             _nodeEntered = snapshot.NodeEntered;
             _stepping = snapshot.MidRun;
             LastOutcome = snapshot.LastOutcome;
+            // Reconstruct the cached terminal result so RestartPolicy.Ignore reports the
+            // restored run's true outcome instead of the field initializer's Success.
+            _terminalResult = snapshot.Status is ExecutionStatus.Failed or ExecutionStatus.Cancelled
+                ? Result.Failure
+                : Result.Success;
             Volatile.Write(ref _statusInt, (int)snapshot.Status);
         }
         finally
@@ -488,36 +535,46 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
         {
             if (!_stepping)
             {
-                ExecutionStatus status = Status;
-                if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+                // Run-start init fires observer callbacks (ResetCore/TransitionTo/OnStateEntered)
+                // which may throw; repair transient status so the machine stays usable.
+                try
                 {
-                    switch (_restartPolicy)
+                    ExecutionStatus status = Status;
+                    if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
                     {
-                        case RestartPolicy.Ignore:
-                            return _terminalResult;
-                        case RestartPolicy.Manual:
-                            throw new InvalidOperationException(
-                                $"AsyncStateMachine is in terminal state '{status}'. Call Reset() before stepping again.");
-                        default:
-                            await ResetCore(ct).ConfigureAwait(false);
-                            break;
+                        switch (_restartPolicy)
+                        {
+                            case RestartPolicy.Ignore:
+                                return _terminalResult;
+                            case RestartPolicy.Manual:
+                                throw new InvalidOperationException(
+                                    $"AsyncStateMachine is in terminal state '{status}'. Call Reset() before stepping again.");
+                            default:
+                                await ResetCore(ct).ConfigureAwait(false);
+                                break;
+                        }
                     }
+
+                    ApplyExecutionContext();
+
+                    await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
+                    _current = _initial;
+                    _attempts = 0;
+                    _nodeEntered = false;
+                    LastOutcome = 0;
+                    if (_observer is not null)
+                    {
+                        await _observer.OnStateEntered(_current, ct).ConfigureAwait(false);
+                    }
+
+                    await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
+                    _stepping = true;
                 }
-
-                ApplyExecutionContext();
-
-                await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
-                _current = _initial;
-                _attempts = 0;
-                _nodeEntered = false;
-                LastOutcome = 0;
-                if (_observer is not null)
+                catch
                 {
-                    await _observer.OnStateEntered(_current, ct).ConfigureAwait(false);
+                    RepairTransientStatus();
+                    throw;
                 }
-
-                await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
-                _stepping = true;
             }
 
             Result result;
@@ -528,11 +585,16 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             catch (OperationCanceledException)
             {
                 _stepping = false;
-                await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
-                _terminalResult = Result.Failure;
-                if (_restartPolicy == RestartPolicy.Auto)
+                // Idempotence guard: don't re-fire the terminal cascade when the status is
+                // already terminal (mirrors sync StateMachine.Finalise).
+                if (!IsTerminal)
                 {
-                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                    await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
+                    _terminalResult = Result.Failure;
+                    if (_restartPolicy == RestartPolicy.Auto)
+                    {
+                        await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                    }
                 }
 
                 throw;
@@ -540,16 +602,19 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             catch (Exception ex)
             {
                 _stepping = false;
-                if (_observer is not null)
+                if (!IsTerminal)
                 {
-                    await _observer.OnStateFailed(_current, ex, ct).ConfigureAwait(false);
-                }
+                    if (_observer is not null)
+                    {
+                        await _observer.OnStateFailed(_current, ex, ct).ConfigureAwait(false);
+                    }
 
-                await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
-                _terminalResult = Result.Failure;
-                if (_restartPolicy == RestartPolicy.Auto)
-                {
-                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                    await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
+                    _terminalResult = Result.Failure;
+                    if (_restartPolicy == RestartPolicy.Auto)
+                    {
+                        await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                    }
                 }
 
                 throw;

--- a/NxGraph/Fsm/Async/AsyncSwitchState.cs
+++ b/NxGraph/Fsm/Async/AsyncSwitchState.cs
@@ -1,27 +1,53 @@
+using NxGraph.Blackboards;
 using NxGraph.Graphs;
 
 namespace NxGraph.Fsm.Async;
 
-public sealed class AsyncSwitchState<TKey>(
-    Func<ValueTask<TKey>> selector,
-    IReadOnlyDictionary<TKey, NodeId> cases,
-    NodeId defaultNode = default)
-    : IAsyncLogic, IAsyncDirector
+/// <summary>
+/// Async switch/case director. The blackboard-context overload receives the machine-bound
+/// routed context (see <see cref="BlackboardContext"/>), so the selector can read shared
+/// memory instead of closing over ad-hoc state.
+/// </summary>
+public sealed class AsyncSwitchState<TKey> : IAsyncLogic, IAsyncDirector, IBlackboardSettable
     where TKey : notnull
 {
-    private readonly Func<ValueTask<TKey>> _selector = selector ?? throw new ArgumentNullException(nameof(selector));
-    private readonly IReadOnlyDictionary<TKey, NodeId> _cases = cases ?? throw new ArgumentNullException(nameof(cases));
+    private readonly Func<ValueTask<TKey>>? _selector;
+    private readonly Func<BlackboardContext, ValueTask<TKey>>? _bbSelector;
+    private readonly IReadOnlyDictionary<TKey, NodeId> _cases;
     // When no explicit default is supplied, fall back to NodeId.Default — the async runtime
     // (AsyncStateMachine.InternalRunAsync) treats that as a terminal-success exit from the
     // director. Defaulting to default(NodeId) would silently route to Start (index 0).
-    private NodeId _defaultNode = defaultNode.Equals(default(NodeId)) ? NodeId.Default : defaultNode;
+    private NodeId _defaultNode;
+    private BlackboardContext _blackboards;
 
+    public AsyncSwitchState(
+        Func<ValueTask<TKey>> selector,
+        IReadOnlyDictionary<TKey, NodeId> cases,
+        NodeId defaultNode = default)
+    {
+        _selector = selector ?? throw new ArgumentNullException(nameof(selector));
+        _cases = cases ?? throw new ArgumentNullException(nameof(cases));
+        _defaultNode = defaultNode.Equals(default(NodeId)) ? NodeId.Default : defaultNode;
+    }
+
+    public AsyncSwitchState(
+        Func<BlackboardContext, ValueTask<TKey>> selector,
+        IReadOnlyDictionary<TKey, NodeId> cases,
+        NodeId defaultNode = default)
+    {
+        _bbSelector = selector ?? throw new ArgumentNullException(nameof(selector));
+        _cases = cases ?? throw new ArgumentNullException(nameof(cases));
+        _defaultNode = defaultNode.Equals(default(NodeId)) ? NodeId.Default : defaultNode;
+    }
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context) => _blackboards = context;
 
     public async ValueTask<NodeId> SelectNextAsync(CancellationToken ct = default)
     {
-        TKey key = await _selector();
+        TKey key = _bbSelector is not null
+            ? await _bbSelector(_blackboards).ConfigureAwait(false)
+            : await _selector!().ConfigureAwait(false);
         return _cases.GetValueOrDefault(key, _defaultNode);
-
     }
 
     /// <inheritdoc />

--- a/NxGraph/Fsm/Async/AsyncTimeoutState.cs
+++ b/NxGraph/Fsm/Async/AsyncTimeoutState.cs
@@ -71,7 +71,7 @@ public class AsyncTimeoutState : IAsyncLogic
         }
         finally
         {
-            await reg.DisposeAsync();
+            await reg.DisposeAsync().ConfigureAwait(false);
             CtsPool.Return(cts);
         }
     }
@@ -124,17 +124,29 @@ public class AsyncTimeoutState : IAsyncLogic
         {
 #if NET6_0_OR_GREATER
             if (cts.TryReset())
-#else
-            if (!cts.IsCancellationRequested)
-#endif
             {
                 Bag.Add(cts);
             }
+#else
+            if (!cts.IsCancellationRequested)
+            {
+                // Disarm the previous CancelAfter timer before pooling. Without this, the
+                // stale timer can fire right after the CTS is re-rented (before the next
+                // CancelAfter re-arms it) and register as a spurious instant timeout.
+                cts.CancelAfter(global::System.Threading.Timeout.InfiniteTimeSpan);
+                if (!cts.IsCancellationRequested)
+                {
+                    Bag.Add(cts);
+                    return;
+                }
+
+                cts.Dispose();
+            }
+#endif
             else
             {
                 cts.Dispose();
             }
-            
         }
     }
 }

--- a/NxGraph/Fsm/ChoiceState.cs
+++ b/NxGraph/Fsm/ChoiceState.cs
@@ -1,17 +1,40 @@
-﻿using NxGraph.Graphs;
+using NxGraph.Blackboards;
+using NxGraph.Graphs;
 
 namespace NxGraph.Fsm;
 
 /// <summary>
 /// Executes a predicate and immediately returns <see cref="Result.Success"/>; the
 /// destination is selected via <see cref="IDirector.SelectNext"/>.
+/// The blackboard-context overload receives the machine-bound routed context (see
+/// <see cref="BlackboardContext"/>), so branching can read shared memory instead of
+/// closing over ad-hoc state.
 /// Purely synchronous — the authoring layer wraps this in a <see cref="SyncLogicAdapter"/>
 /// so that async runtimes can also execute it.
 /// </summary>
-public sealed class ChoiceState(Func<bool> predicate, NodeId trueNode, NodeId falseNode) : ILogic, IDirector
+public sealed class ChoiceState : ILogic, IDirector, IBlackboardSettable
 {
-    private readonly Func<bool> _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+    private readonly Func<bool>? _predicate;
+    private readonly Func<BlackboardContext, bool>? _bbPredicate;
+    private readonly NodeId _trueNode;
+    private readonly NodeId _falseNode;
+    private BlackboardContext _blackboards;
 
+    public ChoiceState(Func<bool> predicate, NodeId trueNode, NodeId falseNode)
+    {
+        _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+        _trueNode = trueNode;
+        _falseNode = falseNode;
+    }
+
+    public ChoiceState(Func<BlackboardContext, bool> predicate, NodeId trueNode, NodeId falseNode)
+    {
+        _bbPredicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+        _trueNode = trueNode;
+        _falseNode = falseNode;
+    }
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context) => _blackboards = context;
 
     /// <inheritdoc />
     public Result Execute() => Result.Success;
@@ -22,13 +45,14 @@ public sealed class ChoiceState(Func<bool> predicate, NodeId trueNode, NodeId fa
     /// <returns>The next node to run.</returns>
     public NodeId SelectNext()
     {
-        return _predicate() ? trueNode : falseNode;
+        bool taken = _bbPredicate is not null ? _bbPredicate(_blackboards) : _predicate!();
+        return taken ? _trueNode : _falseNode;
     }
 
     /// <inheritdoc />
     public IEnumerable<NodeId> EnumerateStaticTargets()
     {
-        yield return trueNode;
-        yield return falseNode;
+        yield return _trueNode;
+        yield return _falseNode;
     }
 }

--- a/NxGraph/Fsm/DynamicParallelState.cs
+++ b/NxGraph/Fsm/DynamicParallelState.cs
@@ -1,0 +1,183 @@
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
+using NxGraph.Graphs;
+
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// Sync twin of <see cref="Async.AsyncDynamicParallelState"/> (runtime parity): at the start
+/// of each visit a selector reads the machine-bound <see cref="BlackboardContext"/> and
+/// returns a <see cref="RegionMask"/> deciding which region graphs run. Only selected regions
+/// are stepped; unselected regions are never stepped and never reset. Join semantics match
+/// <see cref="ParallelState"/>: <see cref="Result.Success"/> only when every selected region
+/// succeeded, else <see cref="Result.Failure"/> through the parent's unified fault model.
+/// <para>
+/// <see cref="ParallelStepMode"/> maps rounds onto ticks exactly as in
+/// <see cref="ParallelState"/> — <see cref="ParallelStepMode.RoundPerTick"/> evaluates the
+/// selector on the visit's first tick only; the selected set is fixed until the join. An empty
+/// mask is a vacuous join (immediate <see cref="Result.Success"/>); mask bits at or above the
+/// region count fail loudly. Selectors run once per visit — keep them allocation-free
+/// (compose with <see cref="RegionMask.Bit"/> and <c>|</c>, or precompute masks at setup).
+/// </para>
+/// </summary>
+public sealed class DynamicParallelState : ILogic, ISubGraphProvider, IBlackboardSettable
+{
+    private readonly Func<BlackboardContext, RegionMask> _selector;
+    private readonly StateMachine[] _regions;
+    private readonly bool[] _done;
+    private readonly ParallelStepMode _mode;
+    private BlackboardContext _blackboards;
+
+    // Join bookkeeping for RoundPerTick, which spans many Execute() calls. The first call of
+    // a visit evaluates the selector and resets it; reaching the join (or an escaping region
+    // exception) clears it.
+    private bool _inFlight;
+    private int _remaining;
+    private bool _anyFailed;
+
+    /// <summary>The region machines (selected or not).</summary>
+    public IReadOnlyList<StateMachine> Regions => _regions;
+
+    /// <summary>How region rounds map onto <see cref="Execute"/> calls.</summary>
+    public ParallelStepMode Mode => _mode;
+
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs
+    {
+        get
+        {
+            foreach (StateMachine region in _regions)
+            {
+                yield return region.Graph;
+            }
+        }
+    }
+
+    public DynamicParallelState(ParallelStepMode mode, Func<BlackboardContext, RegionMask> selector,
+        params Graph[] regions)
+    {
+        _selector = Guard.NotNull(selector, nameof(selector));
+        Guard.NotNull(regions, nameof(regions));
+        if (regions.Length == 0)
+        {
+            throw new ArgumentException("At least one region is required.", nameof(regions));
+        }
+
+        if (regions.Length > 64)
+        {
+            throw new ArgumentException(
+                $"Dynamic parallel composites support at most 64 regions ({regions.Length} given) — " +
+                "the selection mask is a single ulong.", nameof(regions));
+        }
+
+        _mode = mode;
+        _regions = new StateMachine[regions.Length];
+        for (int i = 0; i < regions.Length; i++)
+        {
+            _regions[i] = new StateMachine(regions[i]);
+        }
+
+        _done = new bool[regions.Length];
+    }
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        // The recursive stamping walk stops at IBlackboardSettable nodes — forward to the
+        // region machines ourselves (each validates against its own graph's declarations).
+        _blackboards = context;
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            ((IBlackboardSettable)_regions[i]).SetBlackboards(in context);
+        }
+    }
+
+    public Result Execute()
+    {
+        if (!_inFlight)
+        {
+            RegionMask selected = _selector(_blackboards);
+            ValidateMask(selected);
+
+            _remaining = 0;
+            _anyFailed = false;
+            for (int i = 0; i < _regions.Length; i++)
+            {
+                bool isSelected = selected.Contains(i);
+                _done[i] = !isSelected; // unselected regions are "done" before the first round
+                if (isSelected)
+                {
+                    _remaining++;
+                }
+            }
+
+            if (_remaining == 0)
+            {
+                return Result.Success; // vacuous join; no in-flight state to keep
+            }
+
+            _inFlight = true;
+        }
+
+        try
+        {
+            if (_mode == ParallelStepMode.RunToJoin)
+            {
+                while (_remaining > 0)
+                {
+                    RunRound();
+                }
+            }
+            else
+            {
+                RunRound();
+                if (_remaining > 0)
+                {
+                    return Result.InProgress;
+                }
+            }
+        }
+        catch
+        {
+            // A region threw out of its node logic. Drop the join so the next visit starts
+            // a fresh pass (with a fresh selector evaluation) instead of resuming stale
+            // bookkeeping; the exception propagates into the parent's failure handling.
+            _inFlight = false;
+            throw;
+        }
+
+        _inFlight = false;
+        return _anyFailed ? Result.Failure : Result.Success;
+    }
+
+    private void RunRound()
+    {
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            if (_done[i])
+            {
+                continue;
+            }
+
+            Result step = _regions[i].Execute();
+            if (!step.IsCompleted)
+            {
+                continue;
+            }
+
+            _done[i] = true;
+            _remaining--;
+            if (step.IsFailure)
+            {
+                _anyFailed = true;
+            }
+        }
+    }
+
+    private void ValidateMask(RegionMask mask)
+    {
+        if (_regions.Length < 64 && mask.Bits >> _regions.Length != 0)
+        {
+            throw new InvalidOperationException(
+                $"Selector returned {mask} with bits at or above the region count ({_regions.Length}).");
+        }
+    }
+}

--- a/NxGraph/Fsm/IAsyncStateMachineObserver.cs
+++ b/NxGraph/Fsm/IAsyncStateMachineObserver.cs
@@ -49,7 +49,11 @@ public interface IAsyncStateMachineObserver
         return default;
     }
 
-    ValueTask OnStateFailed(NodeId id, Exception ex, CancellationToken ct = default)
+    /// <summary>
+    /// Raised when a node fails. <paramref name="ex"/> is <c>null</c> when the node returned
+    /// <see cref="Result.Failure"/> without throwing (a result-based failure).
+    /// </summary>
+    ValueTask OnStateFailed(NodeId id, Exception? ex, CancellationToken ct = default)
     {
         return default;
     }

--- a/NxGraph/Fsm/IStateMachineObserver.cs
+++ b/NxGraph/Fsm/IStateMachineObserver.cs
@@ -15,7 +15,11 @@ public interface IStateMachineObserver
 
     void OnTransition(NodeId from, NodeId to) { }
 
-    void OnStateFailed(NodeId id, Exception ex) { }
+    /// <summary>
+    /// Raised when a node fails. <paramref name="ex"/> is <c>null</c> when the node returned
+    /// <see cref="Result.Failure"/> without throwing (a result-based failure).
+    /// </summary>
+    void OnStateFailed(NodeId id, Exception? ex) { }
 
     //--- State Machine Lifecycle Events ---
 

--- a/NxGraph/Fsm/ParallelState.cs
+++ b/NxGraph/Fsm/ParallelState.cs
@@ -1,0 +1,145 @@
+using NxGraph.Compatibility;
+using NxGraph.Graphs;
+
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// Synchronous counterpart of <see cref="Async.AsyncParallelState"/>: orthogonal (AND-state)
+/// regions via cooperative interleaving. Each region is a child graph run by its own sync
+/// <see cref="StateMachine"/>; a <b>round</b> advances every still-running region by one node.
+/// Rounds repeat until all regions reach a terminal result (the join). The composite returns
+/// <see cref="Result.Success"/> only when every region succeeded; if any region failed it
+/// returns <see cref="Result.Failure"/> after the join, which then flows through the parent's
+/// unified fault model (failure edges, retries).
+/// <para>
+/// <see cref="ParallelStepMode"/> decides how rounds map onto ticks:
+/// <see cref="ParallelStepMode.RunToJoin"/> completes the whole join inside one
+/// <see cref="Execute"/> call; <see cref="ParallelStepMode.RoundPerTick"/> runs one round per
+/// call and returns <see cref="Result.InProgress"/> in between, so region progress aligns 1:1
+/// with game-loop frames. <c>RoundPerTick</c> is only valid under the sync
+/// <see cref="StateMachine"/> (the async runtime rejects node-level
+/// <see cref="Result.InProgress"/>); <c>RunToJoin</c> works under both runtimes via the
+/// sync-logic adapter.
+/// </para>
+/// <para>
+/// Like the async composite, this is deliberately not thread-concurrent (see the scope
+/// decision on <see cref="Async.AsyncParallelState"/>); region graphs must contain sync
+/// (<see cref="ILogic"/>) node logic, as with any sync-run graph.
+/// </para>
+/// </summary>
+public sealed class ParallelState : ILogic, ISubGraphProvider
+{
+    private readonly StateMachine[] _regions;
+    private readonly bool[] _done;
+    private readonly ParallelStepMode _mode;
+
+    // Join bookkeeping for RoundPerTick, which spans many Execute() calls. The first call of
+    // a visit resets it; reaching the join (or an escaping region exception) clears it.
+    private bool _inFlight;
+    private int _remaining;
+    private bool _anyFailed;
+
+    /// <summary>The region machines.</summary>
+    public IReadOnlyList<StateMachine> Regions => _regions;
+
+    /// <summary>How region rounds map onto <see cref="Execute"/> calls.</summary>
+    public ParallelStepMode Mode => _mode;
+
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs
+    {
+        get
+        {
+            foreach (StateMachine region in _regions)
+            {
+                yield return region.Graph;
+            }
+        }
+    }
+
+    public ParallelState(ParallelStepMode mode, params Graph[] regions)
+    {
+        Guard.NotNull(regions, nameof(regions));
+        if (regions.Length == 0)
+        {
+            throw new ArgumentException("At least one region is required.", nameof(regions));
+        }
+
+        _mode = mode;
+        _regions = new StateMachine[regions.Length];
+        for (int i = 0; i < regions.Length; i++)
+        {
+            _regions[i] = new StateMachine(regions[i]);
+        }
+
+        _done = new bool[regions.Length];
+    }
+
+    public Result Execute()
+    {
+        if (!_inFlight)
+        {
+            for (int i = 0; i < _done.Length; i++)
+            {
+                _done[i] = false;
+            }
+
+            _remaining = _regions.Length;
+            _anyFailed = false;
+            _inFlight = true;
+        }
+
+        try
+        {
+            if (_mode == ParallelStepMode.RunToJoin)
+            {
+                while (_remaining > 0)
+                {
+                    RunRound();
+                }
+            }
+            else
+            {
+                RunRound();
+                if (_remaining > 0)
+                {
+                    return Result.InProgress;
+                }
+            }
+        }
+        catch
+        {
+            // A region threw out of its node logic. Drop the join so the next visit starts
+            // a fresh pass instead of resuming stale bookkeeping; the exception itself
+            // propagates into the parent machine's normal failure handling.
+            _inFlight = false;
+            throw;
+        }
+
+        _inFlight = false;
+        return _anyFailed ? Result.Failure : Result.Success;
+    }
+
+    private void RunRound()
+    {
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            if (_done[i])
+            {
+                continue;
+            }
+
+            Result step = _regions[i].Execute();
+            if (!step.IsCompleted)
+            {
+                continue;
+            }
+
+            _done[i] = true;
+            _remaining--;
+            if (step.IsFailure)
+            {
+                _anyFailed = true;
+            }
+        }
+    }
+}

--- a/NxGraph/Fsm/ParallelState.cs
+++ b/NxGraph/Fsm/ParallelState.cs
@@ -1,3 +1,4 @@
+using NxGraph.Blackboards;
 using NxGraph.Compatibility;
 using NxGraph.Graphs;
 
@@ -27,11 +28,22 @@ namespace NxGraph.Fsm;
 /// (<see cref="ILogic"/>) node logic, as with any sync-run graph.
 /// </para>
 /// </summary>
-public sealed class ParallelState : ILogic, ISubGraphProvider
+public sealed class ParallelState : ILogic, ISubGraphProvider, IBlackboardSettable
 {
     private readonly StateMachine[] _regions;
     private readonly bool[] _done;
     private readonly ParallelStepMode _mode;
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        // The recursive stamping walk stops at IBlackboardSettable nodes — forward to the
+        // region machines ourselves (each validates against its own graph's declarations),
+        // matching DynamicParallelState.
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            ((IBlackboardSettable)_regions[i]).SetBlackboards(in context);
+        }
+    }
 
     // Join bookkeeping for RoundPerTick, which spans many Execute() calls. The first call of
     // a visit resets it; reaching the join (or an escaping region exception) clears it.

--- a/NxGraph/Fsm/ParallelStepMode.cs
+++ b/NxGraph/Fsm/ParallelStepMode.cs
@@ -1,0 +1,24 @@
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// How the sync <see cref="ParallelState"/> spreads its region rounds across
+/// <see cref="Graphs.ILogic.Execute"/> calls (ticks).
+/// </summary>
+public enum ParallelStepMode
+{
+    /// <summary>
+    /// Loop rounds inside a single <c>Execute()</c> call until every region reaches a
+    /// terminal result — the whole join costs one tick (the caller opts into the work).
+    /// Mirrors <see cref="Async.AsyncParallelState"/>, which always runs to the join.
+    /// </summary>
+    RunToJoin = 0,
+
+    /// <summary>
+    /// Advance every still-running region by exactly one node, then return
+    /// <see cref="Result.InProgress"/> ("re-run me next tick"). Rounds align 1:1 with
+    /// game-loop frames; the join result is returned on the tick the last region
+    /// terminates. Only meaningful under the sync <see cref="StateMachine"/> — the async
+    /// runtime rejects node-level <see cref="Result.InProgress"/>.
+    /// </summary>
+    RoundPerTick = 1,
+}

--- a/NxGraph/Fsm/RegionMask.cs
+++ b/NxGraph/Fsm/RegionMask.cs
@@ -1,0 +1,100 @@
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// Allocation-free set of region indices for the dynamic parallel composites
+/// (<see cref="DynamicParallelState"/> / <see cref="Async.AsyncDynamicParallelState"/>),
+/// backed by a single <see cref="ulong"/> — which caps dynamic composites at 64 regions.
+/// <para>
+/// Build masks with <see cref="Of"/> at setup time (its <c>params</c> array allocates), or
+/// compose them allocation-free inside a selector with <see cref="Bit"/> and
+/// <see cref="op_BitwiseOr"/>: <c>RegionMask.Bit(0) | RegionMask.Bit(2)</c>. Selectors run at
+/// composite entry — once per composite execution — so they must stay allocation-free to
+/// preserve the 0 B guarantee.
+/// </para>
+/// </summary>
+public readonly struct RegionMask : IEquatable<RegionMask>
+{
+    private readonly ulong _bits;
+
+    private RegionMask(ulong bits) => _bits = bits;
+
+    internal ulong Bits => _bits;
+
+    /// <summary>The empty selection. A selector returning it makes the composite succeed as a vacuous join.</summary>
+    public static RegionMask None => default;
+
+    /// <summary>A mask with the single region <paramref name="index"/> (0–63) selected. Allocation-free.</summary>
+    public static RegionMask Bit(int index)
+    {
+        if ((uint)index >= 64)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), index, "Region index must be in 0..63.");
+        }
+
+        return new RegionMask(1UL << index);
+    }
+
+    /// <summary>
+    /// A mask with the given region indices selected. The <c>params</c> array allocates —
+    /// intended for setup time; inside a selector compose with <see cref="Bit"/> and <c>|</c> instead.
+    /// </summary>
+    public static RegionMask Of(params int[] indices)
+    {
+        ulong bits = 0;
+        for (int i = 0; i < indices.Length; i++)
+        {
+            if ((uint)indices[i] >= 64)
+            {
+                throw new ArgumentOutOfRangeException(nameof(indices), indices[i],
+                    "Region index must be in 0..63.");
+            }
+
+            bits |= 1UL << indices[i];
+        }
+
+        return new RegionMask(bits);
+    }
+
+    /// <summary>A mask with the first <paramref name="count"/> regions (0–64) selected.</summary>
+    public static RegionMask All(int count)
+    {
+        if ((uint)count > 64)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count), count, "Region count must be in 0..64.");
+        }
+
+        return new RegionMask(count == 64 ? ulong.MaxValue : (1UL << count) - 1);
+    }
+
+    /// <summary><see langword="true"/> when region <paramref name="index"/> is selected.</summary>
+    public bool Contains(int index) => (uint)index < 64 && (_bits >> index & 1UL) != 0;
+
+    /// <summary><see langword="true"/> when no region is selected.</summary>
+    public bool IsEmpty => _bits == 0;
+
+    /// <summary>Number of selected regions.</summary>
+    public int Count
+    {
+        get
+        {
+            // SWAR popcount — portable across net8.0/netstandard2.1 without BitOperations.
+            ulong v = _bits;
+            v -= (v >> 1) & 0x5555555555555555UL;
+            v = (v & 0x3333333333333333UL) + ((v >> 2) & 0x3333333333333333UL);
+            v = (v + (v >> 4)) & 0x0F0F0F0F0F0F0F0FUL;
+            return (int)((v * 0x0101010101010101UL) >> 56);
+        }
+    }
+
+    /// <summary>Union of two masks. Allocation-free selector composition.</summary>
+    public static RegionMask operator |(RegionMask left, RegionMask right) =>
+        new(left._bits | right._bits);
+
+    public bool Equals(RegionMask other) => _bits == other._bits;
+    public override bool Equals(object? obj) => obj is RegionMask other && Equals(other);
+    public override int GetHashCode() => _bits.GetHashCode();
+    public static bool operator ==(RegionMask left, RegionMask right) => left.Equals(right);
+    public static bool operator !=(RegionMask left, RegionMask right) => !left.Equals(right);
+
+    public override string ToString() => $"RegionMask(0x{_bits:X})";
+}

--- a/NxGraph/Fsm/RelayState.cs
+++ b/NxGraph/Fsm/RelayState.cs
@@ -1,3 +1,4 @@
+using NxGraph.Blackboards;
 using NxGraph.Fsm.Async;
 
 namespace NxGraph.Fsm;
@@ -5,38 +6,125 @@ namespace NxGraph.Fsm;
 /// <summary>
 /// Synchronous counterpart of <see cref="AsyncRelayState"/>.
 /// Wraps plain delegates (<see cref="Func{Result}"/>) for zero-allocation inline execution.
+/// The blackboard-context overload receives the machine-bound routed context (see
+/// <see cref="BlackboardContext"/>) instead of relying on closure capture, so one graph
+/// template can serve N machines with distinct boards.
 /// </summary>
-public sealed class RelayState(
-    Func<Result> run,
-    Action? onEnter = null,
-    Action? onExit = null)
-    : State
+public sealed class RelayState : State
 {
-    private readonly Func<Result> _run = run ?? throw new ArgumentNullException(nameof(run));
+    private readonly Func<Result>? _run;
+    private readonly Action? _onEnter;
+    private readonly Action? _onExit;
 
-    protected override void OnEnter() => onEnter?.Invoke();
+    private readonly Func<BlackboardContext, Result>? _bbRun;
+    private readonly Action<BlackboardContext>? _bbOnEnter;
+    private readonly Action<BlackboardContext>? _bbOnExit;
 
-    protected override Result OnRun() => _run();
+    public RelayState(
+        Func<Result> run,
+        Action? onEnter = null,
+        Action? onExit = null)
+    {
+        _run = run ?? throw new ArgumentNullException(nameof(run));
+        _onEnter = onEnter;
+        _onExit = onExit;
+    }
 
-    protected override void OnExit() => onExit?.Invoke();
+    public RelayState(
+        Func<BlackboardContext, Result> run,
+        Action<BlackboardContext>? onEnter = null,
+        Action<BlackboardContext>? onExit = null)
+    {
+        _bbRun = run ?? throw new ArgumentNullException(nameof(run));
+        _bbOnEnter = onEnter;
+        _bbOnExit = onExit;
+    }
+
+    protected override void OnEnter()
+    {
+        if (_bbRun is not null)
+        {
+            _bbOnEnter?.Invoke(Bb);
+        }
+        else
+        {
+            _onEnter?.Invoke();
+        }
+    }
+
+    protected override Result OnRun() => _bbRun is not null ? _bbRun(Bb) : _run!();
+
+    protected override void OnExit()
+    {
+        if (_bbRun is not null)
+        {
+            _bbOnExit?.Invoke(Bb);
+        }
+        else
+        {
+            _onExit?.Invoke();
+        }
+    }
 }
 
 /// <summary>
-/// Synchronous counterpart of <see cref="AsyncRelayState{TAgent}"/>.
+/// Synchronous counterpart of <see cref="AsyncRelayState{TAgent}"/>. The combined overload
+/// hands the delegate both the stamped agent and the routed blackboard context.
 /// </summary>
 /// <typeparam name="TAgent">The type of agent available during execution.</typeparam>
-public sealed class RelayState<TAgent>(
-    Func<TAgent, Result> run,
-    Action<TAgent>? onEnter = null,
-    Action<TAgent>? onExit = null)
-    : State<TAgent>
+public sealed class RelayState<TAgent> : State<TAgent>
 {
-    private readonly Func<TAgent, Result> _run = run ?? throw new ArgumentNullException(nameof(run));
+    private readonly Func<TAgent, Result>? _run;
+    private readonly Action<TAgent>? _onEnter;
+    private readonly Action<TAgent>? _onExit;
 
-    protected override void OnEnter() => onEnter?.Invoke(Agent);
+    private readonly Func<TAgent, BlackboardContext, Result>? _bbRun;
+    private readonly Action<TAgent, BlackboardContext>? _bbOnEnter;
+    private readonly Action<TAgent, BlackboardContext>? _bbOnExit;
 
-    protected override Result OnRun() => _run(Agent);
+    public RelayState(
+        Func<TAgent, Result> run,
+        Action<TAgent>? onEnter = null,
+        Action<TAgent>? onExit = null)
+    {
+        _run = run ?? throw new ArgumentNullException(nameof(run));
+        _onEnter = onEnter;
+        _onExit = onExit;
+    }
 
-    protected override void OnExit() => onExit?.Invoke(Agent);
+    public RelayState(
+        Func<TAgent, BlackboardContext, Result> run,
+        Action<TAgent, BlackboardContext>? onEnter = null,
+        Action<TAgent, BlackboardContext>? onExit = null)
+    {
+        _bbRun = run ?? throw new ArgumentNullException(nameof(run));
+        _bbOnEnter = onEnter;
+        _bbOnExit = onExit;
+    }
+
+    protected override void OnEnter()
+    {
+        if (_bbRun is not null)
+        {
+            _bbOnEnter?.Invoke(Agent, Bb);
+        }
+        else
+        {
+            _onEnter?.Invoke(Agent);
+        }
+    }
+
+    protected override Result OnRun() => _bbRun is not null ? _bbRun(Agent, Bb) : _run!(Agent);
+
+    protected override void OnExit()
+    {
+        if (_bbRun is not null)
+        {
+            _bbOnExit?.Invoke(Agent, Bb);
+        }
+        else
+        {
+            _onExit?.Invoke(Agent);
+        }
+    }
 }
-

--- a/NxGraph/Fsm/State.cs
+++ b/NxGraph/Fsm/State.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using NxGraph.Blackboards;
 using NxGraph.Diagnostics.Replay;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
@@ -15,8 +16,17 @@ namespace NxGraph.Fsm;
 /// <see cref="IAsyncLogic.ExecuteAsync"/> (zero-allocation on .NET 8+).
 /// </para>
 /// </summary>
-public abstract class State : ILogic, ILogReporter
+public abstract class State : ILogic, ILogReporter, IBlackboardSettable
 {
+    /// <summary>
+    /// Routed blackboard access (see <see cref="BlackboardContext"/>). Non-nullable: when the
+    /// machine has no boards bound, the empty context makes any key access throw a precise
+    /// unbound-scope error. Stamped at bind time and re-stamped at every run start.
+    /// </summary>
+    protected BlackboardContext Bb { get; private set; }
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context) => Bb = context;
+
     /// <summary>
     /// Callback set by the sync runtime so the state can emit log messages.
     /// Uses <see cref="Action{String}"/> instead of an async delegate.

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -134,10 +134,12 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
     /// </summary>
     private protected virtual void ApplyExecutionContext()
     {
-        if (!_blackboards.IsEmpty)
-        {
-            Graph.SetBlackboards(in _blackboards);
-        }
+        // Unconditional re-stamp, empty context included. Skipping the empty case let a
+        // board-less machine sharing a Graph silently execute against the boards a previous
+        // machine stamped — it must get the unbound-scope throw instead. Composite children
+        // receive their context through IBlackboardSettable forwarding, so the empty re-stamp
+        // no longer erases a parent's stamp.
+        Graph.SetBlackboards(in _blackboards);
     }
 
     /// <summary>
@@ -315,6 +317,11 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         _attempts = snapshot.Attempts;
         _nodeEntered = snapshot.NodeEntered;
         LastOutcome = snapshot.LastOutcome;
+        // Reconstruct the cached terminal result so RestartPolicy.Ignore reports the
+        // restored run's true outcome instead of the field initializer's Success.
+        _terminalResult = snapshot.Status is ExecutionStatus.Failed or ExecutionStatus.Cancelled
+            ? Result.Failure
+            : Result.Success;
         // Mid-run: the gate stays held between ticks and the State lifecycle must skip
         // OnEnter (which would restart the run from the initial node) on the next Execute().
         _executeGate = snapshot.MidRun;

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
 
@@ -28,6 +30,7 @@ public class StateMachine<TAgent>(Graph graph, IStateMachineObserver? observer =
 
     private protected override void ApplyExecutionContext()
     {
+        base.ApplyExecutionContext(); // blackboards first, then the agent
         if (_hasAgent)
         {
             Graph.SetAgent(_agent!);
@@ -62,9 +65,10 @@ public class StateMachine<TAgent>(Graph graph, IStateMachineObserver? observer =
 /// must have its <see cref="INode.Logic"/> populated (i.e. implement <see cref="ILogic"/>).
 /// </para>
 /// </summary>
-public class StateMachine : State, ISubGraphProvider
+public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlackboardSettable
 {
     public readonly Graph Graph;
+    private BlackboardContext _blackboards;
 
     IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Graph];
     private readonly IStateMachineObserver? _observer;
@@ -126,9 +130,63 @@ public class StateMachine : State, ISubGraphProvider
     /// <summary>
     /// Hook for derived machines to (re)apply per-machine execution context (e.g. the typed
     /// agent) to the graph's nodes. Runs under the execute gate, right before Starting.
+    /// The base implementation re-stamps the bound blackboard context.
     /// </summary>
     private protected virtual void ApplyExecutionContext()
     {
+        if (!_blackboards.IsEmpty)
+        {
+            Graph.SetBlackboards(in _blackboards);
+        }
+    }
+
+    /// <summary>
+    /// Binds a blackboard into the scope slot its schema declares (replace semantics — like
+    /// <c>SetAgent</c>, rebinding swaps the board, which enables machine pooling). Applied to
+    /// the graph's nodes immediately and re-applied at the start of every run. Validated
+    /// against the graph's schema declarations when present.
+    /// </summary>
+    public void SetBlackboard(Blackboard blackboard)
+    {
+        Guard.NotNull(blackboard, nameof(blackboard));
+        ValidateBoardAgainstDeclarations(blackboard);
+        _blackboards = _blackboards.With(blackboard);
+        Graph.SetBlackboards(in _blackboards);
+    }
+
+    /// <summary>
+    /// Receives the whole context from a parent machine's stamping walk (nested composite
+    /// path). Validates against this machine's own graph declarations, so a conflicting
+    /// child schema fails loudly at stamp time.
+    /// </summary>
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        if (context.Graph is { } graphBoard)
+        {
+            ValidateBoardAgainstDeclarations(graphBoard);
+        }
+
+        if (context.Global is { } globalBoard)
+        {
+            ValidateBoardAgainstDeclarations(globalBoard);
+        }
+
+        _blackboards = context;
+        Graph.SetBlackboards(in context);
+    }
+
+    private void ValidateBoardAgainstDeclarations(Blackboard blackboard)
+    {
+        BlackboardSchema? declared = blackboard.Schema.Scope == BlackboardScope.Global
+            ? Graph.GlobalSchema
+            : Graph.Schema;
+
+        if (declared is not null && !ReferenceEquals(declared, blackboard.Schema))
+        {
+            throw new InvalidOperationException(
+                $"Blackboard schema '{blackboard.Schema.Name ?? "<unnamed>"}' does not match the " +
+                $"{blackboard.Schema.Scope} schema '{declared.Name ?? "<unnamed>"}' declared on graph '{Graph.Id}'.");
+        }
     }
 
     private static State?[] BuildLogReportTable(Graph graph)

--- a/NxGraph/Fsm/SwitchState.cs
+++ b/NxGraph/Fsm/SwitchState.cs
@@ -1,26 +1,50 @@
-﻿using NxGraph.Graphs;
+using NxGraph.Blackboards;
+using NxGraph.Graphs;
 
 namespace NxGraph.Fsm;
 
 /// <summary>
 /// Branches like a switch/case.  Finishes immediately with <see cref="Result.Success"/>; the
 /// runtime asks <see cref="SelectNext"/> for the next node.
+/// The blackboard-context overload receives the machine-bound routed context (see
+/// <see cref="BlackboardContext"/>), so the selector can read shared memory instead of
+/// closing over ad-hoc state.
 /// Purely synchronous — the authoring layer wraps this in a <see cref="SyncLogicAdapter"/>
 /// so that async runtimes can also execute it.
 /// </summary>
-public sealed class SwitchState<TKey>(
-    Func<TKey> selector,
-    IReadOnlyDictionary<TKey, NodeId> cases,
-    NodeId defaultNode = default)
-    : ILogic, IDirector
+public sealed class SwitchState<TKey> : ILogic, IDirector, IBlackboardSettable
     where TKey : notnull
 {
-    private readonly Func<TKey> _selector = selector ?? throw new ArgumentNullException(nameof(selector));
-    private readonly IReadOnlyDictionary<TKey, NodeId> _cases = cases ?? throw new ArgumentNullException(nameof(cases));
+    private readonly Func<TKey>? _selector;
+    private readonly Func<BlackboardContext, TKey>? _bbSelector;
+    private readonly IReadOnlyDictionary<TKey, NodeId> _cases;
     // When no explicit default is supplied, fall back to NodeId.Default — both the sync and
     // the async runtimes treat that as a terminal-success exit from the director. Defaulting
     // to default(NodeId) would silently route to Start (index 0) instead.
-    private NodeId _defaultNode = defaultNode.Equals(default(NodeId)) ? NodeId.Default : defaultNode;
+    private NodeId _defaultNode;
+    private BlackboardContext _blackboards;
+
+    public SwitchState(
+        Func<TKey> selector,
+        IReadOnlyDictionary<TKey, NodeId> cases,
+        NodeId defaultNode = default)
+    {
+        _selector = selector ?? throw new ArgumentNullException(nameof(selector));
+        _cases = cases ?? throw new ArgumentNullException(nameof(cases));
+        _defaultNode = defaultNode.Equals(default(NodeId)) ? NodeId.Default : defaultNode;
+    }
+
+    public SwitchState(
+        Func<BlackboardContext, TKey> selector,
+        IReadOnlyDictionary<TKey, NodeId> cases,
+        NodeId defaultNode = default)
+    {
+        _bbSelector = selector ?? throw new ArgumentNullException(nameof(selector));
+        _cases = cases ?? throw new ArgumentNullException(nameof(cases));
+        _defaultNode = defaultNode.Equals(default(NodeId)) ? NodeId.Default : defaultNode;
+    }
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context) => _blackboards = context;
 
     /// <summary>
     /// Selects the next node based on the selector function.
@@ -28,7 +52,7 @@ public sealed class SwitchState<TKey>(
     /// <returns>The next node to run.</returns>
     public NodeId SelectNext()
     {
-        TKey key = _selector();
+        TKey key = _bbSelector is not null ? _bbSelector(_blackboards) : _selector!();
         return _cases.GetValueOrDefault(key, _defaultNode);
     }
 

--- a/NxGraph/Fsm/TracingObserver.cs
+++ b/NxGraph/Fsm/TracingObserver.cs
@@ -45,15 +45,20 @@ public sealed class TracingObserver : IAsyncStateMachineObserver
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask OnStateFailed(NodeId id, Exception ex, CancellationToken ct = default)
+    public ValueTask OnStateFailed(NodeId id, Exception? ex, CancellationToken ct = default)
     {
         Activity? act = _current.Value;
         if (act is null) return ValueTask.CompletedTask;
 
-        act.SetTag("exception.type", ex.GetType().FullName);
-        act.SetTag("exception.message", ex.Message);
-        act.SetTag("exception.stacktrace", ex.StackTrace);
-        act.SetStatus(ActivityStatusCode.Error, ex.Message);
+        // ex is null when the node returned Result.Failure without throwing.
+        if (ex is not null)
+        {
+            act.SetTag("exception.type", ex.GetType().FullName);
+            act.SetTag("exception.message", ex.Message);
+            act.SetTag("exception.stacktrace", ex.StackTrace);
+        }
+
+        act.SetStatus(ActivityStatusCode.Error, ex?.Message ?? "node returned Failure");
 
         return ValueTask.CompletedTask;
     }

--- a/NxGraph/Graphs/Graph.cs
+++ b/NxGraph/Graphs/Graph.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using NxGraph.Blackboards;
 using NxGraph.Compatibility;
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
@@ -56,8 +57,19 @@ public sealed class Graph : INode, IGraph
     /// <exception cref="ArgumentException">Thrown when the nodes or edges arrays are empty, have unequal lengths, or the first node is not the start node.</exception>
     public Graph(NodeId id, INode[] nodes, Transition[] edges, IAsyncLogic? logic = null,
         RetryPolicy[]? retryPolicies = null, int[]? outcomeCodes = null,
-        IReadOnlyDictionary<int, string>? outcomeNames = null)
+        IReadOnlyDictionary<int, string>? outcomeNames = null,
+        BlackboardSchema? schema = null, BlackboardSchema? globalSchema = null)
     {
+        if (schema is not null && schema.Scope != BlackboardScope.Graph)
+        {
+            throw new ArgumentException("The graph-owned schema must be Graph-scoped.", nameof(schema));
+        }
+
+        if (globalSchema is not null && globalSchema.Scope != BlackboardScope.Global)
+        {
+            throw new ArgumentException("The required global schema must be Global-scoped.", nameof(globalSchema));
+        }
+
         Guard.NotNull(nodes, nameof(nodes));
         Guard.NotNull(edges, nameof(edges));
 
@@ -90,8 +102,23 @@ public sealed class Graph : INode, IGraph
         _retryPolicies = retryPolicies;
         _outcomeCodes = outcomeCodes;
         OutcomeNames = outcomeNames;
+        Schema = schema;
+        GlobalSchema = globalSchema;
         AsyncLogic = logic ?? new EmptyAsyncLogic();
     }
+
+    /// <summary>
+    /// The Graph-scoped <see cref="BlackboardSchema"/> declared at authoring time via
+    /// <c>WithSchema(...)</c>, or <c>null</c> when the graph declares none. Declarations are
+    /// opt-in validation for machine binding; a graph round-tripped through serialization
+    /// has no declarations and binds permissively.
+    /// </summary>
+    public BlackboardSchema? Schema { get; }
+
+    /// <summary>
+    /// The Global-scoped schema this graph requires, or <c>null</c> when it declares none.
+    /// </summary>
+    public BlackboardSchema? GlobalSchema { get; }
 
     /// <summary>
     /// The per-node retry policies indexed by <see cref="NodeId.Index"/>, or <c>null</c>
@@ -229,6 +256,55 @@ public sealed class Graph : INode, IGraph
         }
 
         return found;
+    }
+
+    /// <summary>
+    /// Stamps the routed blackboard context onto every node that implements
+    /// <see cref="IBlackboardSettable"/>, recursing into composites via
+    /// <see cref="ISubGraphProvider"/>. Unlike <see cref="SetAgent{TAgent}"/> this never
+    /// throws when nothing accepts: the state base classes accept automatically, so zero
+    /// acceptors carries no bug signal — the lint lives in the graph validator instead.
+    /// </summary>
+    public void SetBlackboards(in BlackboardContext context)
+    {
+        SetBlackboardsRecursive(in context);
+    }
+
+    private void SetBlackboardsRecursive(in BlackboardContext context)
+    {
+        for (int i = 0; i < _nodes.Length; i++)
+        {
+            if (_nodes[i] is not LogicNode logicNode) continue;
+
+            // Check the async logic first, then the sync logic (for States wrapped in SyncLogicAdapter).
+            IBlackboardSettable? settable =
+                logicNode.AsyncLogic as IBlackboardSettable
+                ?? logicNode.Logic as IBlackboardSettable;
+
+            if (settable is not null)
+            {
+                settable.SetBlackboards(in context);
+                // Nested machines validate and re-walk their inner graph via their own
+                // SetBlackboards — no additional recursion needed.
+                continue;
+            }
+
+            ISubGraphProvider? provider =
+                logicNode.AsyncLogic as ISubGraphProvider
+                ?? logicNode.Logic as ISubGraphProvider;
+            if (provider is null)
+            {
+                continue;
+            }
+
+            foreach (Graph nested in provider.SubGraphs)
+            {
+                if (!ReferenceEquals(nested, this))
+                {
+                    nested.SetBlackboardsRecursive(in context);
+                }
+            }
+        }
     }
 
     public INode GetNodeByIndex(int index)

--- a/NxGraph/Graphs/Graph.cs
+++ b/NxGraph/Graphs/Graph.cs
@@ -73,14 +73,16 @@ public sealed class Graph : INode, IGraph
         Guard.NotNull(nodes, nameof(nodes));
         Guard.NotNull(edges, nameof(edges));
 
-        if (nodes[0].Id != NodeId.Start)
-        {
-            throw new ArgumentException("Start node (nodes[0]) Id must be NodeId.Start (index 0).", nameof(nodes));
-        }
-
+        // Length checks first: an empty nodes array must produce the documented
+        // ArgumentException, not an IndexOutOfRangeException from nodes[0] below.
         if (nodes.Length == 0 || edges.Length == 0 || nodes.Length != edges.Length)
         {
             throw new ArgumentException("Nodes/edges arrays must be non-empty and have equal length.");
+        }
+
+        if (nodes[0] is null || nodes[0].Id != NodeId.Start)
+        {
+            throw new ArgumentException("Start node (nodes[0]) Id must be NodeId.Start (index 0).", nameof(nodes));
         }
 
         if (retryPolicies is not null && retryPolicies.Length != nodes.Length)
@@ -214,8 +216,25 @@ public sealed class Graph : INode, IGraph
         }
     }
 
-    private bool SetAgentRecursive<TAgent>(TAgent agent)
+    /// <summary>
+    /// Cap on composite nesting for the agent/blackboard stamping walks. Indirect graph
+    /// cycles (A nests a machine over B, B nests one over A) are constructible with public
+    /// APIs; without a cap the walk would recurse to a process-killing StackOverflowException.
+    /// Depth-capping instead of a visited set keeps run-start stamping allocation-free.
+    /// </summary>
+    private const int MaxStampingDepth = 64;
+
+    private bool SetAgentRecursive<TAgent>(TAgent agent) => SetAgentRecursive(agent, 0);
+
+    private bool SetAgentRecursive<TAgent>(TAgent agent, int depth)
     {
+        if (depth > MaxStampingDepth)
+        {
+            throw new InvalidOperationException(
+                $"Composite nesting exceeds {MaxStampingDepth} levels while stamping the agent — " +
+                "check for a cycle between graphs nested as composites.");
+        }
+
         bool found = false;
         for (int i = 0; i < _nodes.Length; i++)
         {
@@ -248,7 +267,7 @@ public sealed class Graph : INode, IGraph
 
             foreach (Graph nested in provider.SubGraphs)
             {
-                if (!ReferenceEquals(nested, this) && nested.SetAgentRecursive(agent))
+                if (!ReferenceEquals(nested, this) && nested.SetAgentRecursive(agent, depth + 1))
                 {
                     found = true;
                 }
@@ -270,8 +289,17 @@ public sealed class Graph : INode, IGraph
         SetBlackboardsRecursive(in context);
     }
 
-    private void SetBlackboardsRecursive(in BlackboardContext context)
+    private void SetBlackboardsRecursive(in BlackboardContext context) => SetBlackboardsRecursive(in context, 0);
+
+    private void SetBlackboardsRecursive(in BlackboardContext context, int depth)
     {
+        if (depth > MaxStampingDepth)
+        {
+            throw new InvalidOperationException(
+                $"Composite nesting exceeds {MaxStampingDepth} levels while stamping blackboards — " +
+                "check for a cycle between graphs nested as composites.");
+        }
+
         for (int i = 0; i < _nodes.Length; i++)
         {
             if (_nodes[i] is not LogicNode logicNode) continue;
@@ -301,7 +329,7 @@ public sealed class Graph : INode, IGraph
             {
                 if (!ReferenceEquals(nested, this))
                 {
-                    nested.SetBlackboardsRecursive(in context);
+                    nested.SetBlackboardsRecursive(in context, depth + 1);
                 }
             }
         }

--- a/NxGraph/Graphs/LogicNode.cs
+++ b/NxGraph/Graphs/LogicNode.cs
@@ -47,7 +47,13 @@ public class LogicNode : INode
     public Action? ExitAction { get; }
 
     public static readonly LogicNode Empty = new(NodeId.Default, new EmptyAsyncLogic());
-    public static readonly LogicNode StateMachineMarker = new(NodeId.Default, new EmptyAsyncLogic());
+
+    /// <summary>
+    /// Sentinel for nested-state-machine owner nodes during (de)serialization. Uses the
+    /// dedicated <see cref="NodeId.StateMachineMarker"/> id so the wire marker string is
+    /// "StateMachine" rather than colliding with <see cref="NodeId.Default"/>'s "Default".
+    /// </summary>
+    public static readonly LogicNode StateMachineMarker = new(NodeId.StateMachineMarker, new EmptyAsyncLogic());
 }
 
 /// <summary>

--- a/NxGraph/NxGraph.csproj
+++ b/NxGraph/NxGraph.csproj
@@ -5,16 +5,21 @@
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
         <Title>NxGraph</Title>
         <Authors>Moe Iraji</Authors>
         <Description>A lean, high-performance finite state machine (FSM) / stateflow library for .NET with a clean authoring DSL, strong validation, first-class observability, and export tools (Mermaid, tracing, replay). Designed for correctness on hot paths (allocation-free), production diagnostics, and pleasant authoring.</Description>
         <PackageProjectUrl>https://github.com/Enzx/NxGraph</PackageProjectUrl>
+        <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/Enzx/NxGraph</RepositoryUrl>
-        <PackageTags>Statemachine, FSM, Performance</PackageTags>
+        <PackageTags>statemachine fsm stateflow graph performance zero-allocation unity</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>Docs/readme.md</PackageReadmeFile>
     </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    </ItemGroup>
     <ItemGroup>
         <Compile Remove="Shims\**\*.cs" />
     </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ NxGraph is a lean, high-performance finite state machine / stateflow library for
 - explicit branching through director nodes
 - sync and async runtimes
 - stepped execution for Unity (`Update()`-loop friendly)
+- a unified fault model: per-node retries, failure edges (`.OnError`), and timeouts
+- composites: subgraphs (with history), parallel regions, and blackboard-selected dynamic regions
+- durable suspend/resume via serializable snapshots
+- scoped blackboards (typed, zero-boxing shared memory)
 - graph validation
 - observers, tracing, replay, and Mermaid export
 - optional graph serialization via a codec-based serializer
@@ -35,6 +39,9 @@ The core package targets `net8.0` and `netstandard2.1`.
   - [Branching with `If`](#branching-with-if)
   - [Branching with `Switch`](#branching-with-switch)
   - [Waits and timeouts](#waits-and-timeouts)
+  - [Error handling: retries and failure edges](#error-handling-retries-and-failure-edges)
+  - [Loops with `Goto`](#loops-with-goto)
+  - [Named outcomes](#named-outcomes)
   - [Naming nodes](#naming-nodes)
   - [Agents / context injection](#agents--context-injection)
   - [Blackboards (scoped shared memory)](#blackboards-scoped-shared-memory)
@@ -43,6 +50,8 @@ The core package targets `net8.0` and `netstandard2.1`.
   - [Sync execution, stepped model](#sync-execution--stepped-model)
   - [Unity integration](#unity-integration)
   - [Nested machines](#nested-machines)
+  - [Composites: subgraphs, history, and parallel regions](#composites-subgraphs-history-and-parallel-regions)
+  - [Durable suspend / resume](#durable-suspend--resume)
   - [Restart policy](#restart-policy)
 - [Validation](#validation)
 - [Observability](#observability)
@@ -64,7 +73,7 @@ The core package targets `net8.0` and `netstandard2.1`.
 
 ## Why NxGraph
 
-- **Simple runtime model**: graphs are backed by dense node/transition arrays and each node has at most one direct outgoing edge.
+- **Simple runtime model**: graphs are backed by dense node/transition arrays and each node has at most one success edge plus an optional failure edge.
 - **Predictable branching**: fan-out happens through director nodes such as `ChoiceState` and `SwitchState<TKey>`.
 - **Authoring ergonomics**: build flows with `StartWithAsync`, `.ToAsync(...)`, `.If(...)`, `.Switch(...)`, `.WaitForAsync(...)`, and `.ToWithTimeoutAsync(...)`.
 - **Unity-ready sync runtime**: `StateMachine.Execute()` advances exactly one node per call, drop it into `MonoBehaviour.Update()`.
@@ -130,6 +139,7 @@ dotnet test -c Release
 using NxGraph;
 using NxGraph.Authoring;
 using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
 
 static ValueTask<Result> Acquire(CancellationToken _) => ResultHelpers.Success;
 static ValueTask<Result> Process(CancellationToken _) => ResultHelpers.Success;
@@ -223,6 +233,59 @@ var timed = GraphBuilder
     .Build();
 ```
 
+With `TimeoutBehavior.Fail` an expired timeout is an ordinary node failure — it consumes the node's retry budget and follows its failure edge like any other `Result.Failure` (see the next section). `TimeoutBehavior.Throw` raises a `TimeoutException` instead.
+
+### Error handling: retries and failure edges
+
+A node returning `Result.Failure` flows through one unified fault model: first its per-node `RetryPolicy` re-runs it in place, then its **failure edge** (if any) routes to a handler, and only when neither applies does the machine terminate with `Failure`.
+
+```csharp
+var graph = GraphBuilder
+    .StartWithAsync(CallFlakyService).SetName("Call")
+        .Retry(maxAttempts: 3, backoff: 100.Milliseconds(), BackoffKind.Exponential)
+        .OnErrorAsync(_ => Cleanup()).SetName("Cleanup")
+    .Build();
+```
+
+- `.Retry(maxAttempts, backoff, kind)` re-runs the node in place; `BackoffKind` is `Fixed`, `Linear`, or `Exponential`. Backoff delays apply to the async runtime; the sync runtime retries on the next tick.
+- `.OnError(...)` / `.OnErrorAsync(...)` set the failure destination. The success chain continues from the original node, so failure handlers branch off without disturbing the happy path; `.OnError(StateToken)` wires an already-built detached chain as the handler.
+- Retries fire **before** the failure edge: with the graph above, `Call` runs up to 3 times before `Cleanup` is entered.
+
+### Loops with `Goto`
+
+`.Goto("name")` wires a back-edge to a named node, resolved at `Build()` — unknown or ambiguous names fail the build:
+
+```csharp
+int laps = 0;
+
+var loop = GraphBuilder
+    .StartWith(() => Result.Success).SetName("Gather")
+    .To(() => ++laps < 3 ? Result.Success : Result.Failure).SetName("Craft")
+    .Goto("Gather") // Craft's success edge loops back to Gather
+    .Build();
+```
+
+A `Goto` consumes the node's one success edge and closes the chain, so the loop needs an exit: a node that eventually returns `Failure` (routed by `.OnError` or terminating the run), or a director (`If`/`Switch`) placed inside the loop.
+
+### Named outcomes
+
+Terminal nodes can report *which* outcome ended the run, beyond `Success`/`Failure`:
+
+```csharp
+const int Delivered = 1;
+
+var graph = GraphBuilder
+    .StartWithAsync(ProcessOrder).SetName("Process")
+    .ToAsync(_ => ResultHelpers.Success).SetName("Deliver").WithOutcome(Delivered, "Delivered")
+    .Build();
+
+AsyncStateMachine fsm = graph.ToAsyncStateMachine();
+await fsm.ExecuteAsync();
+Console.WriteLine($"{fsm.LastOutcome}: {fsm.LastOutcomeName}"); // "1: Delivered"
+```
+
+`.WithOutcome(code, name)` tags a node; when a run terminates at that node, the machine exposes the code via `LastOutcome` and the registered name via `LastOutcomeName` (0 / `null` when the terminal node has no outcome). Branch graphs give each terminal branch its own code, so callers can tell *how* the flow ended. `LastOutcome` resets at every run start and survives suspend/resume (it is part of the snapshot).
+
 ### Naming nodes
 
 Names are optional but strongly recommended for diagnostics, Mermaid export, replay, and observer output.
@@ -243,6 +306,7 @@ Use typed state machines when your states need shared mutable context or service
 using NxGraph;
 using NxGraph.Authoring;
 using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
 
 public sealed class AppAgent
 {
@@ -425,6 +489,95 @@ Result result = await parentFsm.ExecuteAsync();
 ```
 
 Nesting can be arbitrarily deep. Each level is stepped independently; the parent treats a running child as `Result.InProgress` and a completed child as `Result.Success`.
+
+### Composites: subgraphs, history, and parallel regions
+
+**Subgraphs.** `.SubGraph(child)` nests a whole child graph as a single node of the parent — the DSL shorthand for the nested-machine pattern above. With `history: true`, a child that *failed* resumes at its last-active node when the parent re-enters the composite (e.g. after a failure edge and a `Goto` back), instead of restarting from its start node; a child that *completed* restarts from the top:
+
+```csharp
+Graph child = GraphBuilder
+    .StartWithAsync(_ => ResultHelpers.Success)
+    .ToAsync(_ => ResultHelpers.Success)
+    .Build();
+
+Graph flow = GraphBuilder
+    .StartWithAsync(_ => ResultHelpers.Success).SetName("Prepare")
+    .SubGraph(child, history: true).SetName("Work")
+    .ToAsync(_ => ResultHelpers.Success).SetName("Finish")
+    .Build();
+```
+
+**Parallel regions (AND-states).** `.Parallel(regions...)` runs N region graphs via **cooperative interleaving**: each round advances every still-running region by one node, and the composite joins when all regions reach a terminal result — `Success` only if every region succeeded, otherwise `Failure` through the parent's fault model (failure edges, retries). This is deliberately not thread-concurrent, which keeps the hot path allocation-free:
+
+```csharp
+AsyncStateMachine fsm = GraphBuilder
+    .Start()
+    .Parallel(tents, fire, scouts) // three region graphs, one node each per round
+    .ToAsyncStateMachine();
+
+Result joined = await fsm.ExecuteAsync();
+```
+
+The sync twin takes a `ParallelStepMode`: `RunToJoin` completes the whole join inside one `Execute()` call, while `RoundPerTick` advances one round per call and returns `Result.InProgress` in between — so region progress aligns 1:1 with game-loop frames:
+
+```csharp
+StateMachine fsm = GraphBuilder
+    .Start()
+    .Parallel(ParallelStepMode.RoundPerTick, watchtower, gateCrew)
+    .ToStateMachine();
+
+// From Update(): each call advances every still-running region by one node.
+Result r = fsm.Execute();
+```
+
+`RoundPerTick` is sync-only (the async loop rejects node-level `InProgress`); `RunToJoin` composites also run under the async machine via the sync-logic adapter.
+
+**Dynamic (some-of-many) regions.** The selector overloads pick which regions run at every composite entry, from the machine-bound [blackboard](#blackboards-scoped-shared-memory):
+
+```csharp
+RegionMask SelectDefenses(BlackboardContext bb)
+{
+    RegionMask mask = RegionMask.Bit(0);                    // archers always
+    if (bb.Get(Threat) >= 2) mask |= RegionMask.Bit(1);     // cauldrons
+    if (bb.Get(Threat) >= 3) mask |= RegionMask.Bit(2);     // catapults
+    return mask;
+}
+
+StateMachine fsm = GraphBuilder
+    .Start()
+    .Parallel(ParallelStepMode.RunToJoin, SelectDefenses, archers, cauldrons, catapults)
+    .ToStateMachine()
+    .WithBlackboard(board);
+```
+
+The selector runs once per composite execution and fixes the selected set for that run; unselected regions are never stepped. An empty mask is a vacuous join (immediate `Success`); mask bits at or above the region count throw; up to 64 regions per composite. Both variants exist in both runtimes (`.Parallel(selector, ...)` for async, `.Parallel(mode, selector, ...)` for sync). See `NxFSM.Examples/ParallelDemo` for runnable sync and async demos.
+
+### Durable suspend / resume
+
+Both runtimes can pause a run at a step boundary, persist it, and continue later — on the same machine, a fresh machine, another process, or even the **other runtime** (snapshots are interchangeable):
+
+```csharp
+using System.Text.Json;
+
+AsyncStateMachine first = graph.ToAsyncStateMachine();
+await first.StepAsync();                              // advance one node
+StateMachineSnapshot snapshot = first.Suspend();      // primitives-only record
+
+string json = JsonSerializer.Serialize(snapshot);     // any serializer works
+
+// Later — possibly after a process restart, on the sync runtime:
+StateMachine second = graph.ToStateMachine();
+second.Resume(JsonSerializer.Deserialize<StateMachineSnapshot>(json)!);
+
+Result result = Result.InProgress;
+while (result == Result.InProgress)
+    result = second.Execute();                        // continues at the next node
+```
+
+- `Suspend()` is legal between `StepAsync()`/`Execute()` calls of a stepped run, or on an idle/terminal machine; it captures the current node, status, retry attempts, and `LastOutcome`.
+- `Resume(snapshot)` requires a graph that is structurally equivalent (same node indices); re-attach agents/blackboards before continuing.
+- A fully durable flow persists three artifacts: the graph payload (`GraphSerializer`), the snapshot, and one `BlackboardSerializer` payload per bound board — see [Serialization](#serialization).
+- Composite-internal progress (positions inside parallel regions or history children) is not part of the flat snapshot; a resumed composite starts its visit fresh.
 
 ### Restart policy
 
@@ -698,9 +851,12 @@ Notes:
 The solution includes a runnable examples project with:
 
 - a simple async FSM
-- an AI enemy example
+- an AI enemy example (typed agent injection)
 - Mermaid export example
+- a serialization round-trip example
 - a sync Dungeon Crawler example using the DSL, observers, director nodes, loops, and named states
+- a blackboard demo (scoped shared memory, schema declarations, per-entity boards)
+- **parallel-region demos**: the sync Stronghold Siege (`ParallelStepMode.RoundPerTick` frame ticking, `RunToJoin` waves, blackboard-selected dynamic regions) and the async Expedition Camp (cooperative round-robin interleaving under `AsyncStateMachine`, dynamic region selection)
 
 Run it with:
 
@@ -750,7 +906,7 @@ dotnet run --project NxGraph.Benchmarks -c Release
 
 Key observations:
 
-- **Zero allocations**, both runtimes are fully alloc-free after graph construction. The earlier 80 B figure was the `async Task<T>` wrapper on the benchmark method itself; benchmarks now return `ValueTask<Result>` directly.
+- **Zero allocations**: both runtimes are fully alloc-free after graph construction.
 - **Sync is ~8× faster on a single node**: 24 ns vs 199 ns, reflecting the absence of async machinery and `Interlocked` operations.
 - **Observer overhead is constant** and runtime-dependent: +3 ns for sync, +40 ns for async, independent of chain length.
 - **Per-node cost falls with chain length**: async 199 ns for 1 node → 80 ns/node for 10 → 67 ns/node for 50.
@@ -782,8 +938,8 @@ The tests cover:
 
 ## FAQ
 
-**Why is there only one direct outgoing transition per node?**  
-Branching is modeled explicitly through directors such as `ChoiceState` and `SwitchState<TKey>`, which keeps execution simple and predictable.
+**Why is there only one direct success transition per node?**  
+Branching is modeled explicitly through directors such as `ChoiceState` and `SwitchState<TKey>`, which keeps execution simple and predictable. A node can additionally carry one failure edge (`.OnError`) for the fault path.
 
 **Can I share a graph across machines?**  
 Yes. `Graph` is immutable after build and can be reused across multiple state machine instances.
@@ -807,9 +963,9 @@ The machine has more nodes to process but is returning control to the caller (e.
 
 ## Roadmap
 
-- richer package docs and example coverage
-- additional validation/reporting improvements
-- more visualization tooling
+- sync twins for the remaining async-only constructs (history subgraphs, waits, timeouts)
+- hierarchical snapshots so composite-internal progress survives durable suspend/resume
+- validator and Mermaid-export awareness of composite interiors
 - continued ergonomics improvements around DSL authoring and serialization
 
 ---

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The core package targets `net8.0` and `netstandard2.1`.
   - [Waits and timeouts](#waits-and-timeouts)
   - [Naming nodes](#naming-nodes)
   - [Agents / context injection](#agents--context-injection)
+  - [Blackboards (scoped shared memory)](#blackboards-scoped-shared-memory)
 - [Execution](#execution)
   - [Async execution](#async-execution)
   - [Sync execution, stepped model](#sync-execution--stepped-model)
@@ -264,6 +265,59 @@ AsyncStateMachine<AppAgent> fsm = GraphBuilder
 
 await fsm.ExecuteAsync();
 ```
+
+### Blackboards (scoped shared memory)
+
+The agent is *who* is acting (an `Enemy`, a workflow context); a **blackboard** is the graph's *working memory*. They are orthogonal channels — both reach nodes simultaneously. Blackboards are typed-key slot stores with two scopes: **Global** (one user-owned board shared by every machine — world state) and **Graph** (one board per machine/entity). Reads and writes are zero-boxing, zero-allocation array accesses.
+
+```csharp
+using NxGraph.Blackboards;
+
+// Schemas are code: declare keys once, share the schema across N boards.
+static class WorldKeys
+{
+    public static readonly BlackboardSchema Schema = new("world", BlackboardScope.Global);
+    public static readonly BlackboardKey<bool> AlarmRaised = Schema.Register<bool>("AlarmRaised");
+}
+
+static class EnemyKeys
+{
+    public static readonly BlackboardSchema Schema = new("enemy"); // Graph scope (default)
+    public static readonly BlackboardKey<int> TargetDistance = Schema.Register<int>("TargetDistance", 10);
+}
+
+sealed class ChaseState : AsyncState<Enemy>
+{
+    protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        // One call site — the key's schema scope picks the board:
+        if (Bb.Get(WorldKeys.AlarmRaised))          // routed → shared global board
+            Bb.GetRef(EnemyKeys.TargetDistance)--;   // routed → this machine's board
+        return ResultHelpers.Success;
+    }
+}
+
+// Declare schemas on the graph (opt-in bind-time validation), bind boards per machine:
+Graph graph = GraphBuilder
+    .StartWithAsync(new ChaseState())
+    .If(bb => bb.Get(WorldKeys.AlarmRaised))         // blackboard-driven branching
+        .ThenAsync((bb, ct) => ResultHelpers.Success)
+        .ElseAsync((bb, ct) => ResultHelpers.Success)
+    .WithSchema(EnemyKeys.Schema)
+    .WithSchema(WorldKeys.Schema)
+    .Build();
+
+Blackboard world = new(WorldKeys.Schema);            // one world board for everyone
+
+AsyncStateMachine<Enemy> fsm = graph.ToAsyncStateMachine<Enemy>()
+    .WithBlackboard(world)                           // routed by schema scope
+    .WithBlackboard(new Blackboard(EnemyKeys.Schema)) // this enemy's own memory
+    .WithAgent(enemy);
+```
+
+> **Anti-pattern:** don't use `Dictionary<string, object>` as a context — every access pays string hashing plus boxing. A `BlackboardKey<T>` slot is a schema-checked array read: type-safe, allocation-free, and serializable (see `BlackboardSerializer` in `NxGraph.Serialization` — each board is its own durability artifact alongside the graph payload and machine snapshot).
+
+Like the state machines, a blackboard is owned by a single runner at a time (not thread-safe).
 
 ---
 

--- a/docs/benchmarks.svg
+++ b/docs/benchmarks.svg
@@ -118,6 +118,6 @@
 
   <!-- footer -->
   <text x="410" y="462" text-anchor="middle" font-size="10" fill="#94a3b8">
-    0 B alloc confirmed after removing async Task&lt;T&gt; benchmark wrapper · Runtime: .NET 8.0.26 · RyuJIT AVX-512 · 2026-04-27
+    Runtime: .NET 8.0.26 · RyuJIT AVX-512 · 2026-04-27
   </text>
 </svg>

--- a/upm/com.enzx.nxgraph/CHANGELOG.md
+++ b/upm/com.enzx.nxgraph/CHANGELOG.md
@@ -1,9 +1,16 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
-- Restored the Unity UPM package structure.
-- Added package metadata, documentation, and Quick Start sample files.
-- Kept source staging driven by `scripts/build-upm.ps1`.
+- Staging documentation now describes the actual mechanism (`dotnet run --project NxGraph.Build -- stage-source|stage-binary`); the previously referenced `scripts/build-upm.ps1` no longer exists.
+- Source staging now includes the `Blackboards` and `Shims` folders (the source-mode package could not compile without them).
+- Refreshed the staged binary (`Runtime/Plugins/NxGraph.dll`) — the previously committed DLL was a stale 1.0.0 build predating failure edges, suspend/resume, parallel composites, and blackboards.
+- Aligned the assembly definition name (`NxGraph.Unity.Runtime`) with its file name.
+- Install instructions now point at the released `upm` branch/tags instead of the main-branch package folder.
 
+## [2.0.1-alpha]
+- Alpha release published from the `upm/v2.0.1-alpha` tag (binary staging mode).
+
+## [2.0.0.1-alpha]
+- First alpha publish of the 2.x package pipeline (tag `upm/v2.0.0.1-alpha`; note: not valid SemVer — superseded by 2.0.1-alpha).

--- a/upm/com.enzx.nxgraph/Documentation~/build-and-release.md
+++ b/upm/com.enzx.nxgraph/Documentation~/build-and-release.md
@@ -1,44 +1,47 @@
-﻿# Build and release
+# Build and release
+
+Staging is driven by the C# build system (`NxGraph.Build`, Bullseye targets). Run all commands from the repository root (`NxGraph_Code`).
 
 ## Source-based staging
 
-From the repository root:
-
-```powershell
-.\scripts\build-upm.ps1 -Mode Source
+```bash
+dotnet run --project NxGraph.Build -- stage-source
 ```
 
 This stages the runtime source into `upm/com.enzx.nxgraph/Runtime/NxGraph`.
 
-The source staging script currently copies:
+Source staging copies:
 
 - `Authoring`
+- `Blackboards`
 - `Compatibility`
 - `Diagnostics/Export`
 - `Diagnostics/Replay`
 - `Diagnostics/Validations`
 - `Fsm`
 - `Graphs`
+- `Shims`
 - `Result.cs`
 - `ResultHelpers.cs`
 
-It also excludes `Fsm/TracingObserver.cs` from the staged Unity runtime.
+It excludes `Fsm/TracingObserver.cs` from the staged Unity runtime (it is `NET8_0_OR_GREATER` only).
 
-## Binary fallback
+## Binary staging
 
 If a binary package is needed instead:
 
-```powershell
-.\scripts\build-upm.ps1 -Mode Binary
+```bash
+dotnet run --project NxGraph.Build -- stage-binary
 ```
 
-This stages `NxGraph.dll` into `Runtime/Plugins`.
+This builds Release and stages the netstandard2.1 `NxGraph.dll` (plus PDB and XML docs) into `Runtime/Plugins`.
 
-For backward compatibility, `scripts/build-upm-binary.ps1` still delegates to binary mode.
+## Release
+
+The `upm-release.yml` workflow (triggered by `upm/v*` tags or manually) runs `ci`, stages the chosen mode, patches `package.json` via `upm-patch-version`, creates the tarball via `upm-tarball`, pushes the package layout to the `upm` branch, and attaches the tarball to a GitHub release.
 
 ## Important
 
 Do not keep both staged source and `NxGraph.dll` in the same package layout, or Unity may see duplicate types.
 
-If a target Unity version cannot compile the staged runtime source as-is, prefer the binary fallback package for that environment.
-
+If a target Unity version cannot compile the staged runtime source as-is, prefer the binary package for that environment.

--- a/upm/com.enzx.nxgraph/Documentation~/index.md
+++ b/upm/com.enzx.nxgraph/Documentation~/index.md
@@ -1,37 +1,28 @@
-﻿# NxGraph Unity Package
+# NxGraph Unity Package
 
 ## Overview
 
-This Unity package wraps the core `NxGraph` runtime as a source-first UPM package.
+This Unity package wraps the core `NxGraph` runtime as a UPM package. It can be staged in two modes:
 
-It is intended to let Unity users:
-
-- inspect the implementation directly
-- step through the source in their own projects
-- avoid relying on decompiled DLLs for runtime understanding
+- **Source mode** — the runtime source is staged into `Runtime/NxGraph`, so Unity users can inspect and step through the implementation directly.
+- **Binary mode** — the netstandard2.1 `NxGraph.dll` (with PDB and XML docs) is staged into `Runtime/Plugins`.
 
 ## Package contents
 
-- `Runtime/NxGraph` - staged runtime source
-- `Runtime/NxGraph.Runtime.asmdef` - runtime assembly definition
-- `Samples~/QuickStart` - starter sample
-- `Documentation~` - package documentation
+- `Runtime/NxGraph` — staged runtime source (source mode), or `Runtime/Plugins/NxGraph.dll` (binary mode)
+- `Runtime/NxGraph.Unity.Runtime.asmdef` — runtime assembly definition
+- `Samples~/QuickStart` — starter sample
+- `Documentation~` — package documentation
 
 ## Recommended workflow
 
-1. Run `scripts/build-upm.ps1 -Mode Source` or `scripts/build-upm.ps1 -Mode Binary`
-2. Reference `upm/com.enzx.nxgraph` from Unity through a local path or Git URL
+1. From the repo root, run `dotnet run --project NxGraph.Build -- stage-source` (or `stage-binary`)
+2. Reference `upm/com.enzx.nxgraph` from Unity through a local path, or consume a published release from the `upm` branch / release tarball
+
+See `build-and-release.md` for the full staging and release pipeline.
 
 ## Important
 
-Use one staging mode at a time:
+Use one staging mode at a time — do not keep both staged source and runtime DLLs in the package simultaneously, or Unity may see duplicate types.
 
-- source mode via `build-upm.ps1 -Mode Source`, or
-- binary fallback via `build-upm.ps1 -Mode Binary`
-
-The legacy `build-upm-binary.ps1` script is still available as a compatibility shortcut.
-
-Do not keep both staged source and runtime DLLs in the package simultaneously.
-
-Because this package stages the live NxGraph source, supported Unity editor versions depend on the C# language features present in the current runtime files.
-
+Because source mode stages the live NxGraph source, supported Unity editor versions depend on the C# language features present in the current runtime files.

--- a/upm/com.enzx.nxgraph/README.md
+++ b/upm/com.enzx.nxgraph/README.md
@@ -1,17 +1,48 @@
-﻿# NxGraph for Unity
+# NxGraph for Unity
 
 NxGraph is a lean finite state machine / stateflow library with:
 
 - a fluent authoring DSL
 - sync and async runtimes
-- graph validation
-- observers, replay, and Mermaid export
+- failure edges, retries, and timeouts (unified fault model)
+- composites: subgraphs, history, parallel regions
+- durable suspend/resume via snapshots
+- scoped blackboards
+- graph validation, observers, replay, and Mermaid export
 
 ## Install
 
+### Git package (recommended)
+
+Releases are published to the `upm` branch. Add to your Unity project's `Packages/manifest.json`:
+
+```json
+{
+  "dependencies": {
+    "com.enzx.nxgraph": "https://github.com/Enzx/NxGraph.git#upm"
+  }
+}
+```
+
+Or pin a specific release tag:
+
+```json
+{
+  "dependencies": {
+    "com.enzx.nxgraph": "https://github.com/Enzx/NxGraph.git#upm/v2.0.1-alpha"
+  }
+}
+```
+
+Do **not** consume the `upm/com.enzx.nxgraph` folder from the `main` branch — its staged artifacts are not refreshed on every commit and may lag the released version.
+
+### Tarball
+
+Each GitHub release under the `upm/v*` tags carries a `.tgz` asset. Install via Unity Package Manager → "Add package from tarball".
+
 ### Local package
 
-Add this package to your Unity project's `Packages/manifest.json`:
+For local development against a checkout:
 
 ```json
 {
@@ -21,23 +52,16 @@ Add this package to your Unity project's `Packages/manifest.json`:
 }
 ```
 
-### Git package
+Stage fresh artifacts into the folder first (see Staging below).
 
-Once the package folder is committed, it can also be consumed through Git:
+## Staging
 
-```json
-{
-  "dependencies": {
-    "com.enzx.nxgraph": "https://github.com/Enzx/NxGraph.git?path=/upm/com.enzx.nxgraph"
-  }
-}
-```
+Staging is driven by the C# build system (`NxGraph.Build`), run from the repo root:
 
-## Source-first package layout
+- Source mode (runtime source staged into `Runtime/NxGraph`): `dotnet run --project NxGraph.Build -- stage-source`
+- Binary mode (netstandard2.1 DLL staged into `Runtime/Plugins`): `dotnet run --project NxGraph.Build -- stage-binary`
 
-This package is designed to be staged from source so consumers can navigate the implementation directly inside Unity projects.
-
-Runtime source is staged into `Runtime/NxGraph` by `scripts/build-upm.ps1`.
+Do not stage both source and runtime DLLs at the same time. Source staging mirrors the current runtime source exactly, so actual Unity editor compatibility depends on the C# features used by the staged files.
 
 ## Quick start
 
@@ -51,14 +75,11 @@ StateMachine fsm = GraphBuilder
     .To(() => Result.Success).SetName("Finish")
     .ToStateMachine();
 
-Result result = fsm.Execute();
+// Execute() is stepped: it advances one node per call and returns
+// Result.InProgress until the machine reaches a terminal result.
+Result result;
+do
+{
+    result = fsm.Execute();
+} while (result == Result.InProgress);
 ```
-
-## Notes
-
-- Use `scripts/build-upm.ps1 -Mode Source` for source staging.
-- Use `scripts/build-upm.ps1 -Mode Binary` for binary staging.
-- `scripts/build-upm-binary.ps1` remains available as a backward-compatible shortcut for binary staging.
-- Do not stage both source and runtime DLLs at the same time.
-- Source staging mirrors the current runtime source exactly, so actual Unity editor compatibility depends on the C# features used by the staged files.
-

--- a/upm/com.enzx.nxgraph/Runtime/NxGraph.Unity.Runtime.asmdef
+++ b/upm/com.enzx.nxgraph/Runtime/NxGraph.Unity.Runtime.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "NxGraph.Unity",
+    "name": "NxGraph.Unity.Runtime",
     "rootNamespace": "NxGraph",
     "references": [],
     "includePlatforms": [],

--- a/upm/com.enzx.nxgraph/Samples~/QuickStart/NxGraphQuickStartBehaviour.cs
+++ b/upm/com.enzx.nxgraph/Samples~/QuickStart/NxGraphQuickStartBehaviour.cs
@@ -6,14 +6,12 @@ using UnityEngine;
 namespace NxGraph.Samples.QuickStart
 {
     /// <summary>
-    /// Demonstrates two ways of running an NxGraph <see cref="StateMachine"/> in Unity:
-    /// <list type="bullet">
-    ///   <item><b>Frame-stepped</b> – <see cref="StateMachine.Tick"/> advances one node
-    ///         per frame. Auto-starts on first call; ideal for gameplay FSMs.</item>
-    ///   <item><b>Blocking</b> – <see cref="StateMachine.Execute"/> (inherited from
-    ///         <see cref="State"/>) runs the entire FSM in a single call
-    ///         (fine for trivial graphs).</item>
-    /// </list>
+    /// Demonstrates running an NxGraph <see cref="StateMachine"/> in Unity. The sync machine
+    /// is <b>frame-stepped</b>: each <see cref="State.Execute"/> call advances exactly one
+    /// node and returns <see cref="Result.InProgress"/> until the run reaches a terminal
+    /// result — a natural fit for calling once per frame from <c>Update()</c>. The first
+    /// call auto-starts the run; <see cref="RestartPolicy"/> controls what happens after a
+    /// terminal result (Auto restarts on the next call).
     /// </summary>
     public sealed class NxGraphQuickStartBehaviour : MonoBehaviour
     {

--- a/upm/com.enzx.nxgraph/package.json
+++ b/upm/com.enzx.nxgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.enzx.nxgraph",
   "displayName": "NxGraph",
-  "version": "2.0.0",
+  "version": "2.0.1-alpha",
   "description": "A lean, high-performance finite state machine / stateflow library for Unity with a fluent authoring DSL, validation, replay, and Mermaid export.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary

This PR ships the scoped-blackboards feature wave plus the fixes from the 2026-07-03 comprehensive code review.

### Features

- **Scoped blackboards** — typed, scope-routed (`Global`/`Graph`) node-to-node data flow: `BlackboardSchema`/`BlackboardKey<T>`, one stamped `BlackboardContext` per machine (`Bb` on the state bases), zero boxing/allocation on the hot path, schema declarations on the graph (`.WithSchema`), per-machine binding (`.WithBlackboard`), and independent `BlackboardSerializer` payloads (Strict/Skip mismatch policy, restore-into).
- **Sync `ParallelState`** — runtime parity for orthogonal regions with `ParallelStepMode.RunToJoin` (one tick) and `RoundPerTick` (one round per `Execute()` tick).
- **Dynamic parallel composites** — some-of-many region selection via `Func<BlackboardContext, RegionMask>` in both runtimes (`AsyncDynamicParallelState`/`DynamicParallelState`), selector fixed at entry, empty mask = vacuous join, ≤64 regions.
- **Stronghold Siege example** — parallel/dynamic-parallel demo covering both step modes and mask selection.

### Review fixes

**Runtime hardening**
- `OnStateFailed` is `Exception?` on both observer interfaces; `ReplayRecorder`/`TracingObserver` no longer NRE whenever a failure edge is taken (they crashed on exactly the paths they exist to diagnose).
- The async machine releases the execute gate and repairs transient status when an observer throws at run start (previously the machine was permanently locked with no recovery API), and its catch paths carry the sync `Finalise` idempotence guard (no more double `OnStateMachineCompleted` / Completed→Failed flip).
- `Resume` reconstructs the terminal result from the snapshot, so `RestartPolicy.Ignore` reports the restored run's true outcome.
- Blackboard context re-stamps unconditionally at run start; all machine-wrapping composites forward context via `IBlackboardSettable` — a board-less machine sharing a graph now throws instead of silently aliasing another machine's boards, and history/static-parallel children get stamp-time schema validation.
- `Start().If(predicate)` builds a sync `ChoiceState` (the graph is executable by the sync runtime again); stamping walks are depth-capped against composite cycles; the netstandard2.1 CTS pool disarms stale `CancelAfter` timers.

**Serialization hardening**
- Binary-codec serializers can read back the subgraph payloads they write (marker check runs before the codec guard).
- Nested-machine markers moved to `"StateMachine"` (legacy `"Default"` accepted on read) and are only honored when a subgraph payload claims the node — kills the in-band collision and the crafted-payload logic-swap lever.
- MessagePack depth accounting in `GraphDtoFormatter` — crafted deep payloads throw instead of stack-overflowing the process.
- Unsupported composites fail at serialize time with a targeted `NotSupportedException`; the broken raw-Graph-as-node branches are gone; every nesting level is version-gated in both formats.
- Blackboard payload type names are runtime-stable (saves with generic keys survive .NET upgrades) and restore is two-phase/all-or-nothing.
- MessagePack bumped 3.1.4 → 3.1.7 (clears the NU1902/NU1903 advisories).

**Packaging / release pipeline / UPM**
- `stage-source` includes `Blackboards/`; the UPM release workflow no longer deletes its own tarball before attaching it (and fails loudly on a missing asset); `dotnet pack` builds with `-p:Version` and real determinism flags; XML docs and SourceLink ship with the NuGet packages; UPM version/README/docs/sample corrected and the staged binary refreshed.

## Testing

- `dotnet test -c Release`: **396/396 green** (363 + 33), including 12 new regression tests (observer-throw recovery, failure-edge replay, cross-runtime snapshot interchange executing on both runtimes, board-aliasing, binary subgraph round-trip, marker collision, stable type names, atomic restore).
- `AllocationGateTests` 0 B invariant holds with the stamping changes.
- Public API baselines regenerated; the diff is limited to the intended `Exception?` annotations and `IBlackboardSettable`/`ISubGraphProvider` additions on the composite types.

## Notes

- One deliberate contract change: user containers that wrap machines must implement `IBlackboardSettable` forwarding alongside `ISubGraphProvider` (matching all built-in composites); the codifying test was updated.
- Feature-sized parity gaps (sync HistoryState/SubGraph DSL/Wait/Timeout, `SetRestartPolicy` naming) are specced in `specs/004-sync-composite-and-timing-parity` rather than rushed here.
