### PR TITLE
Node-scoped blackboards and sync composite/timing parity

### DIFF
--- a/NxFSM.Examples/BlackboardDemo/BlackboardDemoExample.cs
+++ b/NxFSM.Examples/BlackboardDemo/BlackboardDemoExample.cs
@@ -17,6 +17,9 @@ namespace NxFSM.Examples.BlackboardDemo;
 ///   <item>Agent vs blackboard as orthogonal channels — <c>WithBlackboard(...).WithBlackboard(...).WithAgent(...)</c></item>
 ///   <item><see cref="BlackboardScope.Global"/> world board shared by every machine (one guard raises the alarm, all react)</item>
 ///   <item><see cref="BlackboardScope.Graph"/> boards: one graph template, N guards, each with private working memory</item>
+///   <item><see cref="BlackboardScope.Node"/> scratch: the tackle's grip builds across in-place
+///   retries of one visit, resets to defaults when the visit ends, and needs zero binding —
+///   the machine owns the board (see <c>TackleState</c>)</item>
 ///   <item>Schema declarations on the graph (<c>.WithSchema</c>) with bind-time validation</item>
 ///   <item>Blackboard-driven branching: <c>.Switch(bb =&gt; bb.Get(GuardKeys.Mode))</c></item>
 ///   <item>Combined agent + context relay lambdas: <c>.ToAsync&lt;Guard&gt;((guard, bb, ct) =&gt; ...)</c></item>
@@ -44,14 +47,18 @@ public static class BlackboardDemoExample
 
         // ── 1. One graph template for every guard ───────────────────────
         // Sense → Decide (combined agent+context relay) → Switch on the guard's mode.
-        // The schemas are declared on the graph, so binding a board over the wrong
-        // schema fails fast at WithBlackboard time.
-        Graph guardBrain = GraphBuilder
+        // The Global/Graph schemas are declared on the graph, so binding a board over the
+        // wrong schema fails fast at WithBlackboard time. The Node-scoped schema is also a
+        // declaration — but it is the whole setup: every machine auto-creates its own
+        // transient board from it (see TackleState / TackleKeys).
+        TackleState tackle = new();
+        StateToken brain = GraphBuilder
             .StartWithAsync(new SenseState()).SetName("Sense")
             .ToAsync<Guard>((guard, bb, _) =>
             {
                 GuardMode mode =
                     bb.Get(WorldKeys.IntruderCaught) ? GuardMode.Rest :
+                    bb.Get(GuardKeys.Room) == bb.Get(WorldKeys.IntruderRoom) ? GuardMode.Tackle :
                     bb.Get(GuardKeys.Stamina) < 20 ? GuardMode.Rest :
                     bb.Get(GuardKeys.Suspicion) >= 50 ? GuardMode.Chase :
                     bb.Get(WorldKeys.AlarmLevel) > 0 ? GuardMode.Investigate :
@@ -63,11 +70,19 @@ public static class BlackboardDemoExample
             .CaseAsync(GuardMode.Patrol, new PatrolState())
             .CaseAsync(GuardMode.Investigate, new InvestigateState())
             .CaseAsync(GuardMode.Chase, new ChaseState())
+            .CaseAsync(GuardMode.Tackle, tackle)
             .CaseAsync(GuardMode.Rest, new RestState())
             .End().SetName("ModeSwitch")
             .WithSchema(GuardKeys.Schema)
             .WithSchema(WorldKeys.Schema)
-            .Build();
+            .WithSchema(TackleKeys.Schema);
+
+        // Attach the retry policy to the Tackle case: AddNode dedupes by instance, so
+        // TokenFor lands on the node the switch already added. The retries drive the
+        // Node-scoped grip accumulation inside one visit.
+        brain.Builder.TokenFor(brain.Builder.AddNode(tackle)).SetName("Tackle").Retry(maxAttempts: 3);
+
+        Graph guardBrain = brain.Build();
 
         // ── 2. One world board, one machine + board + agent per guard ───
         Blackboard world = new(WorldKeys.Schema);
@@ -88,6 +103,9 @@ public static class BlackboardDemoExample
         // ── 4. Save the world + every guard's board, then "restart" ─────
         // Boards are independent durability artifacts; between runs the machines are idle,
         // so no machine snapshot is needed here — the boards ARE the simulation state.
+        // Note what is absent: the Node-scoped tackle scratch. Transient scratch is not part
+        // of the durable flow — the fresh machines below recreate their own boards at
+        // defaults, which is the meaning of "transient".
         BlackboardSerializer serializer = new();
 
         MemoryStream worldSave = new();

--- a/NxFSM.Examples/BlackboardDemo/GuardStates.cs
+++ b/NxFSM.Examples/BlackboardDemo/GuardStates.cs
@@ -17,9 +17,11 @@ public sealed class SenseState : AsyncState<Guard>
 
         if (!Bb.Get(WorldKeys.IntruderCaught) && room == intruderRoom)
         {
-            Bb.Set(WorldKeys.IntruderCaught, true);
-            Bb.Set(WorldKeys.CaughtBy, Agent.Name);
-            Console.WriteLine($"    {Agent.Name} corners the intruder in room {room} — caught!");
+            // Face to face — Decide will route to the Tackle case; the actual capture is a
+            // per-visit struggle in TackleState (Node-scoped scratch + in-place retries).
+            Bb.Set(GuardKeys.Suspicion, 100);
+            Bb.Set(WorldKeys.LastSeenRoom, intruderRoom);
+            Console.WriteLine($"    {Agent.Name} corners the intruder in room {room}!");
         }
         else if (!Bb.Get(WorldKeys.IntruderCaught) && Math.Abs(room - intruderRoom) == 1)
         {
@@ -86,6 +88,43 @@ public sealed class ChaseState : AsyncState<Guard>
 
         Console.WriteLine($"    {Agent.Name} chases toward room {target} " +
                           $"(now in room {room}, stamina {Bb.Get(GuardKeys.Stamina)}).");
+        return ResultHelpers.Success;
+    }
+}
+
+/// <summary>
+/// The capture struggle — the <see cref="NxGraph.Blackboards.BlackboardScope.Node"/> showcase.
+/// The node carries a <c>.Retry(maxAttempts: 3)</c> policy: every attempt of the <i>same
+/// visit</i> adds grip to the Node-scoped scratch (retrying in place keeps it — partial
+/// progress is the point), and the intruder is caught once grip reaches 80, on the second
+/// attempt. The scratch needs no binding or cleanup: each machine owns a private board that
+/// snaps back to defaults when the visit ends, so a tackle next shift always starts from a
+/// fresh grip — and two guards tackling on the same shared graph template can never feel
+/// each other's hands.
+/// </summary>
+public sealed class TackleState : AsyncState<Guard>
+{
+    protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        ref int grip = ref Bb.GetRef(TackleKeys.Grip);
+        if (grip == 0)
+        {
+            // Node scratch is always at its registered default when a visit begins.
+            Console.WriteLine($"    {Agent.Name} lunges at the intruder (fresh grip — new visit, clean scratch).");
+        }
+
+        grip += 40;
+        if (grip < 80)
+        {
+            Console.WriteLine($"    ...the intruder squirms free of one arm (grip {grip}) — " +
+                              "retrying in place, scratch kept.");
+            return ResultHelpers.Failure; // consumed by the node's retry policy, not the machine
+        }
+
+        Bb.Set(WorldKeys.IntruderCaught, true);
+        Bb.Set(WorldKeys.CaughtBy, Agent.Name);
+        Bb.GetRef(GuardKeys.Stamina) -= 20;
+        Console.WriteLine($"    {Agent.Name} pins the intruder (grip {grip}) — caught!");
         return ResultHelpers.Success;
     }
 }

--- a/NxFSM.Examples/BlackboardDemo/Keys.cs
+++ b/NxFSM.Examples/BlackboardDemo/Keys.cs
@@ -9,6 +9,7 @@ public enum GuardMode
     Investigate = 1,
     Chase = 2,
     Rest = 3,
+    Tackle = 4,
 }
 
 /// <summary>
@@ -39,4 +40,21 @@ public static class GuardKeys
     public static readonly BlackboardKey<int> Room = Schema.Register<int>("Room");
     public static readonly BlackboardKey<int> Suspicion = Schema.Register<int>("Suspicion");
     public static readonly BlackboardKey<int> Stamina = Schema.Register<int>("Stamina", 100);
+}
+
+/// <summary>
+/// Transient per-visit scratch: a <see cref="BlackboardScope.Node"/> schema. Unlike the other
+/// two scopes there is nothing to bind — declaring the schema on the graph is enough, and
+/// every machine auto-creates its own private board (binding one via <c>WithBlackboard</c>
+/// throws). Values reset to their registered defaults whenever the machine moves to another
+/// node (or a run starts/resets/resumes), while <b>in-place retries keep them</b> — which is
+/// exactly what <see cref="TackleState"/> needs: grip builds across retry attempts of one
+/// tackle, and evaporates the moment the visit ends. Node boards are deliberately not
+/// durable; they are also invisible to <c>BlackboardSerializer</c> saves below.
+/// </summary>
+public static class TackleKeys
+{
+    public static readonly BlackboardSchema Schema = new("tackle-scratch", BlackboardScope.Node);
+
+    public static readonly BlackboardKey<int> Grip = Schema.Register<int>("Grip");
 }

--- a/NxFSM.Examples/ReadmeExamples/BlackboardExample.cs
+++ b/NxFSM.Examples/ReadmeExamples/BlackboardExample.cs
@@ -7,9 +7,10 @@ using NxGraph.Graphs;
 namespace NxFSM.Examples.ReadmeExamples;
 
 /// <summary>
-/// Scoped blackboards: one Global "world" board shared by every machine, plus one
-/// Graph-scoped board per enemy. Keys are declared once in static schemas; the graph is a
-/// shared template and each enemy binds its own board + agent.
+/// Scoped blackboards: one Global "world" board shared by every machine, one Graph-scoped
+/// board per enemy, and Node-scoped transient scratch that the machine owns. Keys are
+/// declared once in static schemas; the graph is a shared template and each enemy binds its
+/// own board + agent.
 /// </summary>
 public static class BlackboardExample
 {
@@ -96,5 +97,43 @@ public static class BlackboardExample
                           $"sightings: {world.Get(WorldKeys.Sightings)}");
         Console.WriteLine($"  Goblin distance: {goblinBoard.Get(EnemyKeys.TargetDistance)}, " +
                           $"archer speed after alarm: {archerBoard.Get(EnemyKeys.Speed)}");
+
+        await RunNodeScopeAsync();
+    }
+
+    // ── Node scope: transient per-visit scratch ──────────────────────────
+
+    private static class ScratchKeys
+    {
+        public static readonly BlackboardSchema Schema = new("scratch", BlackboardScope.Node);
+        public static readonly BlackboardKey<int> BytesSent = Schema.Register<int>("BytesSent");
+    }
+
+    private static async ValueTask RunNodeScopeAsync()
+    {
+        Console.WriteLine("=== Scoped Blackboards (Node: transient per-visit scratch) ===");
+
+        // Declaring the Node schema on the graph is the whole setup: the machine auto-creates
+        // its own board (WithBlackboard would throw for a Node-scoped board). The scratch
+        // survives in-place retries of one visit and resets when the machine moves on.
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                ref int sent = ref bb.GetRef(ScratchKeys.BytesSent);
+                sent += 400; // partial progress kept across the retries of this visit
+                Console.WriteLine($"  Upload attempt: {sent}/1000 bytes sent.");
+                return sent >= 1000 ? ResultHelpers.Success : ResultHelpers.Failure;
+            }).SetName("Upload").Retry(maxAttempts: 5)
+            .ToAsync((bb, _) =>
+            {
+                Console.WriteLine($"  Next node sees BytesSent = {bb.Get(ScratchKeys.BytesSent)} " +
+                                  "(scratch reset on transition).");
+                return ResultHelpers.Success;
+            }).SetName("Verify")
+            .WithSchema(ScratchKeys.Schema)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+        Console.WriteLine($"  Upload flow: {result}");
     }
 }

--- a/NxGraph.Benchmarks/NxFsmBenchmarks.cs
+++ b/NxGraph.Benchmarks/NxFsmBenchmarks.cs
@@ -75,7 +75,7 @@ public class NxFsmBenchmarks
 
         _withTimeoutWrapper = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(_ => ValueTask.FromResult(Result.Success), 1.Seconds(), TimeoutBehavior.Fail)
+            .ToWithTimeoutAsync(1.Seconds(), _ => ValueTask.FromResult(Result.Success), TimeoutBehavior.Fail)
             .ToAsyncStateMachine();
 
         // Director that sequences through 10 nodes

--- a/NxGraph.Serialization.Tests/DummyState.cs
+++ b/NxGraph.Serialization.Tests/DummyState.cs
@@ -3,10 +3,13 @@ using NxGraph.Graphs;
 
 namespace NxGraph.Serialization.Tests;
 
-public class DummyState : IAsyncLogic
+public class DummyState : IAsyncLogic, ILogic
 {
     public string Data { get; init; } = string.Empty;
 
     public ValueTask<Result> ExecuteAsync(CancellationToken ct = default)
         => ResultHelpers.Success;
+
+    // Sync-runnable too, so nested sync StateMachine round-trips can rebuild runnable graphs.
+    public Result Execute() => Result.Success;
 }

--- a/NxGraph.Serialization.Tests/FailureEdgeSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/FailureEdgeSerializationTests.cs
@@ -13,9 +13,9 @@ public class FailureEdgeSerializationTests
     private static Graph BuildGraphWithFailureEdge()
     {
         GraphBuilder builder = new();
-        NodeId start = builder.AddNode(new DummyState { Data = "work" }, isStart: true);
-        NodeId next = builder.AddNode(new DummyState { Data = "done" });
-        NodeId handler = builder.AddNode(new DummyState { Data = "cleanup" });
+        NodeId start = builder.AddNode((IAsyncLogic)new DummyState { Data = "work" }, isStart: true);
+        NodeId next = builder.AddNode((IAsyncLogic)new DummyState { Data = "done" });
+        NodeId handler = builder.AddNode((IAsyncLogic)new DummyState { Data = "cleanup" });
         builder.AddTransition(start, next);
         builder.AddFailureTransition(start, handler);
         return builder.Build(throwOnError: false);

--- a/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
+++ b/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
@@ -197,6 +197,64 @@ public class GraphSerializerTestsTextCodec
         Assert.DoesNotThrow(() => s1.WriteByte(0x21)); // still open
     }
 
+    [Test]
+    public async Task Sync_nested_state_machine_roundtrips_and_stays_sync_runnable()
+    {
+        // The wire marker "SyncStateMachine" discriminates sync-nested machines from async
+        // ones, so a sync-authored graph deserializes back into a sync-runnable graph.
+        Graph child = GraphBuilder
+            .StartWith(new DummyState { Data = "c0" })
+            .To(new DummyState { Data = "c1" })
+            .Build();
+
+        Graph parent = GraphBuilder
+            .StartWith(new DummyState { Data = "p0" })
+            .SubGraph(NxGraph.Fsm.ParallelStepMode.RunToJoin, child)
+            .Build();
+
+        await using MemoryStream stream = new();
+        await _serializer.ToJsonAsync(parent, stream);
+        string json = Encoding.UTF8.GetString(stream.ToArray());
+        stream.Position = 0;
+
+        Graph roundTripped = await _serializer.FromJsonAsync(stream);
+        LogicNode composite = (LogicNode)roundTripped.GetNodeByIndex(1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("SyncStateMachine"));
+            Assert.That(composite.Logic, Is.InstanceOf<NxGraph.Fsm.StateMachine>(),
+                "The sync marker must rebuild a sync StateMachine node, not an async one.");
+        });
+
+        // And the round-tripped graph runs on the sync runtime end to end.
+        NxGraph.Fsm.StateMachine machine = new(roundTripped);
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
+
+    [Test]
+    public void Sync_history_and_parallel_composites_still_throw_a_targeted_error()
+    {
+        Graph child = GraphBuilder
+            .StartWith(new DummyState { Data = "c0" })
+            .Build();
+
+        Graph withHistory = GraphBuilder
+            .StartWith(new DummyState { Data = "p0" })
+            .SubGraph(NxGraph.Fsm.ParallelStepMode.RunToJoin, child, history: true)
+            .Build();
+
+        NotSupportedException? ex = Assert.ThrowsAsync<NotSupportedException>(
+            async () => await _serializer.ToJsonAsync(withHistory, new MemoryStream()));
+        Assert.That(ex!.Message, Does.Contain("HistoryState"));
+    }
+
     private sealed class RawStringCodec : ILogicTextCodec
     {
         public IAsyncLogic Deserialize(string s) => new DummyState { Data = s };

--- a/NxGraph.Serialization.Tests/RetryPolicySerializationTests.cs
+++ b/NxGraph.Serialization.Tests/RetryPolicySerializationTests.cs
@@ -13,8 +13,8 @@ public class RetryPolicySerializationTests
     private static Graph BuildGraphWithRetry()
     {
         GraphBuilder builder = new();
-        NodeId start = builder.AddNode(new DummyState { Data = "flaky" }, isStart: true);
-        NodeId next = builder.AddNode(new DummyState { Data = "done" });
+        NodeId start = builder.AddNode((IAsyncLogic)new DummyState { Data = "flaky" }, isStart: true);
+        NodeId next = builder.AddNode((IAsyncLogic)new DummyState { Data = "done" });
         builder.AddTransition(start, next);
         builder.SetRetryPolicy(start,
             new RetryPolicy(3, TimeSpan.FromMilliseconds(250), BackoffKind.Exponential));
@@ -66,8 +66,8 @@ public class RetryPolicySerializationTests
     public async Task json_roundtrip_preserves_outcome_codes_and_names()
     {
         GraphBuilder builder = new();
-        NodeId start = builder.AddNode(new DummyState { Data = "start" }, isStart: true);
-        NodeId done = builder.AddNode(new DummyState { Data = "done" });
+        NodeId start = builder.AddNode((IAsyncLogic)new DummyState { Data = "start" }, isStart: true);
+        NodeId done = builder.AddNode((IAsyncLogic)new DummyState { Data = "done" });
         builder.AddTransition(start, done);
         builder.SetOutcome(done, 7, "Approved");
         Graph graph = builder.Build(throwOnError: false);
@@ -90,7 +90,7 @@ public class RetryPolicySerializationTests
     public async Task graph_without_retry_policies_roundtrips_with_none()
     {
         GraphBuilder builder = new();
-        builder.AddNode(new DummyState { Data = "only" }, isStart: true);
+        builder.AddNode((IAsyncLogic)new DummyState { Data = "only" }, isStart: true);
         Graph graph = builder.Build(throwOnError: false);
 
         await using MemoryStream stream = new();

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -177,6 +177,18 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                         break;
                     }
 
+                    // Sync twin: a plain nested sync StateMachine round-trips with its own
+                    // marker so the deserialized graph stays sync-runnable. Machine-level
+                    // config (step mode, restart policy) is not structure and does not ride.
+                    if (logicNode.Logic is StateMachine syncStateMachine)
+                    {
+                        GraphDto childDto = ToDto(syncStateMachine.Graph, depth + 1);
+                        subGraphs.Add(new SubGraphDto(index, childDto));
+                        nodes[index] = new NodeTextDto(index, node.Id.Name,
+                            LogicNode.SyncStateMachineMarker.Id.Name);
+                        break;
+                    }
+
                     // Other composites (history states, parallel states, custom containers)
                     // carry child graphs a user codec structurally cannot serialize — only
                     // GraphSerializer can recurse into them, and it doesn't yet. Fail with a
@@ -184,10 +196,15 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     // would either throw an opaque cast error or silently drop the children.
                     if (logicNode.AsyncLogic is ISubGraphProvider || logicNode.Logic is ISubGraphProvider)
                     {
+                        // Name the actual composite: sync composites sit behind a
+                        // SyncLogicAdapter, whose type name would only obscure the error.
+                        string compositeName = logicNode.Logic is ISubGraphProvider
+                            ? logicNode.Logic.GetType().Name
+                            : logicNode.AsyncLogic.GetType().Name;
                         throw new NotSupportedException(
-                            $"Node '{node.Id}' holds composite logic '{logicNode.AsyncLogic.GetType().Name}' " +
+                            $"Node '{node.Id}' holds composite logic '{compositeName}' " +
                             "which is not serializable. Only plain nested state machines " +
-                            "(.SubGraph(child) without history) are supported by GraphSerializer.");
+                            "(.SubGraph(...) without history, async or sync) are supported by GraphSerializer.");
                     }
 
                     // Unwrap SyncLogicAdapter so the codec receives the actual IAsyncLogic/ILogic,
@@ -316,7 +333,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                 case NodeTextDto textDto:
                     // Marker check runs before the codec guard: the marker needs no codec, so a
                     // binary-codec serializer can read back the subgraph payloads it wrote.
-                    // "Default" is the legacy marker string (pre-fix payloads); both are only
+                    // "Default" is the legacy marker string (pre-fix payloads); markers are only
                     // honored when a subgraph payload actually claims this node index.
                     if ((textDto.Logic == LogicNode.StateMachineMarker.Id.Name ||
                          textDto.Logic == LegacyStateMachineMarkerName) &&
@@ -324,6 +341,13 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     {
                         // Keep a marker; we'll replace it after we rebuild subgraphs.
                         nodes[nodeDto.Index] = LogicNode.StateMachineMarker;
+                        break;
+                    }
+
+                    if (textDto.Logic == LogicNode.SyncStateMachineMarker.Id.Name &&
+                        subGraphOwners is not null && subGraphOwners.Contains(nodeDto.Index))
+                    {
+                        nodes[nodeDto.Index] = LogicNode.SyncStateMachineMarker;
                         break;
                     }
 
@@ -377,7 +401,8 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             // child Graph as the node itself — with the child graph's own (negative) NodeId —
             // silently corrupting transition routing; a crafted payload could also use it to
             // swap decoded logic for a nested machine.
-            if (nodes[subDto.OwnerIndex] != LogicNode.StateMachineMarker)
+            if (nodes[subDto.OwnerIndex] != LogicNode.StateMachineMarker &&
+                nodes[subDto.OwnerIndex] != LogicNode.SyncStateMachineMarker)
                 throw new InvalidOperationException(
                     $"Subgraph DTO owner index {subDto.OwnerIndex} does not reference a state-machine marker node.");
 
@@ -388,7 +413,8 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         for (int i = 0; i < nodesLength; i++)
         {
             if (nodes[i] is not LogicNode marker) continue;
-            if (marker != LogicNode.StateMachineMarker) continue;
+            bool isSyncMarker = marker == LogicNode.SyncStateMachineMarker;
+            if (marker != LogicNode.StateMachineMarker && !isSyncMarker) continue;
 
             if (!ownerToSubGraph.TryGetValue(i, out Graph? childGraph))
                 throw new InvalidOperationException(
@@ -401,7 +427,13 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                 _ => $"Node_{i}"
             };
 
-            IAsyncLogic stateMachineAsyncLogic = new AsyncStateMachine(childGraph);
+            // The marker kind discriminates the composite runtime: sync-nested machines come
+            // back as sync StateMachines (behind the sync-logic adapter), async ones as an
+            // AsyncStateMachine. Machine-level config (step mode, restart policy) is runtime
+            // configuration, not structure — deserialized machines carry the defaults.
+            IAsyncLogic stateMachineAsyncLogic = isSyncMarker
+                ? new SyncLogicAdapter(new StateMachine(childGraph))
+                : new AsyncStateMachine(childGraph);
             nodes[i] = new LogicNode(new NodeId(i, nodeName), stateMachineAsyncLogic);
         }
 

--- a/NxGraph.Serialization/SerializationVersion.cs
+++ b/NxGraph.Serialization/SerializationVersion.cs
@@ -2,7 +2,9 @@
 
 public static class SerializationVersion
 {
-    public const int Version = 2;
-    
+    // v2: failure edges, retry policies, outcome codes/names.
+    // v3: sync nested-machine marker ("SyncStateMachine") — older readers reject v3 payloads
+    //     cleanly instead of tripping over the unknown marker string.
+    public const int Version = 3;
 }
 

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -471,6 +471,162 @@ public class AllocationGateTests
             .WithBlackboard(local));
     }
 
+    // ── Blackboards: Node scope (per-transition reset included) ─────────
+
+    private static Graph NodeScopeChain(bool sync)
+    {
+        BlackboardSchema schema = new("scratch", BlackboardScope.Node);
+        BlackboardKey<int> value = schema.Register<int>("value");
+
+        if (sync)
+        {
+            return GraphBuilder
+                .StartWith(bb =>
+                {
+                    bb.Set(value, bb.Get(value) + 3); // always starts from the default
+                    return Result.Success;
+                })
+                .To(bb => bb.Get(value) == 0 ? Result.Success : Result.Success) // reset consumed
+                .WithSchema(schema)
+                .Build();
+        }
+
+        return GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(value, bb.Get(value) + 3);
+                return ResultHelpers.Success;
+            })
+            .ToAsync((bb, _) => bb.Get(value) == 0 ? ResultHelpers.Success : ResultHelpers.Success)
+            .WithSchema(schema)
+            .Build();
+    }
+
+    [Test]
+    public async Task async_node_scope_produce_consume_is_allocation_free()
+    {
+        await AssertZeroAllocAsync(NodeScopeChain(sync: false).ToAsyncStateMachine());
+    }
+
+    [Test]
+    public void sync_node_scope_produce_consume_is_allocation_free()
+    {
+        AssertZeroAlloc(NodeScopeChain(sync: true).ToStateMachine());
+    }
+
+    // ── Sync twins of the async gate cases ──────────────────────────────
+
+    [Test]
+    public void sync_failure_routing_is_allocation_free()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Failure)
+            .OnError(() => Result.Success)
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine());
+    }
+
+    [Test]
+    public void sync_no_backoff_retry_is_allocation_free()
+    {
+        int calls = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() => ++calls % 3 == 0 ? Result.Success : Result.Failure)
+            .Retry(maxAttempts: 3)
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine());
+    }
+
+    [Test]
+    public void sync_goto_loop_is_allocation_free()
+    {
+        int laps = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("Top")
+            .To(() => ++laps % 3 != 0 ? Result.Success : Result.Failure)
+            .Goto("Top")
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine());
+    }
+
+    [Test]
+    public void sync_entry_exit_actions_are_allocation_free()
+    {
+        int counter = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success)
+            .OnEnter(() => counter++)
+            .OnExit(() => counter++)
+            .To(() => Result.Success)
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine());
+    }
+
+    [Test]
+    public void sync_subgraph_run_to_join_is_allocation_free()
+    {
+        Graph parent = GraphBuilder
+            .StartWith(() => Result.Success)
+            .SubGraph(ParallelStepMode.RunToJoin, SyncChain(3).Build())
+            .To(() => Result.Success)
+            .Build();
+
+        AssertZeroAlloc(parent.ToStateMachine());
+    }
+
+    [Test]
+    public void sync_subgraph_round_per_tick_is_allocation_free()
+    {
+        Graph parent = GraphBuilder
+            .StartWith(() => Result.Success)
+            .SubGraph(ParallelStepMode.RoundPerTick, SyncChain(3).Build())
+            .To(() => Result.Success)
+            .Build();
+
+        AssertZeroAlloc(parent.ToStateMachine());
+    }
+
+    [Test]
+    public void sync_history_composite_happy_path_is_allocation_free()
+    {
+        Graph parent = GraphBuilder
+            .StartWith(() => Result.Success)
+            .SubGraph(ParallelStepMode.RunToJoin, SyncChain(3).Build(), history: true)
+            .Build();
+
+        AssertZeroAlloc(parent.ToStateMachine());
+    }
+
+    [Test]
+    public void sync_wait_for_ticking_is_allocation_free()
+    {
+        // Deterministic fake clock: every read advances one second, so a 1.5 s wait costs
+        // exactly two ticks per run — the gate covers the record/check path both ways.
+        long now = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success)
+            .To(new WaitState(TimeSpan.FromSeconds(1.5),
+                () => now += System.Diagnostics.Stopwatch.Frequency))
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine());
+    }
+
+    [Test]
+    public void sync_to_with_timeout_happy_path_is_allocation_free()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success)
+            .ToWithTimeout(TimeSpan.FromSeconds(5), () => Result.Success)
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine());
+    }
+
     [Test]
     public void sync_chain_of_10_is_allocation_free()
     {

--- a/NxGraph.Tests/Blackboards/BlackboardSchemaTests.cs
+++ b/NxGraph.Tests/Blackboards/BlackboardSchemaTests.cs
@@ -101,11 +101,10 @@ public class BlackboardSchemaTests
     }
 
     [Test]
-    public void node_scope_is_reserved_and_rejected()
+    public void node_scope_is_accepted()
     {
-        ArgumentOutOfRangeException? ex = Assert.Throws<ArgumentOutOfRangeException>(
-            () => _ = new BlackboardSchema("local", BlackboardScope.Node));
-        Assert.That(ex!.Message, Does.Contain("reserved"));
+        Assert.That(new BlackboardSchema("local", BlackboardScope.Node).Scope,
+            Is.EqualTo(BlackboardScope.Node));
     }
 
     [Test]

--- a/NxGraph.Tests/Blackboards/NodeScopeBlackboardTests.cs
+++ b/NxGraph.Tests/Blackboards/NodeScopeBlackboardTests.cs
@@ -1,0 +1,537 @@
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Diagnostics.Validations;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests.Blackboards;
+
+/// <summary>
+/// <see cref="BlackboardScope.Node"/>: transient per-visit scratch, machine-owned, reset at
+/// every transition boundary (the "Node board resets iff the attempt counter resets" rule),
+/// kept across in-place retries, never user-bound, never durable.
+/// </summary>
+[TestFixture]
+public class NodeScopeBlackboardTests
+{
+    private static BlackboardSchema NewNodeSchema(out BlackboardKey<int> scratch)
+    {
+        BlackboardSchema schema = new("scratch", BlackboardScope.Node);
+        scratch = schema.Register<int>("value");
+        return schema;
+    }
+
+    // ── Reset at transition boundaries ────────────────────────────────────
+
+    [Test]
+    public async Task async_node_value_is_default_again_after_success_transition()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        int seenInB = -1;
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(scratch, 42);
+                return ResultHelpers.Success;
+            })
+            .ToAsync((bb, _) =>
+            {
+                seenInB = bb.Get(scratch);
+                return ResultHelpers.Success;
+            })
+            .WithSchema(schema)
+            .Build();
+
+        await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.That(seenInB, Is.Zero, "Node scratch written in A must be default again in B.");
+    }
+
+    [Test]
+    public void sync_node_value_is_default_again_after_success_transition()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        int seenInB = -1;
+
+        Graph graph = GraphBuilder
+            .StartWith(bb =>
+            {
+                bb.Set(scratch, 42);
+                return Result.Success;
+            })
+            .To(bb =>
+            {
+                seenInB = bb.Get(scratch);
+                return Result.Success;
+            })
+            .WithSchema(schema)
+            .Build();
+
+        RunToCompletion(graph.ToStateMachine());
+
+        Assert.That(seenInB, Is.Zero, "Node scratch written in A must be default again in B.");
+    }
+
+    [Test]
+    public async Task async_node_value_is_default_after_director_route()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        int seenInBranch = -1;
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(scratch, 7);
+                return ResultHelpers.Success;
+            })
+            .If(() => true)
+            .ThenAsync((bb, _) =>
+            {
+                seenInBranch = bb.Get(scratch);
+                return ResultHelpers.Success;
+            })
+            .ElseAsync((_, _) => ResultHelpers.Success)
+            .WithSchema(schema)
+            .Build();
+
+        await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.That(seenInBranch, Is.Zero, "Node scratch must reset across a director route too.");
+    }
+
+    [Test]
+    public async Task async_node_value_is_default_after_failure_edge_reroute()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        int seenInHandler = -1;
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(scratch, 13);
+                return ResultHelpers.Failure;
+            })
+            .OnErrorAsync(new AsyncRelayState((bb, _) =>
+            {
+                seenInHandler = bb.Get(scratch);
+                return ResultHelpers.Success;
+            }))
+            .WithSchema(schema)
+            .Build();
+
+        await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.That(seenInHandler, Is.Zero, "Node scratch must reset when routing the failure edge.");
+    }
+
+    [Test]
+    public void sync_node_value_is_default_after_failure_edge_reroute()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        int seenInHandler = -1;
+
+        Graph graph = GraphBuilder
+            .StartWith(bb =>
+            {
+                bb.Set(scratch, 13);
+                return Result.Failure;
+            })
+            .OnError(new RelayState(bb =>
+            {
+                seenInHandler = bb.Get(scratch);
+                return Result.Success;
+            }))
+            .WithSchema(schema)
+            .Build();
+
+        RunToCompletion(graph.ToStateMachine());
+
+        Assert.That(seenInHandler, Is.Zero, "Node scratch must reset when routing the failure edge.");
+    }
+
+    // ── Retries keep the scratch (same visit) ─────────────────────────────
+
+    [Test]
+    public async Task async_node_value_persists_across_in_place_retries()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        List<int> attemptsSaw = [];
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                attemptsSaw.Add(bb.Get(scratch));
+                bb.GetRef(scratch)++;
+                return bb.Get(scratch) < 3 ? ResultHelpers.Failure : ResultHelpers.Success;
+            })
+            .Retry(maxAttempts: 5)
+            .WithSchema(schema)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(attemptsSaw, Is.EqualTo(new[] { 0, 1, 2 }),
+                "Retrying in place keeps the visit's scratch — partial progress across attempts.");
+        });
+    }
+
+    [Test]
+    public void sync_node_value_persists_across_in_place_retries()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        List<int> attemptsSaw = [];
+
+        Graph graph = GraphBuilder
+            .StartWith(bb =>
+            {
+                attemptsSaw.Add(bb.Get(scratch));
+                bb.GetRef(scratch)++;
+                return bb.Get(scratch) < 3 ? Result.Failure : Result.Success;
+            })
+            .Retry(maxAttempts: 5)
+            .WithSchema(schema)
+            .Build();
+
+        Result result = RunToCompletion(graph.ToStateMachine());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(attemptsSaw, Is.EqualTo(new[] { 0, 1, 2 }));
+        });
+    }
+
+    [Test]
+    public async Task node_value_is_default_at_the_start_of_every_run()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        List<int> runsSaw = [];
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                runsSaw.Add(bb.Get(scratch));
+                bb.Set(scratch, 99);
+                return ResultHelpers.Success;
+            })
+            .WithSchema(schema)
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+        await machine.ExecuteAsync();
+        await machine.ExecuteAsync();
+
+        Assert.That(runsSaw, Is.EqualTo(new[] { 0, 0 }), "Each run starts with fresh scratch.");
+    }
+
+    // ── Ownership: machine-owned, never user-bound ────────────────────────
+
+    [Test]
+    public void binding_a_node_scoped_board_throws_on_both_machines()
+    {
+        BlackboardSchema schema = NewNodeSchema(out _);
+        Graph graph = GraphBuilder.StartWith(() => Result.Success).Build();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(schema)),
+                Throws.InvalidOperationException.With.Message.Contain("machine-owned"),
+                "Node boards are transient runtime scratch and must not be shared or rebound.");
+            Assert.That(() => graph.ToStateMachine().WithBlackboard(new Blackboard(schema)),
+                Throws.InvalidOperationException.With.Message.Contain("machine-owned"));
+        });
+    }
+
+    [Test]
+    public void unbound_node_key_access_throws_with_guidance()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        _ = schema;
+
+        // The schema is never declared on the graph, so no machine composes a board for it.
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(scratch, 1);
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await graph.ToAsyncStateMachine().ExecuteAsync());
+        Assert.That(ex!.Message, Does.Contain("no node blackboard").And.Contain("WithSchema"));
+    }
+
+    [Test]
+    public async Task two_machines_over_one_graph_never_see_each_others_node_values()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        List<int> firstAttemptSaw = [];
+
+        // Retry visit: attempt 1 records what it finds, writes a marker, and fails;
+        // attempt 2 succeeds. Any leakage between the machines' boards would surface
+        // as a non-default value on a later machine's first attempt.
+        Graph shared = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                if (bb.Get(scratch) == 0)
+                {
+                    firstAttemptSaw.Add(bb.Get(scratch));
+                    bb.Set(scratch, 7);
+                    return ResultHelpers.Failure;
+                }
+
+                return ResultHelpers.Success;
+            })
+            .Retry(maxAttempts: 3)
+            .WithSchema(schema)
+            .Build();
+
+        AsyncStateMachine machineA = shared.ToAsyncStateMachine();
+        AsyncStateMachine machineB = shared.ToAsyncStateMachine();
+
+        Assert.That(await machineA.ExecuteAsync(), Is.EqualTo(Result.Success));
+        Assert.That(await machineB.ExecuteAsync(), Is.EqualTo(Result.Success));
+        Assert.That(await machineA.ExecuteAsync(), Is.EqualTo(Result.Success));
+
+        Assert.That(firstAttemptSaw, Is.All.Zero,
+            "Every machine (and every run) starts its visits from defaults — zero setup, no aliasing.");
+    }
+
+    // ── Not durable: suspend/resume resets scratch ────────────────────────
+
+    [Test]
+    public async Task async_resume_on_a_fresh_machine_resets_node_scratch_but_keeps_other_scopes()
+    {
+        BlackboardSchema nodeSchema = NewNodeSchema(out BlackboardKey<int> scratch);
+        BlackboardSchema graphSchema = new("persistent");
+        BlackboardKey<int> persistent = graphSchema.Register<int>("value");
+        List<(int node, int graph)> attemptsSaw = [];
+
+        Graph graph = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                attemptsSaw.Add((bb.Get(scratch), bb.Get(persistent)));
+                bb.Set(scratch, 5);
+                if (bb.Get(persistent) >= 10)
+                {
+                    return ResultHelpers.Success;
+                }
+
+                bb.Set(persistent, 5);
+                return ResultHelpers.Failure;
+            })
+            .Retry(maxAttempts: 10)
+            .WithSchema(nodeSchema)
+            .WithSchema(graphSchema)
+            .Build();
+
+        Blackboard board = new(graphSchema);
+        AsyncStateMachine machine = graph.ToAsyncStateMachine().WithBlackboard(board);
+
+        // One step: attempt 1 writes scratch+persistent and fails (retry pending).
+        Result step = await machine.StepAsync();
+        Assert.That(step, Is.EqualTo(Result.InProgress));
+
+        StateMachineSnapshot snapshot = machine.Suspend();
+
+        AsyncStateMachine resumed = graph.ToAsyncStateMachine().WithBlackboard(board);
+        resumed.Resume(snapshot);
+        board.Set(persistent, 10); // makes the next attempt succeed
+
+        Result result = await resumed.StepAsync();
+        while (result == Result.InProgress)
+        {
+            result = await resumed.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(attemptsSaw[0], Is.EqualTo((0, 0)));
+            Assert.That(attemptsSaw[1].node, Is.Zero,
+                "Node scratch is transient: a suspended visit loses it across resume.");
+            Assert.That(attemptsSaw[1].graph, Is.EqualTo(10),
+                "Graph-scoped values ride the user-owned board and survive.");
+        });
+    }
+
+    [Test]
+    public void sync_resume_on_a_fresh_machine_resets_node_scratch()
+    {
+        BlackboardSchema nodeSchema = NewNodeSchema(out BlackboardKey<int> scratch);
+        List<int> attemptsSaw = [];
+        bool failFirst = true;
+
+        Graph graph = GraphBuilder
+            .StartWith(bb =>
+            {
+                attemptsSaw.Add(bb.Get(scratch));
+                bb.Set(scratch, 5);
+                if (failFirst)
+                {
+                    failFirst = false;
+                    return Result.Failure;
+                }
+
+                return Result.Success;
+            })
+            .Retry(maxAttempts: 5)
+            .WithSchema(nodeSchema)
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result step = machine.Execute();
+        Assert.That(step, Is.EqualTo(Result.InProgress));
+
+        StateMachineSnapshot snapshot = machine.Suspend();
+
+        StateMachine resumed = graph.ToStateMachine();
+        resumed.Resume(snapshot);
+        Result result = RunToCompletion(resumed);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(attemptsSaw, Is.All.Zero,
+                "Node scratch is transient: a suspended visit loses it across resume.");
+        });
+    }
+
+    // ── Composites own their own scratch ──────────────────────────────────
+
+    [Test]
+    public async Task parallel_regions_do_not_bleed_node_scratch_into_each_other()
+    {
+        BlackboardSchema schema = NewNodeSchema(out BlackboardKey<int> scratch);
+        List<int> regionASaw = [];
+        List<int> regionBSaw = [];
+
+        // Interleaved regions: A attempt 1, B attempt 1, A attempt 2, B attempt 2. If the
+        // regions shared one board, each second attempt would find the *other* region's marker.
+        Graph regionA = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                regionASaw.Add(bb.Get(scratch));
+                bb.Set(scratch, 1);
+                return regionASaw.Count < 2 ? ResultHelpers.Failure : ResultHelpers.Success;
+            })
+            .Retry(maxAttempts: 3)
+            .WithSchema(schema)
+            .Build();
+
+        Graph regionB = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                regionBSaw.Add(bb.Get(scratch));
+                bb.Set(scratch, 2);
+                return regionBSaw.Count < 2 ? ResultHelpers.Failure : ResultHelpers.Success;
+            })
+            .Retry(maxAttempts: 3)
+            .WithSchema(schema)
+            .Build();
+
+        Graph parent = GraphBuilder.Start().Parallel(regionA, regionB).Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(regionASaw, Is.EqualTo(new[] { 0, 1 }), "Region A only ever sees its own scratch.");
+            Assert.That(regionBSaw, Is.EqualTo(new[] { 0, 2 }), "Region B only ever sees its own scratch.");
+        });
+    }
+
+    [Test]
+    public async Task subgraph_child_scratch_is_independent_of_the_parent()
+    {
+        BlackboardSchema parentSchema = NewNodeSchema(out BlackboardKey<int> parentScratch);
+        BlackboardSchema childSchema = new("child-scratch", BlackboardScope.Node);
+        BlackboardKey<int> childScratch = childSchema.Register<int>("value");
+        int childSaw = -1;
+
+        // If the parent's Node slot leaked into the child machine, the child's key (from a
+        // different Node schema) would hit the foreign-schema throw instead of its own board.
+        Graph child = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(childScratch, 21);
+                childSaw = bb.Get(childScratch);
+                return ResultHelpers.Success;
+            })
+            .WithSchema(childSchema)
+            .Build();
+
+        Graph parent = GraphBuilder
+            .StartWithAsync((bb, _) =>
+            {
+                bb.Set(parentScratch, 11);
+                return ResultHelpers.Success;
+            })
+            .SubGraph(child)
+            .WithSchema(parentSchema)
+            .Build();
+
+        Result result = await parent.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(childSaw, Is.EqualTo(21), "The child machine composes its own Node board.");
+        });
+    }
+
+    // ── Diagnostics ───────────────────────────────────────────────────────
+
+    [Test]
+    public void validator_reports_node_schema_with_no_settable_nodes()
+    {
+        BlackboardSchema schema = NewNodeSchema(out _);
+
+        Graph graph = GraphBuilder
+            .StartWithAsync(new RawLogic())
+            .WithSchema(schema)
+            .Build();
+
+        GraphValidationResult result = graph.Validate();
+
+        Assert.That(result.Diagnostics.Any(d =>
+                d.Severity == Severity.Info && d.Message.Contains("Node-scoped")),
+            Is.True, "Expected an Info diagnostic about the unused Node schema.");
+    }
+
+    [Test]
+    public void declaring_two_node_schemas_throws()
+    {
+        BlackboardSchema first = NewNodeSchema(out _);
+        BlackboardSchema second = NewNodeSchema(out _);
+
+        Assert.That(() => GraphBuilder
+                .StartWithAsync((_, _) => ResultHelpers.Success)
+                .WithSchema(first)
+                .WithSchema(second),
+            Throws.InvalidOperationException.With.Message.Contain("already been declared"));
+    }
+
+    private sealed class RawLogic : IAsyncLogic
+    {
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => ResultHelpers.Success;
+    }
+
+    private static Result RunToCompletion(StateMachine machine)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+}

--- a/NxGraph.Tests/HierarchicalFsmsTests.cs
+++ b/NxGraph.Tests/HierarchicalFsmsTests.cs
@@ -92,7 +92,7 @@ public class HierarchicalFsmTests
                 onExit: () => log.Add("parent-exit")))
             .SetName("Cleanup")
             .ToStateMachine();
-        parentFsm.SetResetPolicy(RestartPolicy.Manual);
+        parentFsm.SetRestartPolicy(RestartPolicy.Manual);
 
         Result r1 = parentFsm.Execute(); // child node 1 runs
         Result r2 = parentFsm.Execute(); // child node 2 runs → child done, parent transitions to Cleanup
@@ -124,7 +124,7 @@ public class HierarchicalFsmTests
             .StartWith(childFsm)
             .To(() => Result.Success)
             .ToStateMachine();
-        parentFsm.SetResetPolicy(RestartPolicy.Manual);
+        parentFsm.SetRestartPolicy(RestartPolicy.Manual);
 
         // Tick 1: grandchild's only node
         // Tick 2: child's second node  (grandchild finished → child transitions)

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -36,7 +36,10 @@ static class NxGraph.Authoring.Dsl
   method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
   method NxGraph.Authoring.StateToken SetName(NxGraph.Authoring.StateToken, System.String)
   method NxGraph.Authoring.StateToken StartWithTimeoutAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken StartWithTimeoutAsync(System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StartToken, NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph, Boolean)
   method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StartToken, NxGraph.Graphs.Graph, Boolean)
+  method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StateToken, NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph, Boolean)
   method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StateToken, NxGraph.Graphs.Graph, Boolean)
   method NxGraph.Authoring.StateToken To(BranchEnd, System.Func`1[NxGraph.Result])
   method NxGraph.Authoring.StateToken To(BranchEnd, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
@@ -50,11 +53,20 @@ static class NxGraph.Authoring.Dsl
   method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StateToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StateToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken ToAsync[TAgent](NxGraph.Authoring.StateToken, System.Func`4[TAgent,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StartToken, System.TimeSpan, NxGraph.Graphs.ILogic, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StartToken, System.TimeSpan, System.Func`1[NxGraph.Result], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StateToken, System.TimeSpan, NxGraph.Graphs.ILogic, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StateToken, System.TimeSpan, System.Func`1[NxGraph.Result], NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, System.TimeSpan, NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, System.TimeSpan, NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken To[TAgent](NxGraph.Authoring.StateToken, System.Func`3[TAgent,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken WaitFor(NxGraph.Authoring.StartToken, System.TimeSpan)
+  method NxGraph.Authoring.StateToken WaitFor(NxGraph.Authoring.StateToken, System.TimeSpan)
   method NxGraph.Authoring.StateToken WaitForAsync(NxGraph.Authoring.StartToken, System.TimeSpan)
   method NxGraph.Authoring.StateToken WaitForAsync(NxGraph.Authoring.StateToken, System.TimeSpan)
   method NxGraph.Authoring.StateToken WithSchema(NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardSchema)
@@ -107,6 +119,7 @@ struct NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1
 struct NxGraph.Authoring.Dsl+BranchBuilder
   method BranchBuilder To(NxGraph.Graphs.ILogic)
   method BranchBuilder ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method BranchBuilder WaitFor(System.TimeSpan)
   method BranchBuilder WaitForAsync(System.TimeSpan)
   method BranchEnd Else(NxGraph.Graphs.ILogic)
   method BranchEnd ElseAsync(NxGraph.Graphs.IAsyncLogic)
@@ -115,6 +128,7 @@ struct NxGraph.Authoring.Dsl+BranchBuilder
 struct NxGraph.Authoring.Dsl+BranchEnd
   method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
   method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken WaitFor(System.TimeSpan)
   method NxGraph.Authoring.StateToken WaitForAsync(System.TimeSpan)
   method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Fsm.IAsyncStateMachineObserver)
   method NxGraph.Fsm.Async.AsyncStateMachine`1[T] ToAsyncStateMachine[T](NxGraph.Fsm.IAsyncStateMachineObserver)
@@ -201,17 +215,19 @@ sealed class NxGraph.Blackboards.Blackboard
   method Void Set[T](NxGraph.Blackboards.BlackboardKey`1[T], T)
   property NxGraph.Blackboards.BlackboardSchema Schema { get; }
 struct NxGraph.Blackboards.BlackboardContext
-  ctor Void .ctor(NxGraph.Blackboards.Blackboard, NxGraph.Blackboards.Blackboard)
+  ctor Void .ctor(NxGraph.Blackboards.Blackboard, NxGraph.Blackboards.Blackboard, NxGraph.Blackboards.Blackboard)
   method Boolean HasBoard(NxGraph.Blackboards.BlackboardScope)
   method Boolean TryGet[T](NxGraph.Blackboards.BlackboardKey`1[T], T ByRef)
   method NxGraph.Blackboards.Blackboard Board(NxGraph.Blackboards.BlackboardScope)
   method NxGraph.Blackboards.BlackboardContext With(NxGraph.Blackboards.Blackboard)
+  method NxGraph.Blackboards.BlackboardContext WithoutNode()
   method T Get[T](NxGraph.Blackboards.BlackboardKey`1[T])
   method T& GetRef[T](NxGraph.Blackboards.BlackboardKey`1[T])
   method Void Set[T](NxGraph.Blackboards.BlackboardKey`1[T], T)
   property Boolean IsEmpty { get; }
   property NxGraph.Blackboards.Blackboard Global { get; }
   property NxGraph.Blackboards.Blackboard Graph { get; }
+  property NxGraph.Blackboards.Blackboard Node { get; }
 abstract class NxGraph.Blackboards.BlackboardKeyDescriptor
   method System.Object GetValue(NxGraph.Blackboards.Blackboard)
   method Void ResetValue(NxGraph.Blackboards.Blackboard)
@@ -329,6 +345,7 @@ static class NxGraph.Diagnostics.Validations.GraphValidationExtensions
   method NxGraph.Diagnostics.Validations.GraphValidationResult ValidateAndThrowIfErrorsDebug(NxGraph.Graphs.Graph, System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId])
 sealed class NxGraph.Diagnostics.Validations.GraphValidationOptions
   ctor Void .ctor(System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId])
+  property Boolean StrictAsyncCompatible { get; set; }
   property Boolean StrictNoTerminalPath { get; set; }
   property Boolean StrictSyncOnly { get; set; }
   property Boolean WarnOnSelfLoop { get; set; }
@@ -448,6 +465,11 @@ enum NxGraph.Fsm.ExecutionStatus : System.IComparable, System.IConvertible, Syst
   Running = 2
   Starting = 1
   Transitioning = 3
+sealed class NxGraph.Fsm.HistoryState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.ParallelStepMode)
+  method NxGraph.Result Execute()
+  property NxGraph.Fsm.ParallelStepMode Mode { get; }
+  property NxGraph.Fsm.StateMachine Child { get; }
 interface NxGraph.Fsm.IAgentSettable`1
   method Void SetAgent(TAgent)
 interface NxGraph.Fsm.IAsyncDirector
@@ -562,8 +584,11 @@ class NxGraph.Fsm.StateMachine : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackbo
   method Void SetAutoReset(Boolean)
   method Void SetBlackboard(NxGraph.Blackboards.Blackboard)
   method Void SetResetPolicy(NxGraph.Fsm.RestartPolicy)
+  method Void SetRestartPolicy(NxGraph.Fsm.RestartPolicy)
+  method Void SetStepMode(NxGraph.Fsm.ParallelStepMode)
   property Int32 LastOutcome { get; }
   property NxGraph.Fsm.ExecutionStatus Status { get; }
+  property NxGraph.Fsm.ParallelStepMode StepMode { get; }
   property System.String LastOutcomeName { get; }
 sealed class NxGraph.Fsm.StateMachineSnapshot : System.IEquatable`1[[NxGraph.Fsm.StateMachineSnapshot, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
   ctor Void .ctor(Int32, NxGraph.Fsm.ExecutionStatus, Int32, Boolean, Boolean, Int32)
@@ -597,6 +622,10 @@ sealed class NxGraph.Fsm.SwitchState`1 : NxGraph.Blackboards.IBlackboardSettable
 enum NxGraph.Fsm.TimeoutBehavior : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
   Fail = 0
   Throw = 1
+sealed class NxGraph.Fsm.TimeoutState : NxGraph.Graphs.ILogic
+  ctor Void .ctor(NxGraph.Graphs.ILogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  ctor Void .ctor(NxGraph.Graphs.ILogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior, System.Func`1[System.Int64])
+  method NxGraph.Result Execute()
 sealed class NxGraph.Fsm.TracingObserver : NxGraph.Fsm.IAsyncStateMachineObserver
   ctor Void .ctor()
   method System.Threading.Tasks.ValueTask OnStateEntered(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
@@ -608,6 +637,10 @@ sealed class NxGraph.Fsm.TracingObserver : NxGraph.Fsm.IAsyncStateMachineObserve
   method System.Threading.Tasks.ValueTask OnStateMachineStarted(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask StateMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus, System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.WaitState : NxGraph.Graphs.ILogic
+  ctor Void .ctor(System.TimeSpan)
+  ctor Void .ctor(System.TimeSpan, System.Func`1[System.Int64])
+  method NxGraph.Result Execute()
 sealed class NxGraph.Graphs.EmptyAsyncLogic : NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor()
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
@@ -615,7 +648,7 @@ sealed class NxGraph.Graphs.EmptyLogic : NxGraph.Graphs.ILogic
   ctor Void .ctor()
   method NxGraph.Result Execute()
 sealed class NxGraph.Graphs.Graph : NxGraph.Graphs.IGraph, NxGraph.Graphs.INode
-  ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode[], NxGraph.Graphs.Transition[], NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.RetryPolicy[], Int32[], System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String], NxGraph.Blackboards.BlackboardSchema, NxGraph.Blackboards.BlackboardSchema)
+  ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode[], NxGraph.Graphs.Transition[], NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.RetryPolicy[], Int32[], System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String], NxGraph.Blackboards.BlackboardSchema, NxGraph.Blackboards.BlackboardSchema, NxGraph.Blackboards.BlackboardSchema)
   method Boolean TryGetNode(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode ByRef)
   method Boolean TryGetNodeByIndex(Int32, NxGraph.Graphs.INode ByRef)
   method Boolean TryGetTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.Transition ByRef)
@@ -627,6 +660,7 @@ sealed class NxGraph.Graphs.Graph : NxGraph.Graphs.IGraph, NxGraph.Graphs.INode
   property Int32 TransitionCount { get; }
   property Int32[] OutcomeCodes { get; }
   property NxGraph.Blackboards.BlackboardSchema GlobalSchema { get; }
+  property NxGraph.Blackboards.BlackboardSchema NodeSchema { get; }
   property NxGraph.Blackboards.BlackboardSchema Schema { get; }
   property NxGraph.Fsm.RetryPolicy[] RetryPolicies { get; }
   property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
@@ -656,6 +690,7 @@ class NxGraph.Graphs.LogicNode : NxGraph.Graphs.INode
   ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.IAsyncLogic, System.Action, System.Action)
   field static readonly NxGraph.Graphs.LogicNode Empty
   field static readonly NxGraph.Graphs.LogicNode StateMachineMarker
+  field static readonly NxGraph.Graphs.LogicNode SyncStateMachineMarker
   property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
   property NxGraph.Graphs.ILogic Logic { get; }
   property NxGraph.Graphs.NodeId Id { get; }
@@ -677,6 +712,7 @@ struct NxGraph.Graphs.NodeId : System.IEquatable`1[[NxGraph.Graphs.NodeId, NxGra
   property NxGraph.Graphs.NodeId Default { get; }
   property NxGraph.Graphs.NodeId Start { get; }
   property NxGraph.Graphs.NodeId StateMachineMarker { get; }
+  property NxGraph.Graphs.NodeId SyncStateMachineMarker { get; }
   property System.String Name { get; }
 sealed class NxGraph.Graphs.SyncLogicAdapter : NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor(NxGraph.Graphs.ILogic)

--- a/NxGraph.Tests/ReplayTests.cs
+++ b/NxGraph.Tests/ReplayTests.cs
@@ -339,7 +339,7 @@ public class ReplayTests
             .ToStateMachine(recorder);
         // Auto-restart is on by default, which would loop forever. Keep deterministic by
         // disabling auto-reset and only running once.
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         Result r;
         do { r = fsm.Execute(); } while (r == Result.InProgress);

--- a/NxGraph.Tests/StateMachineTests.cs
+++ b/NxGraph.Tests/StateMachineTests.cs
@@ -103,7 +103,7 @@ public class StateMachineTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Success)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Auto);
+        fsm.SetRestartPolicy(RestartPolicy.Auto);
 
         fsm.Execute();
 
@@ -116,7 +116,7 @@ public class StateMachineTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Success)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute();
 
@@ -129,7 +129,7 @@ public class StateMachineTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Failure)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute();
 
@@ -144,7 +144,7 @@ public class StateMachineTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Success)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
         fsm.Execute();
 
         Result resetResult = fsm.Reset();
@@ -173,7 +173,7 @@ public class StateMachineTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => { counter++; return Result.Success; })
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute();
         Assert.That(counter, Is.EqualTo(1));
@@ -190,7 +190,7 @@ public class StateMachineTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Success)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute();
         Assert.That(fsm.Status, Is.EqualTo(ExecutionStatus.Completed));
@@ -204,7 +204,7 @@ public class StateMachineTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Failure)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute();
         Assert.That(fsm.Status, Is.EqualTo(ExecutionStatus.Failed));
@@ -223,7 +223,7 @@ public class StateMachineTests
                 return Result.Success;
             })
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Ignore);
+        fsm.SetRestartPolicy(RestartPolicy.Ignore);
 
         Result first = fsm.Execute();
         Assert.That(first, Is.EqualTo(Result.Success));
@@ -247,7 +247,7 @@ public class StateMachineTests
                 return Result.Success;
             })
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Ignore);
+        fsm.SetRestartPolicy(RestartPolicy.Ignore);
 
         fsm.Execute();
         Assert.That(counter, Is.EqualTo(1));
@@ -380,7 +380,7 @@ public class StateMachineTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => throw new ApplicationException("boom"))
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         Assert.Throws<ApplicationException>(() => fsm.Execute());
         Assert.That(fsm.Status, Is.EqualTo(ExecutionStatus.Failed));
@@ -392,7 +392,7 @@ public class StateMachineTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => throw new ApplicationException("boom"))
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Auto);
+        fsm.SetRestartPolicy(RestartPolicy.Auto);
 
         Assert.Throws<ApplicationException>(() => fsm.Execute());
         Assert.That(fsm.Status, Is.EqualTo(ExecutionStatus.Ready));
@@ -553,14 +553,18 @@ public class StateMachineTests
     // ── Mixed sync + ILogic nodes ───────────────────────────────────────
 
     [Test]
-    public void should_throw_when_node_does_not_implement_ISyncLogic()
+    public void should_throw_at_construction_when_node_does_not_implement_ISyncLogic()
     {
-        // AsyncRelayState (async only) does not implement ILogic.
-        StateMachine fsm = GraphBuilder
-            .StartWithAsync(new AsyncRelayState(_ => ResultHelpers.Success))
-            .ToStateMachine();
+        // AsyncRelayState (async only) does not implement ILogic. The constructor fails fast
+        // naming the offending node instead of throwing mid-run after earlier nodes already
+        // produced side effects.
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success)
+            .ToAsync(new AsyncRelayState(_ => ResultHelpers.Success)).SetName("AsyncOnly")
+            .Build();
 
-        Assert.Throws<InvalidOperationException>(() => fsm.Execute());
+        ArgumentException? ex = Assert.Throws<ArgumentException>(() => graph.ToStateMachine());
+        Assert.That(ex!.Message, Does.Contain("AsyncOnly").And.Contain("ILogic"));
     }
 
     // ── Multiple runs ───────────────────────────────────────────────────

--- a/NxGraph.Tests/SteppedExecutionTests.cs
+++ b/NxGraph.Tests/SteppedExecutionTests.cs
@@ -16,7 +16,7 @@ public class SteppedExecutionTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Success)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         Result result = fsm.Execute();
 
@@ -33,7 +33,7 @@ public class SteppedExecutionTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Failure)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         Result result = fsm.Execute();
 
@@ -66,7 +66,7 @@ public class SteppedExecutionTests
             .StartWith(() => Result.Success)
             .To(() => Result.Success)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute();
         Result second = fsm.Execute();
@@ -83,7 +83,7 @@ public class SteppedExecutionTests
             .To(() => { counter++; return Result.Success; })
             .To(() => { counter++; return Result.Success; })
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         Assert.That(fsm.Execute(), Is.EqualTo(Result.InProgress));
         Assert.That(counter, Is.EqualTo(1));
@@ -104,7 +104,7 @@ public class SteppedExecutionTests
             .To(() => { counter++; return Result.Failure; })
             .To(() => { counter++; return Result.Success; })
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute(); // node 1 → Continue
         Result second = fsm.Execute(); // node 2 → Failure (node 3 never runs)
@@ -147,7 +147,7 @@ public class SteppedExecutionTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Success)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute();
 
@@ -160,7 +160,7 @@ public class SteppedExecutionTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Success)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Auto);
+        fsm.SetRestartPolicy(RestartPolicy.Auto);
 
         fsm.Execute();
 
@@ -175,7 +175,7 @@ public class SteppedExecutionTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => throw new ApplicationException("boom"))
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         Assert.Throws<ApplicationException>(() => fsm.Execute());
         Assert.That(fsm.Status, Is.EqualTo(ExecutionStatus.Failed));
@@ -199,7 +199,7 @@ public class SteppedExecutionTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => Result.Success)
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
         fsm.Execute();
 
         Assert.Throws<InvalidOperationException>(() => fsm.Execute());
@@ -212,7 +212,7 @@ public class SteppedExecutionTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => { counter++; return Result.Success; })
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Ignore);
+        fsm.SetRestartPolicy(RestartPolicy.Ignore);
 
         Result first = fsm.Execute();
         Result second = fsm.Execute();
@@ -232,7 +232,7 @@ public class SteppedExecutionTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => { counter++; return Result.Success; })
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute();
         Assert.That(counter, Is.EqualTo(1));
@@ -249,7 +249,7 @@ public class SteppedExecutionTests
         StateMachine fsm = GraphBuilder
             .StartWith(() => { counter++; return Result.Success; })
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Auto);
+        fsm.SetRestartPolicy(RestartPolicy.Auto);
 
         for (int i = 0; i < 5; i++)
             fsm.Execute();
@@ -269,7 +269,7 @@ public class SteppedExecutionTests
                 onEnter: () => enterCount++,
                 onExit: () => exitCount++))
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute();
         fsm.Execute();
@@ -294,7 +294,7 @@ public class SteppedExecutionTests
                 return callCount < 3 ? Result.InProgress : Result.Success;
             })
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         Result r1 = fsm.Execute(); // node called (count=1), returns Continue
         Result r2 = fsm.Execute(); // node called again (count=2), returns Continue
@@ -321,7 +321,7 @@ public class SteppedExecutionTests
             })
             .To(() => { nodeBCount++; return Result.Success; })
             .ToStateMachine();
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         fsm.Execute(); // nodeA (count=1), Continue
         fsm.Execute(); // nodeA (count=2), Success → transitions to nodeB, returns Continue
@@ -402,7 +402,7 @@ public class SteppedExecutionTests
             .StartWith(() => Result.Success)
             .To(() => Result.Success)
             .ToStateMachine(observer);
-        fsm.SetResetPolicy(RestartPolicy.Manual);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
 
         // Tick 1: Created → Starting → Running (transition) → Running
         fsm.Execute();

--- a/NxGraph.Tests/SyncSubGraphHistoryTests.cs
+++ b/NxGraph.Tests/SyncSubGraphHistoryTests.cs
@@ -1,0 +1,331 @@
+using NxGraph.Authoring;
+using NxGraph.Diagnostics.Validations;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Sync twins of <see cref="SubGraphHistoryTests"/>: DSL-authored subgraph nesting and
+/// history composites running under the sync <see cref="StateMachine"/>, in both
+/// <see cref="ParallelStepMode"/>s, plus the cross-runtime rules (RunToJoin composites run
+/// under the async machine too; RoundPerTick is sync-only).
+/// </summary>
+[TestFixture]
+public class SyncSubGraphHistoryTests
+{
+    private static Result RunToCompletion(StateMachine machine, out int ticks)
+    {
+        ticks = 0;
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            ticks++;
+            result = machine.Execute();
+            if (ticks > 1_000)
+            {
+                Assert.Fail("Machine did not complete within 1000 ticks.");
+            }
+        }
+
+        return result;
+    }
+
+    private static Graph TwoNodeChild(List<string> log)
+    {
+        return GraphBuilder
+            .StartWith(() =>
+            {
+                log.Add("child:0");
+                return Result.Success;
+            })
+            .To(() =>
+            {
+                log.Add("child:1");
+                return Result.Success;
+            })
+            .Build();
+    }
+
+    [Test]
+    public void run_to_join_subgraph_completes_the_child_within_one_parent_tick()
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .StartWith(() =>
+            {
+                log.Add("parent:start");
+                return Result.Success;
+            })
+            .SubGraph(ParallelStepMode.RunToJoin, TwoNodeChild(log))
+            .To(() =>
+            {
+                log.Add("parent:end");
+                return Result.Success;
+            })
+            .Build();
+
+        Result result = RunToCompletion(parent.ToStateMachine(), out int ticks);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "parent:start", "child:0", "child:1", "parent:end" }));
+            Assert.That(ticks, Is.EqualTo(3), "Three parent nodes, one tick each — the child joined within its tick.");
+        });
+    }
+
+    [Test]
+    public void round_per_tick_subgraph_advances_one_child_node_per_parent_tick()
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .Start()
+            .SubGraph(ParallelStepMode.RoundPerTick, TwoNodeChild(log))
+            .Build();
+
+        Result result = RunToCompletion(parent.ToStateMachine(), out int ticks);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "child:0", "child:1" }));
+            Assert.That(ticks, Is.GreaterThan(1),
+                "One child node per parent tick — the two-node child cannot finish in a single tick.");
+        });
+    }
+
+    [Test]
+    public void run_to_join_subgraph_is_executable_by_the_async_runtime()
+    {
+        List<string> log = [];
+        Graph parent = GraphBuilder
+            .Start()
+            .SubGraph(ParallelStepMode.RunToJoin, TwoNodeChild(log))
+            .Build();
+
+        Result result = parent.ToAsyncStateMachine().ExecuteAsync().AsTask().GetAwaiter().GetResult();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "child:0", "child:1" }),
+                "A RunToJoin sync composite returns a terminal result per tick, so the adapter can run it.");
+        });
+    }
+
+    [Test]
+    public void round_per_tick_subgraph_is_rejected_by_the_async_runtime()
+    {
+        Graph parent = GraphBuilder
+            .Start()
+            .SubGraph(ParallelStepMode.RoundPerTick, TwoNodeChild([]))
+            .Build();
+
+        Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await parent.ToAsyncStateMachine().ExecuteAsync(),
+            "Node-level InProgress is reserved in the async runtime — RoundPerTick is sync-only.");
+    }
+
+    [Test]
+    public void history_composite_resumes_at_the_failed_child_node_on_reentry(
+        [Values(ParallelStepMode.RunToJoin, ParallelStepMode.RoundPerTick)] ParallelStepMode mode)
+    {
+        List<string> log = [];
+        bool repaired = false;
+
+        Graph child = GraphBuilder
+            .StartWith(() =>
+            {
+                log.Add("c0");
+                return Result.Success;
+            })
+            .To(() =>
+            {
+                log.Add("c1");
+                return repaired ? Result.Success : Result.Failure;
+            })
+            .To(() =>
+            {
+                log.Add("c2");
+                return Result.Success;
+            })
+            .Build();
+
+        StateToken sub = GraphBuilder
+            .Start()
+            .SubGraph(mode, child, history: true)
+            .SetName("Sub");
+
+        StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new RelayState(() =>
+        {
+            repaired = true;
+            log.Add("repair");
+            return Result.Success;
+        })));
+        repair.Goto("Sub");
+
+        Graph parent = sub.OnError(repair).Build();
+
+        Result result = RunToCompletion(parent.ToStateMachine(), out _);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1", "repair", "c1", "c2" }),
+                "After the repair, the child resumed at the failed node c1 — c0 did not re-run.");
+        });
+    }
+
+    [Test]
+    public void without_history_reentry_restarts_the_child_from_its_start()
+    {
+        List<string> log = [];
+        bool repaired = false;
+
+        Graph child = GraphBuilder
+            .StartWith(() =>
+            {
+                log.Add("c0");
+                return Result.Success;
+            })
+            .To(() =>
+            {
+                log.Add("c1");
+                return repaired ? Result.Success : Result.Failure;
+            })
+            .Build();
+
+        StateToken sub = GraphBuilder
+            .Start()
+            .SubGraph(ParallelStepMode.RunToJoin, child)
+            .SetName("Sub");
+
+        StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new RelayState(() =>
+        {
+            repaired = true;
+            return Result.Success;
+        })));
+        repair.Goto("Sub");
+
+        Graph parent = sub.OnError(repair).Build();
+
+        Result result = RunToCompletion(parent.ToStateMachine(), out _);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1", "c0", "c1" }),
+                "Without history the child restarts from c0 on re-entry.");
+        });
+    }
+
+    [Test]
+    public void completed_history_composite_restarts_from_the_top_on_reentry()
+    {
+        List<string> log = [];
+        int laps = 0;
+
+        Graph child = GraphBuilder
+            .StartWith(() =>
+            {
+                log.Add("c0");
+                return Result.Success;
+            })
+            .Build();
+
+        Graph parent = GraphBuilder
+            .Start()
+            .SubGraph(ParallelStepMode.RunToJoin, child, history: true).SetName("Sub")
+            .To(() => ++laps < 2 ? Result.Success : Result.Failure)
+            .Goto("Sub")
+            .Build();
+
+        Result result = RunToCompletion(parent.ToStateMachine(), out _);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c0" }),
+                "A completed child restarts from its start node on the next visit.");
+        });
+    }
+
+    [Test]
+    public void resumed_child_node_gets_a_fresh_retry_budget()
+    {
+        List<string> log = [];
+        int failures = 0;
+
+        // The child node consumes its full retry budget (2 attempts) and fails the child on
+        // the first visit. On re-entry the resumed node must start from a zeroed attempt
+        // counter — a stale counter would skip the retry and fail immediately.
+        Graph child = GraphBuilder
+            .StartWith(() =>
+            {
+                log.Add("try");
+                return ++failures < 4 ? Result.Failure : Result.Success;
+            })
+            .Retry(maxAttempts: 2)
+            .Build();
+
+        StateToken sub = GraphBuilder
+            .Start()
+            .SubGraph(ParallelStepMode.RunToJoin, child, history: true)
+            .SetName("Sub");
+
+        StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new RelayState(() =>
+        {
+            log.Add("repair");
+            return Result.Success;
+        })));
+        repair.Goto("Sub");
+
+        Graph parent = sub.OnError(repair).Build();
+
+        Result result = RunToCompletion(parent.ToStateMachine(), out _);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "try", "try", "repair", "try", "try" }),
+                "Visit 1 spends attempts 1+2; the resumed visit gets a fresh budget for attempts 3+4.");
+        });
+    }
+
+    [Test]
+    public void validator_flags_round_per_tick_composites_when_strict_async_compatible()
+    {
+        Graph roundPerTick = GraphBuilder
+            .Start()
+            .SubGraph(ParallelStepMode.RoundPerTick, TwoNodeChild([]))
+            .Build();
+
+        Graph runToJoin = GraphBuilder
+            .Start()
+            .SubGraph(ParallelStepMode.RunToJoin, TwoNodeChild([]))
+            .Build();
+
+        GraphValidationResult flagged = roundPerTick.Validate(new GraphValidationOptions
+        {
+            StrictAsyncCompatible = true,
+        });
+        GraphValidationResult cleanStrict = runToJoin.Validate(new GraphValidationOptions
+        {
+            StrictAsyncCompatible = true,
+        });
+        GraphValidationResult cleanDefault = roundPerTick.Validate();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(flagged.Diagnostics.Any(d =>
+                    d.Severity == Severity.Error && d.Message.Contains("RoundPerTick")),
+                Is.True, "StrictAsyncCompatible must flag RoundPerTick composites.");
+            Assert.That(cleanStrict.Diagnostics.Any(d => d.Message.Contains("RoundPerTick")), Is.False,
+                "RunToJoin composites run under both runtimes and must stay clean.");
+            Assert.That(cleanDefault.Diagnostics.Any(d => d.Message.Contains("RoundPerTick")), Is.False,
+                "The lint is opt-in — default validation must not flag sync-destined graphs.");
+        });
+    }
+}

--- a/NxGraph.Tests/SyncWaitTimeoutTests.cs
+++ b/NxGraph.Tests/SyncWaitTimeoutTests.cs
@@ -1,0 +1,256 @@
+using System.Diagnostics;
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Sync twins of the async wait/timeout constructs: <see cref="WaitState"/> (multi-tick wait)
+/// and <see cref="TimeoutState"/> (between-ticks deadline feeding the unified fault model).
+/// Deterministic via an injected clock — no wall-clock assertions.
+/// </summary>
+[TestFixture]
+public class SyncWaitTimeoutTests
+{
+    private sealed class FakeClock
+    {
+        public long Now;
+        public void Advance(TimeSpan by) => Now += (long)(by.TotalSeconds * Stopwatch.Frequency);
+        public Func<long> Func => () => Now;
+    }
+
+    // ── WaitState ─────────────────────────────────────────────────────────
+
+    [Test]
+    public void wait_returns_in_progress_until_the_duration_elapses()
+    {
+        FakeClock clock = new();
+        WaitState wait = new(TimeSpan.FromSeconds(1), clock.Func);
+
+        Assert.That(wait.Execute(), Is.EqualTo(Result.InProgress), "Tick 1 records the start.");
+
+        clock.Advance(TimeSpan.FromMilliseconds(500));
+        Assert.That(wait.Execute(), Is.EqualTo(Result.InProgress), "Halfway — still waiting.");
+
+        clock.Advance(TimeSpan.FromMilliseconds(600));
+        Assert.That(wait.Execute(), Is.EqualTo(Result.Success), "Past the duration — done.");
+    }
+
+    [Test]
+    public void zero_and_negative_durations_complete_immediately()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(new WaitState(TimeSpan.Zero).Execute(), Is.EqualTo(Result.Success));
+            Assert.That(new WaitState(TimeSpan.FromSeconds(-1)).Execute(), Is.EqualTo(Result.Success));
+        });
+    }
+
+    [Test]
+    public void reentering_a_completed_wait_starts_a_fresh_wait()
+    {
+        FakeClock clock = new();
+        WaitState wait = new(TimeSpan.FromSeconds(1), clock.Func);
+
+        wait.Execute();
+        clock.Advance(TimeSpan.FromSeconds(2));
+        Assert.That(wait.Execute(), Is.EqualTo(Result.Success));
+
+        // Same instance revisited: the recorded timestamp was cleared on completion.
+        Assert.That(wait.Execute(), Is.EqualTo(Result.InProgress),
+            "Re-entry records a fresh start instead of reusing the elapsed one.");
+        clock.Advance(TimeSpan.FromSeconds(2));
+        Assert.That(wait.Execute(), Is.EqualTo(Result.Success));
+    }
+
+    [Test]
+    public void wait_for_dsl_ticks_under_the_sync_machine()
+    {
+        int after = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success)
+            .WaitFor(TimeSpan.FromMilliseconds(30))
+            .To(() =>
+            {
+                after++;
+                return Result.Success;
+            })
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result first = machine.Execute(); // start node
+        Result second = machine.Execute(); // wait's first tick — cannot have elapsed yet
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo(Result.InProgress));
+            Assert.That(second, Is.EqualTo(Result.InProgress), "The wait spans ticks.");
+            Assert.That(after, Is.Zero);
+        });
+
+        Result result = Result.InProgress;
+        Stopwatch guard = Stopwatch.StartNew();
+        while (result == Result.InProgress && guard.ElapsedMilliseconds < 5_000)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(after, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void wait_for_is_rejected_by_the_async_runtime()
+    {
+        Graph graph = GraphBuilder
+            .Start()
+            .WaitFor(TimeSpan.FromSeconds(1))
+            .Build();
+
+        Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await graph.ToAsyncStateMachine().ExecuteAsync(),
+            "Node-level InProgress is reserved in the async runtime — WaitFor is sync-only.");
+    }
+
+    // ── TimeoutState ──────────────────────────────────────────────────────
+
+    private sealed class CountingInProgressLogic : ILogic
+    {
+        public int Executions;
+        public Result Next = Result.InProgress;
+
+        public Result Execute()
+        {
+            Executions++;
+            return Next;
+        }
+    }
+
+    [Test]
+    public void timeout_produces_failure_when_the_inner_logic_overstays()
+    {
+        FakeClock clock = new();
+        CountingInProgressLogic inner = new();
+        TimeoutState state = new(inner, TimeSpan.FromSeconds(1), TimeoutBehavior.Fail, clock.Func);
+
+        Assert.That(state.Execute(), Is.EqualTo(Result.InProgress));
+
+        clock.Advance(TimeSpan.FromSeconds(2));
+        Result result = state.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(result.Message, Does.Contain("timed out"));
+            Assert.That(inner.Executions, Is.EqualTo(2),
+                "The deadline is detected between ticks — the inner logic ran once more on the " +
+                "tick that noticed the overrun; the sync runtime cannot interrupt mid-execution.");
+        });
+    }
+
+    [Test]
+    public void timeout_throws_when_behavior_is_throw()
+    {
+        FakeClock clock = new();
+        TimeoutState state = new(new CountingInProgressLogic(), TimeSpan.FromSeconds(1),
+            TimeoutBehavior.Throw, clock.Func);
+
+        Assert.That(state.Execute(), Is.EqualTo(Result.InProgress));
+
+        clock.Advance(TimeSpan.FromSeconds(2));
+        Assert.Throws<TimeoutException>(() => state.Execute());
+    }
+
+    [Test]
+    public void inner_completion_before_the_deadline_passes_through()
+    {
+        FakeClock clock = new();
+        CountingInProgressLogic inner = new() { Next = Result.Success };
+        TimeoutState state = new(inner, TimeSpan.FromSeconds(1), TimeoutBehavior.Fail, clock.Func);
+
+        Assert.That(state.Execute(), Is.EqualTo(Result.Success));
+
+        inner.Next = Result.Failure;
+        Assert.That(state.Execute(), Is.EqualTo(Result.Failure),
+            "Terminal inner results pass through untouched — only overstaying InProgress times out.");
+    }
+
+    [Test]
+    public void a_retried_timeout_gets_a_fresh_deadline()
+    {
+        FakeClock clock = new();
+        CountingInProgressLogic inner = new();
+        TimeoutState state = new(inner, TimeSpan.FromSeconds(1), TimeoutBehavior.Fail, clock.Func);
+
+        state.Execute();
+        clock.Advance(TimeSpan.FromSeconds(2));
+        Assert.That(state.Execute(), Is.EqualTo(Result.Failure), "First visit times out.");
+
+        // In-place retry: the wrapper re-arms; without advancing the clock there is no overrun.
+        inner.Next = Result.Success;
+        Assert.That(state.Execute(), Is.EqualTo(Result.Success), "The retry starts a fresh deadline.");
+    }
+
+    [Test]
+    public void non_positive_timeouts_are_rejected()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => _ = new TimeoutState(new CountingInProgressLogic(), TimeSpan.Zero));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => _ = new TimeoutState(new CountingInProgressLogic(), TimeSpan.FromMilliseconds(-1)));
+        });
+    }
+
+    [Test]
+    public void timeout_routes_through_the_failure_edge_under_the_sync_machine()
+    {
+        bool cleanupRan = false;
+        Graph graph = GraphBuilder
+            .Start()
+            .ToWithTimeout(TimeSpan.FromMilliseconds(30), new CountingInProgressLogic())
+            .OnError(new RelayState(() =>
+            {
+                cleanupRan = true;
+                return Result.Success;
+            }))
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result result = Result.InProgress;
+        Stopwatch guard = Stopwatch.StartNew();
+        while (result == Result.InProgress && guard.ElapsedMilliseconds < 5_000)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(cleanupRan, Is.True, "The timeout flowed through the unified fault model.");
+        });
+    }
+
+    [Test]
+    public void to_with_timeout_lambda_runs_the_happy_path()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success)
+            .ToWithTimeout(TimeSpan.FromSeconds(5), () => Result.Success)
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
+}

--- a/NxGraph.Tests/TimeoutFaultModelTests.cs
+++ b/NxGraph.Tests/TimeoutFaultModelTests.cs
@@ -25,7 +25,7 @@ public class TimeoutFaultModelTests
         bool cleanupRan = false;
         Graph graph = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(HangForever, TimeSpan.FromMilliseconds(30), TimeoutBehavior.Fail)
+            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(30), HangForever, TimeoutBehavior.Fail)
             .OnErrorAsync(_ =>
             {
                 cleanupRan = true;
@@ -48,7 +48,7 @@ public class TimeoutFaultModelTests
         int executions = 0;
         Graph graph = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(async ct =>
+            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(30), async ct =>
             {
                 executions++;
                 if (executions < 2)
@@ -57,7 +57,7 @@ public class TimeoutFaultModelTests
                 }
 
                 return Result.Success;
-            }, TimeSpan.FromMilliseconds(30), TimeoutBehavior.Fail)
+            }, TimeoutBehavior.Fail)
             .Retry(maxAttempts: 2)
             .Build();
 
@@ -75,7 +75,7 @@ public class TimeoutFaultModelTests
     {
         Graph graph = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(HangForever, TimeSpan.FromMilliseconds(30), TimeoutBehavior.Fail)
+            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(30), HangForever, TimeoutBehavior.Fail)
             .Build();
 
         Result result = await graph.ToAsyncStateMachine().ExecuteAsync();

--- a/NxGraph.Tests/TimeoutWrapperTests.cs
+++ b/NxGraph.Tests/TimeoutWrapperTests.cs
@@ -13,12 +13,12 @@ public class TimeoutWrapperTests
     {
         AsyncStateMachine fsm = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(new AsyncRelayState(
+            .ToWithTimeoutAsync(100.Milliseconds(), new AsyncRelayState(
                     async ct =>
                     {
                         await Task.Delay(1000, ct);
                         return Result.Success;
-                    }), 100.Milliseconds(), TimeoutBehavior.Fail
+                    }), TimeoutBehavior.Fail
             )
             .ToAsyncStateMachine();
 
@@ -32,12 +32,12 @@ public class TimeoutWrapperTests
     {
         AsyncStateMachine throwing = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(new AsyncRelayState(async ct =>
+            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(100), new AsyncRelayState(async ct =>
                 {
                     await Task.Delay(1000, ct);
                     return Result.Success;
                 }),
-                TimeSpan.FromMilliseconds(100), TimeoutBehavior.Throw)
+                TimeoutBehavior.Throw)
             .ToAsyncStateMachine();
 
         Assert.ThrowsAsync<TimeoutException>(async () => await throwing.ExecuteAsync());
@@ -51,11 +51,11 @@ public class TimeoutWrapperTests
 
         AsyncStateMachine fsm = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(async ct =>
+            .ToWithTimeoutAsync(2000.Milliseconds(), async ct =>
             {
                 await Task.Delay(5000, ct);
                 return Result.Success;
-            }, 2000.Milliseconds(), TimeoutBehavior.Fail) // timeout later than external cancel
+            }, TimeoutBehavior.Fail) // timeout later than external cancel
             .ToAsyncStateMachine();
 
         Assert.ThrowsAsync<TaskCanceledException>(async () =>
@@ -72,12 +72,12 @@ public class TimeoutWrapperTests
         // Using StartWithTimeout should throw when timeout <= 0
         Assert.Throws<ArgumentOutOfRangeException>(() =>
         {
-            StateToken _ = Dsl.StartWithTimeoutAsync(_ => ResultHelpers.Success, TimeSpan.Zero);
+            StateToken _ = Dsl.StartWithTimeoutAsync(TimeSpan.Zero, _ => ResultHelpers.Success);
         });
         Assert.Throws<ArgumentOutOfRangeException>(() =>
         {
             StateToken _ =
-                Dsl.StartWithTimeoutAsync(_ => ResultHelpers.Success, TimeSpan.FromMilliseconds(-1));
+                Dsl.StartWithTimeoutAsync(TimeSpan.FromMilliseconds(-1), _ => ResultHelpers.Success);
         });
     }
 
@@ -87,11 +87,11 @@ public class TimeoutWrapperTests
     {
         AsyncStateMachine fsm = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(async ct =>
+            .ToWithTimeoutAsync(1.Seconds(), async ct =>
             {
                 await Task.Delay(50, ct); // finishes well before timeout
                 return Result.Success;
-            }, 1.Seconds(), TimeoutBehavior.Fail)
+            }, TimeoutBehavior.Fail)
             .ToAsyncStateMachine();
 
         Result result = await fsm.ExecuteAsync();

--- a/NxGraph/Authoring/Dsl.Blackboard.cs
+++ b/NxGraph/Authoring/Dsl.Blackboard.cs
@@ -12,8 +12,9 @@ public static partial class Dsl
     /// <summary>
     /// Declares a blackboard schema on the graph being built, routed by the schema's scope:
     /// Graph-scoped schemas become the graph's own declaration, Global-scoped schemas record
-    /// the global board the graph requires. Machines validate bound boards against these
-    /// declarations at <c>WithBlackboard(...)</c> time.
+    /// the global board the graph requires, and Node-scoped schemas declare transient
+    /// per-visit scratch that each machine auto-creates its own board for. Machines validate
+    /// bound boards against these declarations at <c>WithBlackboard(...)</c> time.
     /// </summary>
     public static StartToken WithSchema(this StartToken token, BlackboardSchema schema)
     {

--- a/NxGraph/Authoring/Dsl.IfBuilder.cs
+++ b/NxGraph/Authoring/Dsl.IfBuilder.cs
@@ -108,6 +108,12 @@ public static partial class Dsl
             return ToAsync(AsyncWait.For(delay));
         }
 
+        /// <summary>Chains a sync multi-tick wait state onto the "then" branch (see <see cref="WaitState"/>).</summary>
+        public BranchBuilder WaitFor(TimeSpan delay)
+        {
+            return To(new WaitState(delay));
+        }
+
         /// <summary>Adds an async "else" branch.</summary>
         public BranchEnd ElseAsync(IAsyncLogic asyncLogic)
         {
@@ -158,6 +164,12 @@ public static partial class Dsl
         public StateToken WaitForAsync(TimeSpan delay)
         {
             return ToAsync(AsyncWait.For(delay));
+        }
+
+        /// <summary>Adds a sync multi-tick wait state after the "else" branch (see <see cref="WaitState"/>).</summary>
+        public StateToken WaitFor(TimeSpan delay)
+        {
+            return To(new WaitState(delay));
         }
 
         public Graph Build(bool throwOnError = false)

--- a/NxGraph/Authoring/Dsl.Timeout.cs
+++ b/NxGraph/Authoring/Dsl.Timeout.cs
@@ -10,11 +10,20 @@ public static partial class Dsl
     /// <summary>
     /// Starts a new graph with a timed async node as the start state.
     /// </summary>
-    public static StateToken StartWithTimeoutAsync(Func<CancellationToken, ValueTask<Result>> run, TimeSpan timeout,
+    public static StateToken StartWithTimeoutAsync(TimeSpan timeout, Func<CancellationToken, ValueTask<Result>> run,
         TimeoutBehavior behavior = TimeoutBehavior.Fail)
     {
         Guard.NotNull(run, nameof(run));
         return GraphBuilder.StartWithAsync(Timeout.For(timeout, run, behavior));
+    }
+
+    /// <inheritdoc cref="StartWithTimeoutAsync(TimeSpan, Func{CancellationToken, ValueTask{Result}}, TimeoutBehavior)"/>
+    [Obsolete("Use the timeout-first overload — the timeout DSL overloads disagreed on parameter order; " +
+              "they now uniformly take the timeout first. This alias forwards and will not change behavior.")]
+    public static StateToken StartWithTimeoutAsync(Func<CancellationToken, ValueTask<Result>> run, TimeSpan timeout,
+        TimeoutBehavior behavior = TimeoutBehavior.Fail)
+    {
+        return StartWithTimeoutAsync(timeout, run, behavior);
     }
 
     /// <summary>
@@ -40,22 +49,31 @@ public static partial class Dsl
     /// <summary>
     /// Utility to wrap an existing async node logic in-place with a timeout (when you already have a node instance).
     /// </summary>
-    public static StateToken ToWithTimeoutAsync(this StateToken prev, IAsyncLogic nextStateAsyncLogic, TimeSpan timeout,
-        TimeoutBehavior behavior)
+    public static StateToken ToWithTimeoutAsync(this StateToken prev, TimeSpan timeout,
+        IAsyncLogic nextStateAsyncLogic, TimeoutBehavior behavior = TimeoutBehavior.Fail)
     {
         return prev.ToAsync(Timeout.Wrap(nextStateAsyncLogic, timeout, behavior));
     }
 
-    /// <summary>
-    /// Wraps the next async state logic in a timeout and returns a new state token.
-    /// </summary>
-    /// <param name="prev"> The previous state token, which is the source of the transition.</param>
-    /// <param name="nextStateAsyncLogic">  The logic for the next state, which will be wrapped in a timeout.</param>
-    /// <param name="timeout">The duration of the timeout for the next state logic.</param>
-    /// <param name="behavior">The behavior to apply when the timeout occurs, such as failing or skipping.</param>
-    /// <returns>A new state token that represents the next state logic wrapped in a timeout.</returns>
-    public static StateToken ToWithTimeoutAsync(this StartToken prev, IAsyncLogic nextStateAsyncLogic, TimeSpan timeout,
+    /// <inheritdoc cref="ToWithTimeoutAsync(StateToken, TimeSpan, IAsyncLogic, TimeoutBehavior)"/>
+    [Obsolete("Use the timeout-first overload — the timeout DSL overloads disagreed on parameter order; " +
+              "they now uniformly take the timeout first. This alias forwards and will not change behavior.")]
+    public static StateToken ToWithTimeoutAsync(this StateToken prev, IAsyncLogic nextStateAsyncLogic, TimeSpan timeout,
         TimeoutBehavior behavior)
+    {
+        return prev.ToWithTimeoutAsync(timeout, nextStateAsyncLogic, behavior);
+    }
+
+    /// <summary>
+    /// Wraps the next async state logic in a timeout and starts the graph with it.
+    /// </summary>
+    /// <param name="prev">The start token, which is the entry point of the FSM graph.</param>
+    /// <param name="timeout">The duration of the timeout for the next state logic.</param>
+    /// <param name="nextStateAsyncLogic">The logic for the next state, which will be wrapped in a timeout.</param>
+    /// <param name="behavior">The behavior to apply when the timeout occurs.</param>
+    /// <returns>A new state token that represents the next state logic wrapped in a timeout.</returns>
+    public static StateToken ToWithTimeoutAsync(this StartToken prev, TimeSpan timeout,
+        IAsyncLogic nextStateAsyncLogic, TimeoutBehavior behavior = TimeoutBehavior.Fail)
     {
         Guard.NotNull(nextStateAsyncLogic, nameof(nextStateAsyncLogic));
         IAsyncLogic wrapped = Timeout.Wrap(nextStateAsyncLogic, timeout, behavior);
@@ -63,23 +81,87 @@ public static partial class Dsl
         return new StateToken(id, prev.Builder);
     }
 
+    /// <inheritdoc cref="ToWithTimeoutAsync(StartToken, TimeSpan, IAsyncLogic, TimeoutBehavior)"/>
+    [Obsolete("Use the timeout-first overload — the timeout DSL overloads disagreed on parameter order; " +
+              "they now uniformly take the timeout first. This alias forwards and will not change behavior.")]
+    public static StateToken ToWithTimeoutAsync(this StartToken prev, IAsyncLogic nextStateAsyncLogic, TimeSpan timeout,
+        TimeoutBehavior behavior)
+    {
+        return prev.ToWithTimeoutAsync(timeout, nextStateAsyncLogic, behavior);
+    }
 
     /// <summary>
-    /// Wraps the next async state logic in a timeout and returns a new state token.
+    /// Wraps the next async state logic in a timeout and starts the graph with it.
     /// </summary>
-    /// <param name="prev">The previous state token, which is the source of the transition.</param>
-    /// <param name="run">The logic for the next state, which will be executed with a timeout.</param>
+    /// <param name="prev">The start token, which is the entry point of the FSM graph.</param>
     /// <param name="timeout">The duration of the timeout for the next state logic.</param>
-    /// <param name="behavior">The behavior to apply when the timeout occurs, such as failing or skipping.</param>
+    /// <param name="run">The logic for the next state, which will be executed with a timeout.</param>
+    /// <param name="behavior">The behavior to apply when the timeout occurs.</param>
     /// <returns>A new state token that represents the next state logic wrapped in a timeout.</returns>
-    public static StateToken ToWithTimeoutAsync(this StartToken prev, Func<CancellationToken, ValueTask<Result>> run,
-        TimeSpan timeout,
-        TimeoutBehavior behavior)
+    public static StateToken ToWithTimeoutAsync(this StartToken prev, TimeSpan timeout,
+        Func<CancellationToken, ValueTask<Result>> run, TimeoutBehavior behavior = TimeoutBehavior.Fail)
     {
         Guard.NotNull(run, nameof(run));
         IAsyncLogic nextStateAsyncLogic = new AsyncRelayState(run);
         IAsyncLogic wrapped = Timeout.Wrap(nextStateAsyncLogic, timeout, behavior);
         NodeId id = prev.Builder.AddNode(wrapped, true);
         return new StateToken(id, prev.Builder);
+    }
+
+    /// <inheritdoc cref="ToWithTimeoutAsync(StartToken, TimeSpan, Func{CancellationToken, ValueTask{Result}}, TimeoutBehavior)"/>
+    [Obsolete("Use the timeout-first overload — the timeout DSL overloads disagreed on parameter order; " +
+              "they now uniformly take the timeout first. This alias forwards and will not change behavior.")]
+    public static StateToken ToWithTimeoutAsync(this StartToken prev, Func<CancellationToken, ValueTask<Result>> run,
+        TimeSpan timeout, TimeoutBehavior behavior)
+    {
+        return prev.ToWithTimeoutAsync(timeout, run, behavior);
+    }
+
+    // ── Sync twins (see TimeoutState) ─────────────────────────────────────
+
+    /// <summary>
+    /// Adds a brand-new timed <b>sync</b> node and wires a transition to it — the
+    /// runtime-parity twin of <see cref="ToWithTimeoutAsync(StateToken, TimeSpan, Func{CancellationToken, ValueTask{Result}}, TimeoutBehavior)"/>.
+    /// The deadline is checked between ticks (see <see cref="TimeoutState"/>): a node that
+    /// returns <see cref="Result.InProgress"/> past the timeout produces the timeout outcome
+    /// per <paramref name="behavior"/>.
+    /// </summary>
+    public static StateToken ToWithTimeout(this StateToken prev, TimeSpan timeout, Func<Result> run,
+        TimeoutBehavior behavior = TimeoutBehavior.Fail)
+    {
+        Guard.NotNull(run, nameof(run));
+        return prev.To(new TimeoutState(new RelayState(run), timeout, behavior));
+    }
+
+    /// <summary>
+    /// Wraps an existing sync node logic with a timeout and wires a transition to it
+    /// (see <see cref="TimeoutState"/>).
+    /// </summary>
+    public static StateToken ToWithTimeout(this StateToken prev, TimeSpan timeout, ILogic nextStateLogic,
+        TimeoutBehavior behavior = TimeoutBehavior.Fail)
+    {
+        Guard.NotNull(nextStateLogic, nameof(nextStateLogic));
+        return prev.To(new TimeoutState(nextStateLogic, timeout, behavior));
+    }
+
+    /// <summary>
+    /// Starts the graph with a timed sync node (see <see cref="TimeoutState"/>).
+    /// </summary>
+    public static StateToken ToWithTimeout(this StartToken prev, TimeSpan timeout, Func<Result> run,
+        TimeoutBehavior behavior = TimeoutBehavior.Fail)
+    {
+        Guard.NotNull(run, nameof(run));
+        return prev.To(new TimeoutState(new RelayState(run), timeout, behavior));
+    }
+
+    /// <summary>
+    /// Starts the graph with an existing sync node logic wrapped in a timeout
+    /// (see <see cref="TimeoutState"/>).
+    /// </summary>
+    public static StateToken ToWithTimeout(this StartToken prev, TimeSpan timeout, ILogic nextStateLogic,
+        TimeoutBehavior behavior = TimeoutBehavior.Fail)
+    {
+        Guard.NotNull(nextStateLogic, nameof(nextStateLogic));
+        return prev.To(new TimeoutState(nextStateLogic, timeout, behavior));
     }
 }

--- a/NxGraph/Authoring/Dsl.Wait.cs
+++ b/NxGraph/Authoring/Dsl.Wait.cs
@@ -29,4 +29,24 @@ public static partial class Dsl
         NodeId id = token.Builder.AddNode(node, true);
         return new StateToken(id, token.Builder);
     }
+
+    /// <summary>
+    /// Creates a <b>sync</b> multi-tick wait state and wires a transition to it — the
+    /// runtime-parity twin of <see cref="WaitForAsync(StateToken, TimeSpan)"/> (see
+    /// <see cref="WaitState"/>). Returns <see cref="Result.InProgress"/> across ticks, so it
+    /// runs under the sync <see cref="StateMachine"/> only.
+    /// </summary>
+    public static StateToken WaitFor(this StateToken token, TimeSpan delay)
+    {
+        return token.To(new WaitState(delay));
+    }
+
+    /// <summary>
+    /// Starts the graph with a sync multi-tick wait state (see <see cref="WaitState"/>).
+    /// </summary>
+    public static StateToken WaitFor(this StartToken token, TimeSpan delay)
+    {
+        NodeId id = token.Builder.AddNode(new WaitState(delay), true);
+        return new StateToken(id, token.Builder);
+    }
 }

--- a/NxGraph/Authoring/Dsl.cs
+++ b/NxGraph/Authoring/Dsl.cs
@@ -45,6 +45,46 @@ public static partial class Dsl
     }
 
     /// <summary>
+    /// Adds a <b>sync</b> child-graph composite and wires a transition to it — the
+    /// runtime-parity twin of <see cref="SubGraph(StateToken, Graph, bool)"/>. Without
+    /// history the child runs as a nested sync <see cref="StateMachine"/>; with
+    /// <paramref name="history"/> a failed child resumes at its last-active node on re-entry
+    /// (see <see cref="HistoryState"/>). <paramref name="mode"/> decides whether the child
+    /// completes within one tick (<see cref="ParallelStepMode.RunToJoin"/>, usable from both
+    /// runtimes) or advances one node per tick (<see cref="ParallelStepMode.RoundPerTick"/>,
+    /// sync runtime only).
+    /// </summary>
+    public static StateToken SubGraph(this StateToken prev, ParallelStepMode mode, Graph child,
+        bool history = false)
+    {
+        Guard.NotNull(child, nameof(child));
+        return prev.To(CreateSyncComposite(mode, child, history));
+    }
+
+    /// <summary>
+    /// Starts the graph with a sync child-graph composite as its first state
+    /// (see <see cref="SubGraph(StateToken, ParallelStepMode, Graph, bool)"/>).
+    /// </summary>
+    public static StateToken SubGraph(this StartToken root, ParallelStepMode mode, Graph child,
+        bool history = false)
+    {
+        Guard.NotNull(child, nameof(child));
+        return root.To(CreateSyncComposite(mode, child, history));
+    }
+
+    private static ILogic CreateSyncComposite(ParallelStepMode mode, Graph child, bool history)
+    {
+        if (history)
+        {
+            return new HistoryState(child, mode);
+        }
+
+        StateMachine machine = new(child);
+        machine.SetStepMode(mode);
+        return machine;
+    }
+
+    /// <summary>
     /// Adds an orthogonal-regions composite and wires a transition to it: every region graph
     /// progresses one node per round (cooperative interleaving) until all reach a terminal
     /// result. Succeeds only when every region succeeded (see <see cref="AsyncParallelState"/>).

--- a/NxGraph/Authoring/GraphBuilder.cs
+++ b/NxGraph/Authoring/GraphBuilder.cs
@@ -27,6 +27,7 @@ public sealed partial class GraphBuilder
     private readonly Dictionary<int, string> _outcomeNames = new(); // code -> display name
     private BlackboardSchema? _graphSchema; // Graph-scoped declaration, baked into the Graph at Build()
     private BlackboardSchema? _globalSchema; // required Global-scoped schema, baked into the Graph at Build()
+    private BlackboardSchema? _nodeSchema; // transient Node-scoped schema, baked into the Graph at Build()
 
     /// <summary>
     /// Declares a blackboard schema on the graph, routed by the schema's scope: a
@@ -38,23 +39,35 @@ public sealed partial class GraphBuilder
     {
         Guard.NotNull(schema, nameof(schema));
 
-        if (schema.Scope == BlackboardScope.Global)
+        switch (schema.Scope)
         {
-            if (_globalSchema is not null)
-            {
-                throw new InvalidOperationException("A Global-scoped schema has already been declared on this graph.");
-            }
+            case BlackboardScope.Global:
+                if (_globalSchema is not null)
+                {
+                    throw new InvalidOperationException(
+                        "A Global-scoped schema has already been declared on this graph.");
+                }
 
-            _globalSchema = schema;
-        }
-        else
-        {
-            if (_graphSchema is not null)
-            {
-                throw new InvalidOperationException("A Graph-scoped schema has already been declared on this graph.");
-            }
+                _globalSchema = schema;
+                break;
+            case BlackboardScope.Node:
+                if (_nodeSchema is not null)
+                {
+                    throw new InvalidOperationException(
+                        "A Node-scoped schema has already been declared on this graph.");
+                }
 
-            _graphSchema = schema;
+                _nodeSchema = schema;
+                break;
+            default:
+                if (_graphSchema is not null)
+                {
+                    throw new InvalidOperationException(
+                        "A Graph-scoped schema has already been declared on this graph.");
+                }
+
+                _graphSchema = schema;
+                break;
         }
 
         return this;
@@ -350,7 +363,7 @@ public sealed partial class GraphBuilder
 
         NodeId graphId = _next.Next();
         return new Graph(graphId, nodes, edges, logic: null, retries, outcomes, outcomeNames,
-            _graphSchema, _globalSchema);
+            _graphSchema, _globalSchema, _nodeSchema);
     }
 
 

--- a/NxGraph/Blackboards/BlackboardContext.cs
+++ b/NxGraph/Blackboards/BlackboardContext.cs
@@ -14,16 +14,16 @@ namespace NxGraph.Blackboards;
 /// </summary>
 public readonly struct BlackboardContext
 {
-    // Node scope (reserved) will add a third slot here; the layout is private and
-    // invisible to the public API baseline.
     private readonly Blackboard? _global;
     private readonly Blackboard? _graph;
+    private readonly Blackboard? _node;
 
     /// <summary>
     /// Creates a context from explicit per-scope boards. Each board's schema scope must
-    /// match the slot it is passed for.
+    /// match the slot it is passed for. The <paramref name="node"/> slot is machine-owned
+    /// transient scratch — user code composes contexts through the machines, never directly.
     /// </summary>
-    public BlackboardContext(Blackboard? global, Blackboard? graph)
+    public BlackboardContext(Blackboard? global, Blackboard? graph, Blackboard? node = null)
     {
         if (global is not null && global.Schema.Scope != BlackboardScope.Global)
         {
@@ -39,12 +39,20 @@ public readonly struct BlackboardContext
                 "and cannot occupy the Graph slot.", nameof(graph));
         }
 
+        if (node is not null && node.Schema.Scope != BlackboardScope.Node)
+        {
+            throw new ArgumentException(
+                $"Board over schema '{node.Schema.Name ?? "<unnamed>"}' is {node.Schema.Scope}-scoped " +
+                "and cannot occupy the Node slot.", nameof(node));
+        }
+
         _global = global;
         _graph = graph;
+        _node = node;
     }
 
     /// <summary><see langword="true"/> when no board is bound for any scope.</summary>
-    public bool IsEmpty => _global is null && _graph is null;
+    public bool IsEmpty => _global is null && _graph is null && _node is null;
 
     /// <summary>The Global-scoped board, or <see langword="null"/> when unbound. Escape hatch for bulk ops and serialization.</summary>
     public Blackboard? Global => _global;
@@ -52,11 +60,18 @@ public readonly struct BlackboardContext
     /// <summary>The Graph-scoped board, or <see langword="null"/> when unbound. Escape hatch for bulk ops and serialization.</summary>
     public Blackboard? Graph => _graph;
 
+    /// <summary>
+    /// The machine-owned Node-scoped board, or <see langword="null"/> when the graph declares
+    /// no Node schema. Transient per-visit scratch — not durable, never user-bound.
+    /// </summary>
+    public Blackboard? Node => _node;
+
     /// <summary>The board bound for <paramref name="scope"/>, or <see langword="null"/> when unbound.</summary>
     public Blackboard? Board(BlackboardScope scope) => scope switch
     {
         BlackboardScope.Global => _global,
         BlackboardScope.Graph => _graph,
+        BlackboardScope.Node => _node,
         _ => null,
     };
 
@@ -70,10 +85,19 @@ public readonly struct BlackboardContext
     public BlackboardContext With(Blackboard board)
     {
         Guard.NotNull(board, nameof(board));
-        return board.Schema.Scope == BlackboardScope.Global
-            ? new BlackboardContext(board, _graph)
-            : new BlackboardContext(_global, board);
+        return board.Schema.Scope switch
+        {
+            BlackboardScope.Global => new BlackboardContext(board, _graph, _node),
+            BlackboardScope.Graph => new BlackboardContext(_global, board, _node),
+            _ => new BlackboardContext(_global, _graph, board),
+        };
     }
+
+    /// <summary>
+    /// Returns a copy with the machine-owned Node slot cleared. Machines drop a parent's Node
+    /// board when receiving a context through the stamping walk — each machine composes its own.
+    /// </summary>
+    public BlackboardContext WithoutNode() => _node is null ? this : new BlackboardContext(_global, _graph);
 
     /// <summary>Reads <paramref name="key"/> from the board its schema scope routes to.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -112,10 +136,16 @@ public readonly struct BlackboardContext
             ThrowUninitializedKey();
         }
 
-        Blackboard? board = key.Schema!.Scope == BlackboardScope.Global ? _global : _graph;
+        BlackboardScope scope = key.Schema!.Scope;
+        Blackboard? board = scope switch
+        {
+            BlackboardScope.Global => _global,
+            BlackboardScope.Graph => _graph,
+            _ => _node,
+        };
         if (board is null)
         {
-            ThrowUnboundScope(key.Schema.Scope, key.Name);
+            ThrowUnboundScope(scope, key.Name);
         }
 
         return board!;
@@ -129,6 +159,13 @@ public readonly struct BlackboardContext
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowUnboundScope(BlackboardScope scope, string keyName)
     {
+        if (scope == BlackboardScope.Node)
+        {
+            throw new InvalidOperationException(
+                $"node key '{keyName}' used but no node blackboard — declare a Node-scoped schema " +
+                "via WithSchema(...) on the graph; the machine creates its own board from it.");
+        }
+
         string scopeWord = scope == BlackboardScope.Global ? "global" : "graph";
         throw new InvalidOperationException(
             $"{scopeWord} key '{keyName}' used but no {scopeWord} blackboard bound — " +

--- a/NxGraph/Blackboards/BlackboardSchema.cs
+++ b/NxGraph/Blackboards/BlackboardSchema.cs
@@ -20,17 +20,11 @@ public sealed class BlackboardSchema
 
     /// <summary>
     /// Creates a schema. <paramref name="scope"/> decides which <see cref="BlackboardContext"/>
-    /// slot the schema's keys route to; <see cref="BlackboardScope.Node"/> is reserved and rejected.
+    /// slot the schema's keys route to.
     /// </summary>
     public BlackboardSchema(string? name = null, BlackboardScope scope = BlackboardScope.Graph)
     {
-        if (scope == BlackboardScope.Node)
-        {
-            throw new ArgumentOutOfRangeException(nameof(scope), scope,
-                "BlackboardScope.Node is reserved for transient per-node keys and is not yet implemented.");
-        }
-
-        if (scope is not (BlackboardScope.Global or BlackboardScope.Graph))
+        if (scope is not (BlackboardScope.Global or BlackboardScope.Graph or BlackboardScope.Node))
         {
             throw new ArgumentOutOfRangeException(nameof(scope), scope, "Undefined blackboard scope.");
         }

--- a/NxGraph/Blackboards/BlackboardScope.cs
+++ b/NxGraph/Blackboards/BlackboardScope.cs
@@ -18,8 +18,11 @@ public enum BlackboardScope
     Graph = 1,
 
     /// <summary>
-    /// Reserved for transient per-node keys reset at transition boundaries.
-    /// Not yet implemented: <see cref="BlackboardSchema"/> rejects it at construction.
+    /// Transient per-node scratch: values live for one node <i>visit</i> and reset to their
+    /// registered defaults at transition boundaries (success transition, failure-edge reroute,
+    /// run start, reset, resume). In-place retries keep the scratch — same visit, same values.
+    /// The board is machine-owned (auto-created from the graph's declared Node schema) and can
+    /// never be user-bound or shared; it is also not durable — resuming a snapshot resets it.
     /// </summary>
     Node = 2,
 }

--- a/NxGraph/Diagnostics/Validations/GraphValidationOptions.cs
+++ b/NxGraph/Diagnostics/Validations/GraphValidationOptions.cs
@@ -24,4 +24,13 @@ public sealed class GraphValidationOptions(IReadOnlyList<NodeId>? allNodes = nul
     /// Use this to validate that a graph can be executed by the synchronous <c>StateMachine</c> runtime.
     /// </summary>
     public bool StrictSyncOnly { get; set; }
+
+    /// <summary>
+    /// If true, emit an Error when a reachable node holds a sync composite configured with
+    /// <c>ParallelStepMode.RoundPerTick</c> (including a nested sync <c>StateMachine</c> in its
+    /// default RoundPerTick step mode). Such nodes return node-level <c>Result.InProgress</c>,
+    /// which the async runtime rejects mid-run — use this to validate a graph destined for
+    /// the <c>AsyncStateMachine</c>.
+    /// </summary>
+    public bool StrictAsyncCompatible { get; set; }
 }

--- a/NxGraph/Diagnostics/Validations/GraphValidator.cs
+++ b/NxGraph/Diagnostics/Validations/GraphValidator.cs
@@ -178,6 +178,36 @@ public static class GraphValidator
             }
         }
 
+        // 4b) Strict async-compatibility validation: RoundPerTick composites return node-level
+        // InProgress, which the async run loop rejects mid-run.
+        if (options.StrictAsyncCompatible)
+        {
+            foreach (int index in visited)
+            {
+                if (!graph.TryGetNodeByIndex(index, out INode? node) || node is not LogicNode logicNode)
+                {
+                    continue;
+                }
+
+                bool roundPerTick = logicNode.Logic switch
+                {
+                    ParallelState p => p.Mode == ParallelStepMode.RoundPerTick,
+                    DynamicParallelState d => d.Mode == ParallelStepMode.RoundPerTick,
+                    HistoryState h => h.Mode == ParallelStepMode.RoundPerTick,
+                    StateMachine m => m.StepMode == ParallelStepMode.RoundPerTick,
+                    _ => false,
+                };
+
+                if (roundPerTick)
+                {
+                    result.Add(Severity.Error,
+                        "Node holds a RoundPerTick sync composite, which returns node-level InProgress — " +
+                        "the async runtime rejects it mid-run. Use RunToJoin for graphs destined for the " +
+                        "AsyncStateMachine.", node.Id);
+                }
+            }
+        }
+
         // 5) If AllNodes are supplied, check for unreachable nodes and duplicate names
         if (options.AllNodes is { Count: > 0 } all)
         {
@@ -231,6 +261,13 @@ public static class GraphValidator
             result.Add(Severity.Info,
                 "A blackboard schema is declared but no node implements IBlackboardSettable — " +
                 "bound boards will never reach any logic.", graph.Id);
+        }
+
+        if (graph.NodeSchema is not null && !AnyBlackboardSettable(graph))
+        {
+            result.Add(Severity.Info,
+                "A Node-scoped blackboard schema is declared but no node implements IBlackboardSettable — " +
+                "the machine-owned transient board will never reach any logic.", graph.Id);
         }
 
         WarnOnConflictingChildSchemas(graph, graph, result);

--- a/NxGraph/Docs/readme.md
+++ b/NxGraph/Docs/readme.md
@@ -120,21 +120,27 @@ var graph = GraphBuilder
 
 ### Delays & timeouts
 
+Both runtimes have wait and timeout constructs; all timeout overloads take the timeout first.
+
 ```csharp
+// Sync (frame-stepped): WaitFor returns InProgress across ticks; ToWithTimeout checks the
+// deadline between ticks and feeds the unified fault model on overrun.
 var graph = GraphBuilder
     .StartWith(Start)
     .WaitFor(250.Milliseconds())
+    .ToWithTimeout(500.Milliseconds(), () => Result.Success)
     .To(End)
     .Build();
 
-// Timeout wrapper for a long-running state
-var timeoutGraph = GraphBuilder
-    .StartWith(Start).ToWithTimeout(500.Milliseconds(), _=> ResultHelpers.Failure)
-    .To(Release)
+// Async: WaitForAsync awaits a delay; ToWithTimeoutAsync cancels the wrapped logic on overrun.
+var asyncGraph = GraphBuilder
+    .StartWithAsync(StartAsync)
+    .WaitForAsync(250.Milliseconds())
+    .ToWithTimeoutAsync(500.Milliseconds(), async ct => await WorkAsync(ct))
     .Build();
 ```
 
-> `Timeout` cancels the wrapped logic if it exceeds the specified duration and routes to the next node. Prefer passing a linked `CancellationToken` inside your logic for graceful stops.
+> The async timeout cancels the wrapped logic via `CancellationToken` — honor the token inside your logic for graceful stops. The sync timeout cannot interrupt a node mid-execution (no cancellation in the sync runtime); it detects the deadline between ticks. Under `TimeoutBehavior.Fail` (default) a timeout is an ordinary node failure routed through failure edges and retries.
 
 ### Agents (dependency injection)
 
@@ -161,7 +167,9 @@ sm.SetAgent(new AppAgent { Log = logger });
 
 ### Blackboards (scoped shared memory)
 
-Orthogonal to the agent: typed-key working memory with **Global** (one board shared across machines) and **Graph** (one board per machine) scopes. Keys live on a `BlackboardSchema`; nodes access everything through the routed `Bb` context on the state bases — zero-boxing, zero-allocation reads/writes. Avoid `Dictionary<string, object>` contexts (string hashing + boxing per access).
+Orthogonal to the agent: typed-key working memory with **Global** (one board shared across machines), **Graph** (one board per machine), and **Node** (transient per-visit scratch) scopes. Keys live on a `BlackboardSchema`; nodes access everything through the routed `Bb` context on the state bases — zero-boxing, zero-allocation reads/writes. Avoid `Dictionary<string, object>` contexts (string hashing + boxing per access).
+
+Node-scoped boards are machine-owned: declare the schema on the graph via `.WithSchema(...)` and every machine auto-creates its own board — they can never be bound with `WithBlackboard`. Values reset to their registered defaults at every transition boundary (new visit, failure reroute, run start, reset, resume); in-place retries of the same visit keep the scratch. They are not durable: resuming a snapshot restores Node keys to defaults.
 
 ```csharp
 static class Keys

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -46,6 +46,10 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
     public readonly Graph Graph;
     private BlackboardContext _blackboards;
 
+    // Machine-owned transient scratch created from the graph's declared Node schema; null when
+    // none is declared, so board-less graphs pay nothing beyond a null check per transition.
+    private readonly Blackboard? _nodeBoard;
+
     IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Graph];
     private readonly IAsyncStateMachineObserver? _observer;
 
@@ -92,6 +96,11 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
         _reporters = BuildReporterTable(graph);
         _retryPolicies = graph.RetryPolicies;
         _outcomeCodes = graph.OutcomeCodes;
+        if (graph.NodeSchema is { } nodeSchema)
+        {
+            _nodeBoard = new Blackboard(nodeSchema);
+            _blackboards = new BlackboardContext(null, null, _nodeBoard);
+        }
         // _statusInt already initialized to Created at field declaration; no transition needed.
     }
 
@@ -119,6 +128,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
     public void SetBlackboard(Blackboard blackboard)
     {
         Guard.NotNull(blackboard, nameof(blackboard));
+        ThrowIfNodeScoped(blackboard);
         ValidateBoardAgainstDeclarations(blackboard);
         _blackboards = _blackboards.With(blackboard);
         Graph.SetBlackboards(in _blackboards);
@@ -127,7 +137,8 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
     /// <summary>
     /// Receives the whole context from a parent machine's stamping walk (nested composite
     /// path). Validates against this machine's own graph declarations, so a conflicting
-    /// child schema fails loudly at stamp time.
+    /// child schema fails loudly at stamp time. The parent's Node slot is dropped — Node
+    /// boards are per-machine scratch; this machine composes its own from its own graph.
     /// </summary>
     void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
     {
@@ -141,8 +152,24 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             ValidateBoardAgainstDeclarations(globalBoard);
         }
 
-        _blackboards = context;
-        Graph.SetBlackboards(in context);
+        BlackboardContext own = context.WithoutNode();
+        if (_nodeBoard is not null)
+        {
+            own = own.With(_nodeBoard);
+        }
+
+        _blackboards = own;
+        Graph.SetBlackboards(in own);
+    }
+
+    private static void ThrowIfNodeScoped(Blackboard blackboard)
+    {
+        if (blackboard.Schema.Scope == BlackboardScope.Node)
+        {
+            throw new InvalidOperationException(
+                "Node-scoped boards are machine-owned transient scratch and cannot be bound — " +
+                "declare the schema on the graph via WithSchema(...) and each machine creates its own board.");
+        }
     }
 
     private void ValidateBoardAgainstDeclarations(Blackboard blackboard)
@@ -258,6 +285,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
         _current = _initial;
         _attempts = 0;
         _nodeEntered = false;
+        _nodeBoard?.ResetToDefaults();
 
         await TransitionTo(ExecutionStatus.Ready).ConfigureAwait(false);
         return Result.Success;
@@ -313,6 +341,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             _current = _initial;
             _attempts = 0;
             _nodeEntered = false;
+            _nodeBoard?.ResetToDefaults();
             LastOutcome = 0;
             if (_observer is not null)
             {
@@ -503,6 +532,13 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             _nodeEntered = snapshot.NodeEntered;
             _stepping = snapshot.MidRun;
             LastOutcome = snapshot.LastOutcome;
+            // Snapshots are primitives-only: Node-scoped scratch is transient by definition
+            // and comes back as defaults after a resume.
+            _nodeBoard?.ResetToDefaults();
+            // A mid-run resume continues via StepAsync, which skips the run-start init where
+            // the context is normally stamped — stamp here so a fresh machine's own boards
+            // (including the machine-owned Node board) reach the graph's nodes.
+            ApplyExecutionContext();
             // Reconstruct the cached terminal result so RestartPolicy.Ignore reports the
             // restored run's true outcome instead of the field initializer's Success.
             _terminalResult = snapshot.Status is ExecutionStatus.Failed or ExecutionStatus.Cancelled
@@ -561,6 +597,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                     _current = _initial;
                     _attempts = 0;
                     _nodeEntered = false;
+                    _nodeBoard?.ResetToDefaults();
                     LastOutcome = 0;
                     if (_observer is not null)
                     {
@@ -757,6 +794,9 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
 
                     _current = next;
                     _attempts = 0;
+                    // New visit begins: transient Node-scoped scratch resets with the
+                    // attempt counter (in-place retries above keep both).
+                    _nodeBoard?.ResetToDefaults();
 
                     if (_observer is not null)
                     {
@@ -810,6 +850,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
 
                     _current = handler;
                     _attempts = 0;
+                    _nodeBoard?.ResetToDefaults();
 
                     if (_observer is not null)
                     {

--- a/NxGraph/Fsm/HistoryState.cs
+++ b/NxGraph/Fsm/HistoryState.cs
@@ -1,0 +1,120 @@
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
+using NxGraph.Graphs;
+
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// Synchronous counterpart of <see cref="Async.AsyncHistoryState"/>: wraps a child graph as a
+/// composite node with <b>history</b>. When the child fails (or is cancelled) and the parent
+/// later re-enters the composite — e.g. after a failure edge and a <c>Goto</c> back —
+/// execution resumes at the child's last-active node instead of restarting from its start
+/// node. A child that <i>completed</i> restarts from the top on re-entry.
+/// <para>
+/// This is <b>shallow</b> history for the wrapped graph: the resumed node itself restarts
+/// fresh. <b>Deep</b> history falls out of composition — wrap the nested subgraphs inside the
+/// child with their own history composites and each level resumes its own position.
+/// </para>
+/// <para>
+/// <see cref="ParallelStepMode"/> decides how child nodes map onto ticks:
+/// <see cref="ParallelStepMode.RunToJoin"/> completes the child run inside one
+/// <see cref="Execute"/> call (usable from both runtimes via the sync-logic adapter);
+/// <see cref="ParallelStepMode.RoundPerTick"/> advances one child node per call and returns
+/// <see cref="Result.InProgress"/> in between (sync runtime only — the async loop rejects
+/// node-level <see cref="Result.InProgress"/>). A parent suspend between RoundPerTick ticks
+/// does not capture composite-internal position (snapshots are primitives-only); resuming on
+/// a fresh graph restarts the visit.
+/// </para>
+/// </summary>
+public sealed class HistoryState : ILogic, ISubGraphProvider, IBlackboardSettable
+{
+    /// <summary>The wrapped child machine.</summary>
+    public StateMachine Child { get; }
+
+    /// <summary>How child nodes map onto <see cref="Execute"/> calls.</summary>
+    public ParallelStepMode Mode { get; }
+
+    // Visit bookkeeping for RoundPerTick, which spans many Execute() calls. The first call of
+    // a visit applies the history semantics; reaching a terminal result (or an escaping child
+    // exception) clears it so the next visit re-applies them.
+    private bool _inFlight;
+
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Child.Graph];
+
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        // The recursive stamping walk stops at IBlackboardSettable nodes — forward to the
+        // child machine so it validates against its own graph's declarations at stamp time
+        // (uniform with the async history composite and the parallel composites).
+        ((IBlackboardSettable)Child).SetBlackboards(in context);
+    }
+
+    public HistoryState(Graph child, ParallelStepMode mode = ParallelStepMode.RunToJoin)
+    {
+        Guard.NotNull(child, nameof(child));
+        Child = new StateMachine(child);
+        // Manual keeps the child's position (current node) intact after a failure instead of
+        // auto-resetting to the start — that position is exactly the history to resume from.
+        Child.SetRestartPolicy(RestartPolicy.Manual);
+        Mode = mode;
+    }
+
+    public Result Execute()
+    {
+        if (!_inFlight)
+        {
+            ExecutionStatus status = Child.Status;
+            switch (status)
+            {
+                case ExecutionStatus.Failed:
+                case ExecutionStatus.Cancelled:
+                {
+                    // Re-enter at the recorded position: lift the terminal snapshot back into
+                    // a running stepped session with a fresh retry budget for the resumed node.
+                    StateMachineSnapshot history = Child.Suspend();
+                    Child.Resume(history with
+                    {
+                        Status = ExecutionStatus.Running,
+                        MidRun = true,
+                        Attempts = 0,
+                    });
+                    break;
+                }
+                case ExecutionStatus.Completed:
+                    Child.Reset();
+                    break;
+            }
+
+            _inFlight = true;
+        }
+
+        Result result;
+        try
+        {
+            result = Child.Execute();
+            if (Mode == ParallelStepMode.RunToJoin)
+            {
+                while (result == Result.InProgress)
+                {
+                    result = Child.Execute();
+                }
+            }
+        }
+        catch
+        {
+            // The child threw out of its node logic. Drop the visit so the next entry
+            // re-applies the history semantics; the exception itself propagates into the
+            // parent machine's normal failure handling.
+            _inFlight = false;
+            throw;
+        }
+
+        if (!result.IsCompleted)
+        {
+            return Result.InProgress;
+        }
+
+        _inFlight = false;
+        return result;
+    }
+}

--- a/NxGraph/Fsm/ParallelStepMode.cs
+++ b/NxGraph/Fsm/ParallelStepMode.cs
@@ -1,24 +1,30 @@
 namespace NxGraph.Fsm;
 
 /// <summary>
-/// How the sync <see cref="ParallelState"/> spreads its region rounds across
-/// <see cref="Graphs.ILogic.Execute"/> calls (ticks).
+/// How a sync composite spreads its child work across <see cref="Graphs.ILogic.Execute"/>
+/// calls (ticks). Shared by <see cref="ParallelState"/>/<see cref="DynamicParallelState"/>
+/// (a round = one node per still-running region), <see cref="HistoryState"/> and a nested
+/// <see cref="StateMachine"/>'s own <see cref="StateMachine.StepMode"/> (a round = one node
+/// of the child machine).
 /// </summary>
 public enum ParallelStepMode
 {
     /// <summary>
-    /// Loop rounds inside a single <c>Execute()</c> call until every region reaches a
-    /// terminal result — the whole join costs one tick (the caller opts into the work).
-    /// Mirrors <see cref="Async.AsyncParallelState"/>, which always runs to the join.
+    /// Loop rounds inside a single <c>Execute()</c> call until the composite reaches a
+    /// terminal result — the whole join costs one tick (the caller opts into the work; a
+    /// child node that keeps returning <see cref="Result.InProgress"/>, e.g. a multi-tick
+    /// wait, busy-spins for the duration). Mirrors the async composites, which always run
+    /// to the join, so <c>RunToJoin</c> composites are executable from <b>both</b> runtimes
+    /// via the sync-logic adapter.
     /// </summary>
     RunToJoin = 0,
 
     /// <summary>
-    /// Advance every still-running region by exactly one node, then return
-    /// <see cref="Result.InProgress"/> ("re-run me next tick"). Rounds align 1:1 with
-    /// game-loop frames; the join result is returned on the tick the last region
-    /// terminates. Only meaningful under the sync <see cref="StateMachine"/> — the async
-    /// runtime rejects node-level <see cref="Result.InProgress"/>.
+    /// Advance one round per call, then return <see cref="Result.InProgress"/> ("re-run me
+    /// next tick"). Rounds align 1:1 with game-loop frames; the terminal result is returned
+    /// on the tick the composite finishes. Only meaningful under the sync
+    /// <see cref="StateMachine"/> — the async runtime rejects node-level
+    /// <see cref="Result.InProgress"/>.
     /// </summary>
     RoundPerTick = 1,
 }

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -70,6 +70,10 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
     public readonly Graph Graph;
     private BlackboardContext _blackboards;
 
+    // Machine-owned transient scratch created from the graph's declared Node schema; null when
+    // none is declared, so board-less graphs pay nothing beyond a null check per transition.
+    private readonly Blackboard? _nodeBoard;
+
     IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Graph];
     private readonly IStateMachineObserver? _observer;
 
@@ -115,6 +119,21 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
 
     public StateMachine(Graph graph, IStateMachineObserver? observer = null)
     {
+        Guard.NotNull(graph, nameof(graph));
+        // Fail fast on graphs the sync runtime cannot execute, instead of throwing mid-run
+        // after earlier nodes already produced side effects. The validator's StrictSyncOnly
+        // option offers the same check as a lint.
+        for (int i = 0; i < graph.NodeCount; i++)
+        {
+            if (graph.TryGetNodeByIndex(i, out INode? node) && node!.Logic is null)
+            {
+                throw new ArgumentException(
+                    $"Node '{node.Id}' logic ({node.AsyncLogic.GetType().Name}) does not implement ILogic " +
+                    "and cannot be executed by the sync StateMachine. Use the async runtime for this graph, " +
+                    "or author the node with sync logic.", nameof(graph));
+            }
+        }
+
         Graph = graph;
         _observer = observer;
         _initial = graph.StartNode.Id;
@@ -123,6 +142,11 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         _logReportStates = BuildLogReportTable(graph);
         _retryPolicies = graph.RetryPolicies;
         _outcomeCodes = graph.OutcomeCodes;
+        if (graph.NodeSchema is { } nodeSchema)
+        {
+            _nodeBoard = new Blackboard(nodeSchema);
+            _blackboards = new BlackboardContext(null, null, _nodeBoard);
+        }
     }
 
     private int OutcomeOf(NodeId id) => _outcomeCodes is null ? 0 : _outcomeCodes[id.Index];
@@ -151,6 +175,7 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
     public void SetBlackboard(Blackboard blackboard)
     {
         Guard.NotNull(blackboard, nameof(blackboard));
+        ThrowIfNodeScoped(blackboard);
         ValidateBoardAgainstDeclarations(blackboard);
         _blackboards = _blackboards.With(blackboard);
         Graph.SetBlackboards(in _blackboards);
@@ -159,7 +184,8 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
     /// <summary>
     /// Receives the whole context from a parent machine's stamping walk (nested composite
     /// path). Validates against this machine's own graph declarations, so a conflicting
-    /// child schema fails loudly at stamp time.
+    /// child schema fails loudly at stamp time. The parent's Node slot is dropped — Node
+    /// boards are per-machine scratch; this machine composes its own from its own graph.
     /// </summary>
     void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
     {
@@ -173,8 +199,24 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
             ValidateBoardAgainstDeclarations(globalBoard);
         }
 
-        _blackboards = context;
-        Graph.SetBlackboards(in context);
+        BlackboardContext own = context.WithoutNode();
+        if (_nodeBoard is not null)
+        {
+            own = own.With(_nodeBoard);
+        }
+
+        _blackboards = own;
+        Graph.SetBlackboards(in own);
+    }
+
+    private static void ThrowIfNodeScoped(Blackboard blackboard)
+    {
+        if (blackboard.Schema.Scope == BlackboardScope.Node)
+        {
+            throw new InvalidOperationException(
+                "Node-scoped boards are machine-owned transient scratch and cannot be bound — " +
+                "declare the schema on the graph via WithSchema(...) and each machine creates its own board.");
+        }
     }
 
     private void ValidateBoardAgainstDeclarations(Blackboard blackboard)
@@ -214,7 +256,30 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
     /// </list>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void SetResetPolicy(RestartPolicy policy) => _restartPolicy = policy;
+    public void SetRestartPolicy(RestartPolicy policy) => _restartPolicy = policy;
+
+    /// <summary>
+    /// Renamed alias of <see cref="SetRestartPolicy"/>. The sync and async machines shipped
+    /// with two names for the same feature; both now converge on <c>SetRestartPolicy</c>,
+    /// matching the <see cref="RestartPolicy"/> enum.
+    /// </summary>
+    [Obsolete("Renamed to SetRestartPolicy — the same feature carried two names across the sync/async machines. " +
+              "This alias forwards and will not change behavior.")]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetResetPolicy(RestartPolicy policy) => SetRestartPolicy(policy);
+
+    /// <summary>
+    /// How <see cref="State.Execute"/> maps child work onto ticks when this machine is used
+    /// directly or nested as a node: <see cref="ParallelStepMode.RoundPerTick"/> (default)
+    /// advances exactly one node per call; <see cref="ParallelStepMode.RunToJoin"/> loops to
+    /// the terminal result inside one call, which also makes the machine executable as a
+    /// node under the async runtime via the sync-logic adapter.
+    /// </summary>
+    public ParallelStepMode StepMode { get; private set; } = ParallelStepMode.RoundPerTick;
+
+    /// <summary>Sets <see cref="StepMode"/>. Machine-level runtime configuration — like the
+    /// restart policy, it is not part of the graph structure and does not serialize.</summary>
+    public void SetStepMode(ParallelStepMode mode) => StepMode = mode;
 
     /// <summary>
     /// Backwards-compatible switch for the legacy auto-reset behaviour.
@@ -252,6 +317,7 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         _current = _initial;
         _attempts = 0;
         _nodeEntered = false;
+        _nodeBoard?.ResetToDefaults();
         TransitionTo(ExecutionStatus.Ready);
         return Result.Success;
     }
@@ -317,6 +383,13 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         _attempts = snapshot.Attempts;
         _nodeEntered = snapshot.NodeEntered;
         LastOutcome = snapshot.LastOutcome;
+        // Snapshots are primitives-only: Node-scoped scratch is transient by definition
+        // and comes back as defaults after a resume.
+        _nodeBoard?.ResetToDefaults();
+        // A mid-run resume continues via Execute(), which skips the run-start init where
+        // the context is normally stamped — stamp here so a fresh machine's own boards
+        // (including the machine-owned Node board) reach the graph's nodes.
+        ApplyExecutionContext();
         // Reconstruct the cached terminal result so RestartPolicy.Ignore reports the
         // restored run's true outcome instead of the field initializer's Success.
         _terminalResult = snapshot.Status is ExecutionStatus.Failed or ExecutionStatus.Cancelled
@@ -362,6 +435,7 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         _current = _initial;
         _attempts = 0;
         _nodeEntered = false;
+        _nodeBoard?.ResetToDefaults();
         LastOutcome = 0;
         _observer?.OnStateEntered(_current);
         TransitionTo(ExecutionStatus.Running);
@@ -384,6 +458,17 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         try
         {
             Result result = TickInternal();
+            if (StepMode == ParallelStepMode.RunToJoin)
+            {
+                // One-tick mode: complete the whole run inside this Execute() call. A node
+                // that keeps returning InProgress (multi-tick state) busy-spins here — the
+                // caller opted into the cost, mirroring ParallelState.RunToJoin.
+                while (result == Result.InProgress)
+                {
+                    result = TickInternal();
+                }
+            }
+
             if (result == Result.InProgress)
                 return Result.InProgress; // not finished; caller will Execute() again next frame
 
@@ -531,6 +616,9 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
 
                 _current = next;
                 _attempts = 0;
+                // New visit begins: transient Node-scoped scratch resets with the
+                // attempt counter (in-place retries keep both).
+                _nodeBoard?.ResetToDefaults();
 
                 _observer?.OnStateEntered(_current);
 
@@ -571,6 +659,7 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
 
                 _current = handler;
                 _attempts = 0;
+                _nodeBoard?.ResetToDefaults();
 
                 _observer?.OnStateEntered(_current);
 

--- a/NxGraph/Fsm/TimeoutState.cs
+++ b/NxGraph/Fsm/TimeoutState.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics;
+using NxGraph.Compatibility;
+using NxGraph.Graphs;
+
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// Synchronous counterpart of <see cref="Async.AsyncTimeoutState"/>: wraps an
+/// <see cref="ILogic"/> with a deadline. The first <see cref="Execute"/> of a visit records a
+/// <see cref="Stopwatch"/> timestamp; each tick runs the inner logic once. A terminal inner
+/// result passes through and ends the visit. When the inner logic returns
+/// <see cref="Result.InProgress"/> past the deadline, the wrapper produces the timeout
+/// outcome per <see cref="TimeoutBehavior"/>: <see cref="TimeoutBehavior.Fail"/> returns
+/// <see cref="Result.Failure"/> into the unified fault model (failure edges, retries — a
+/// retry starts a fresh deadline); <see cref="TimeoutBehavior.Throw"/> throws
+/// <see cref="TimeoutException"/>.
+/// <para>
+/// Mechanics differ from the async twin by design: the sync runtime has no cancellation, so
+/// the deadline cannot interrupt a node mid-execution — it is detected <b>between</b> ticks,
+/// after the inner logic returns. No CTS, no timers, no allocation on the happy path.
+/// </para>
+/// </summary>
+public sealed class TimeoutState : ILogic
+{
+    private readonly ILogic _inner;
+    private readonly TimeoutBehavior _behavior;
+    private readonly long _timeoutTimestampTicks;
+    private readonly Func<long> _clock;
+    private readonly string _timeoutMessage;
+    private long _startedAt;
+    private bool _inFlight;
+
+    public TimeoutState(ILogic inner, TimeSpan timeout, TimeoutBehavior behavior = TimeoutBehavior.Fail)
+        : this(inner, timeout, behavior, static () => Stopwatch.GetTimestamp())
+    {
+    }
+
+    /// <summary>
+    /// Creates a timeout wrapper over a custom time source. <paramref name="clock"/> must
+    /// return monotonic timestamps in <see cref="Stopwatch.Frequency"/> units — inject scaled
+    /// or paused game time, or a fake clock for deterministic tests.
+    /// </summary>
+    public TimeoutState(ILogic inner, TimeSpan timeout, TimeoutBehavior behavior, Func<long> clock)
+    {
+        _inner = Guard.NotNull(inner, nameof(inner));
+        Guard.NotNull(clock, nameof(clock));
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be > 0.");
+        }
+
+        _behavior = behavior;
+        _timeoutTimestampTicks = (long)(timeout.TotalSeconds * Stopwatch.Frequency);
+        _clock = clock;
+        _timeoutMessage = $"Node timed out after {timeout}.";
+    }
+
+    public Result Execute()
+    {
+        if (!_inFlight)
+        {
+            _startedAt = _clock();
+            _inFlight = true;
+        }
+
+        Result result = _inner.Execute();
+        if (result.IsCompleted)
+        {
+            _inFlight = false;
+            return result;
+        }
+
+        if (_clock() - _startedAt < _timeoutTimestampTicks)
+        {
+            return Result.InProgress;
+        }
+
+        _inFlight = false;
+        if (_behavior == TimeoutBehavior.Throw)
+        {
+            throw new TimeoutException(_timeoutMessage);
+        }
+
+        // A timeout is an ordinary node failure: it participates in the unified fault model —
+        // per-node retry policies and failure edges — exactly like a node returning Failure.
+        return Result.Fail(_timeoutMessage);
+    }
+}

--- a/NxGraph/Fsm/WaitState.cs
+++ b/NxGraph/Fsm/WaitState.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+using NxGraph.Compatibility;
+using NxGraph.Graphs;
+
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// Synchronous counterpart of <see cref="Async.AsyncWait"/>: a multi-tick wait for the
+/// frame-stepped runtime. The first <see cref="Execute"/> of a visit records a
+/// <see cref="Stopwatch"/> timestamp; every tick until the duration elapses returns
+/// <see cref="Result.InProgress"/> ("re-run me next tick"), then <see cref="Result.Success"/>.
+/// Zero or negative durations complete immediately. Completing the wait clears the recorded
+/// timestamp, so re-entering the state starts a fresh wait.
+/// <para>
+/// Sync runtime only: returning node-level <see cref="Result.InProgress"/> across ticks is
+/// the sync machine's multi-frame contract; the async loop rejects it (use
+/// <c>.WaitForAsync(...)</c> there). No timers, no allocation — the wait is a timestamp
+/// comparison per tick.
+/// </para>
+/// </summary>
+public sealed class WaitState : ILogic
+{
+    private readonly long _durationTimestampTicks;
+    private readonly Func<long> _clock;
+    private long _startedAt;
+    private bool _inFlight;
+
+    /// <summary>Creates a state that waits for <paramref name="duration"/> before succeeding.</summary>
+    public WaitState(TimeSpan duration)
+        : this(duration, static () => Stopwatch.GetTimestamp())
+    {
+    }
+
+    /// <summary>
+    /// Creates a wait over a custom time source. <paramref name="clock"/> must return
+    /// monotonic timestamps in <see cref="Stopwatch.Frequency"/> units — inject scaled or
+    /// paused game time, or a fake clock for deterministic tests.
+    /// </summary>
+    public WaitState(TimeSpan duration, Func<long> clock)
+    {
+        _durationTimestampTicks = duration <= TimeSpan.Zero
+            ? 0
+            : (long)(duration.TotalSeconds * Stopwatch.Frequency);
+        _clock = Guard.NotNull(clock, nameof(clock));
+    }
+
+    public Result Execute()
+    {
+        if (_durationTimestampTicks == 0)
+        {
+            return Result.Success;
+        }
+
+        if (!_inFlight)
+        {
+            _startedAt = _clock();
+            _inFlight = true;
+        }
+
+        if (_clock() - _startedAt < _durationTimestampTicks)
+        {
+            return Result.InProgress;
+        }
+
+        _inFlight = false;
+        return Result.Success;
+    }
+}

--- a/NxGraph/Graphs/Graph.cs
+++ b/NxGraph/Graphs/Graph.cs
@@ -58,7 +58,8 @@ public sealed class Graph : INode, IGraph
     public Graph(NodeId id, INode[] nodes, Transition[] edges, IAsyncLogic? logic = null,
         RetryPolicy[]? retryPolicies = null, int[]? outcomeCodes = null,
         IReadOnlyDictionary<int, string>? outcomeNames = null,
-        BlackboardSchema? schema = null, BlackboardSchema? globalSchema = null)
+        BlackboardSchema? schema = null, BlackboardSchema? globalSchema = null,
+        BlackboardSchema? nodeSchema = null)
     {
         if (schema is not null && schema.Scope != BlackboardScope.Graph)
         {
@@ -68,6 +69,11 @@ public sealed class Graph : INode, IGraph
         if (globalSchema is not null && globalSchema.Scope != BlackboardScope.Global)
         {
             throw new ArgumentException("The required global schema must be Global-scoped.", nameof(globalSchema));
+        }
+
+        if (nodeSchema is not null && nodeSchema.Scope != BlackboardScope.Node)
+        {
+            throw new ArgumentException("The transient node schema must be Node-scoped.", nameof(nodeSchema));
         }
 
         Guard.NotNull(nodes, nameof(nodes));
@@ -106,6 +112,7 @@ public sealed class Graph : INode, IGraph
         OutcomeNames = outcomeNames;
         Schema = schema;
         GlobalSchema = globalSchema;
+        NodeSchema = nodeSchema;
         AsyncLogic = logic ?? new EmptyAsyncLogic();
     }
 
@@ -121,6 +128,13 @@ public sealed class Graph : INode, IGraph
     /// The Global-scoped schema this graph requires, or <c>null</c> when it declares none.
     /// </summary>
     public BlackboardSchema? GlobalSchema { get; }
+
+    /// <summary>
+    /// The Node-scoped (transient per-visit) schema declared via <c>WithSchema(...)</c>, or
+    /// <c>null</c> when the graph declares none. Machines auto-create their own board from
+    /// this schema — Node boards are never user-bound, shared, or serialized.
+    /// </summary>
+    public BlackboardSchema? NodeSchema { get; }
 
     /// <summary>
     /// The per-node retry policies indexed by <see cref="NodeId.Index"/>, or <c>null</c>

--- a/NxGraph/Graphs/LogicNode.cs
+++ b/NxGraph/Graphs/LogicNode.cs
@@ -54,6 +54,13 @@ public class LogicNode : INode
     /// "StateMachine" rather than colliding with <see cref="NodeId.Default"/>'s "Default".
     /// </summary>
     public static readonly LogicNode StateMachineMarker = new(NodeId.StateMachineMarker, new EmptyAsyncLogic());
+
+    /// <summary>
+    /// Sentinel for nested <b>sync</b> state-machine owner nodes during (de)serialization —
+    /// the composite-kind discriminator that lets a payload round-trip a sync-nested graph
+    /// back into a sync-runnable one (wire marker string "SyncStateMachine").
+    /// </summary>
+    public static readonly LogicNode SyncStateMachineMarker = new(NodeId.SyncStateMachineMarker, new EmptyAsyncLogic());
 }
 
 /// <summary>

--- a/NxGraph/Graphs/NodeId.cs
+++ b/NxGraph/Graphs/NodeId.cs
@@ -58,6 +58,7 @@ public struct NodeId(int index) : IEquatable<NodeId>
     /// </summary>
     public static NodeId Default => new(-1) { Name = "Default" };
     public static NodeId StateMachineMarker => new(-2) { Name = "StateMachine" };
+    public static NodeId SyncStateMachineMarker => new(-3) { Name = "SyncStateMachine" };
 
     /// <summary>
     /// Represents the start NodeId with an index of 0 and a name of "Start".

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The core package targets `net8.0` and `netstandard2.1`.
 
 - **Simple runtime model**: graphs are backed by dense node/transition arrays and each node has at most one success edge plus an optional failure edge.
 - **Predictable branching**: fan-out happens through director nodes such as `ChoiceState` and `SwitchState<TKey>`.
-- **Authoring ergonomics**: build flows with `StartWithAsync`, `.ToAsync(...)`, `.If(...)`, `.Switch(...)`, `.WaitForAsync(...)`, and `.ToWithTimeoutAsync(...)`.
+- **Authoring ergonomics**: build flows with `StartWithAsync`, `.ToAsync(...)`, `.If(...)`, `.Switch(...)`, `.WaitForAsync(...)`/`.WaitFor(...)`, and `.ToWithTimeoutAsync(...)`/`.ToWithTimeout(...)` — every construct has twins in both runtimes.
 - **Unity-ready sync runtime**: `StateMachine.Execute()` advances exactly one node per call, drop it into `MonoBehaviour.Update()`.
 - **Diagnostics built in**: validate graphs, inspect Mermaid output, attach observers, capture replay logs, or emit `Activity` traces.
 - **Both async and sync**: use `AsyncStateMachine` for async logic and `StateMachine` for sync-only flows.
@@ -235,6 +235,16 @@ var timed = GraphBuilder
 
 With `TimeoutBehavior.Fail` an expired timeout is an ordinary node failure — it consumes the node's retry budget and follows its failure edge like any other `Result.Failure` (see the next section). `TimeoutBehavior.Throw` raises a `TimeoutException` instead.
 
+The sync runtime has frame-stepped twins. `.WaitFor(TimeSpan)` returns `Result.InProgress` across ticks until the duration elapses (a `Stopwatch` timestamp comparison — no timers, no allocation); `.ToWithTimeout(timeout, ...)` runs the wrapped logic once per tick and produces the timeout outcome when it overstays the deadline. Because the sync runtime has no cancellation, the deadline is detected *between* ticks — a node cannot be interrupted mid-execution. Both are sync-only (`WaitFor`'s node-level `InProgress` is rejected by the async loop); all timeout overloads, sync and async, take the timeout first.
+
+```csharp
+var syncFlow = GraphBuilder
+    .StartWith(() => Result.Success)
+    .WaitFor(250.Milliseconds())
+    .ToWithTimeout(2.Seconds(), () => Result.Success)
+    .Build();
+```
+
 ### Error handling: retries and failure edges
 
 A node returning `Result.Failure` flows through one unified fault model: first its per-node `RetryPolicy` re-runs it in place, then its **failure edge** (if any) routes to a handler, and only when neither applies does the machine terminate with `Failure`.
@@ -332,7 +342,7 @@ await fsm.ExecuteAsync();
 
 ### Blackboards (scoped shared memory)
 
-The agent is *who* is acting (an `Enemy`, a workflow context); a **blackboard** is the graph's *working memory*. They are orthogonal channels — both reach nodes simultaneously. Blackboards are typed-key slot stores with two scopes: **Global** (one user-owned board shared by every machine — world state) and **Graph** (one board per machine/entity). Reads and writes are zero-boxing, zero-allocation array accesses.
+The agent is *who* is acting (an `Enemy`, a workflow context); a **blackboard** is the graph's *working memory*. They are orthogonal channels — both reach nodes simultaneously. Blackboards are typed-key slot stores with three scopes: **Global** (one user-owned board shared by every machine — world state), **Graph** (one board per machine/entity), and **Node** (transient per-visit scratch). Reads and writes are zero-boxing, zero-allocation array accesses.
 
 ```csharp
 using NxGraph.Blackboards;
@@ -379,7 +389,23 @@ AsyncStateMachine<Enemy> fsm = graph.ToAsyncStateMachine<Enemy>()
     .WithAgent(enemy);
 ```
 
-> **Anti-pattern:** don't use `Dictionary<string, object>` as a context — every access pays string hashing plus boxing. A `BlackboardKey<T>` slot is a schema-checked array read: type-safe, allocation-free, and serializable (see `BlackboardSerializer` in `NxGraph.Serialization` — each board is its own durability artifact alongside the graph payload and machine snapshot).
+**Node scope (transient per-visit scratch).** A `BlackboardSchema` with `BlackboardScope.Node` declares keys whose values live for one node *visit*: they reset to their registered defaults at every transition boundary (success transition, failure-edge reroute, run start, reset, resume), while in-place retries of the same visit keep the scratch — partial progress across attempts is the point. Node boards are **machine-owned**: declare the schema on the graph with `.WithSchema(...)` and every machine auto-creates its own board (two machines over one shared `Graph` never see each other's scratch); binding one with `WithBlackboard` throws. They are deliberately **not durable** — resuming a `StateMachineSnapshot` restores Node keys to defaults.
+
+```csharp
+static class ScratchKeys
+{
+    public static readonly BlackboardSchema Schema = new("scratch", BlackboardScope.Node);
+    public static readonly BlackboardKey<int> BytesSent = Schema.Register<int>("BytesSent");
+}
+
+// bb.GetRef(ScratchKeys.BytesSent) accumulates across retries of one visit,
+// and is back to 0 when the machine moves to the next node.
+Graph graph = GraphBuilder.StartWith(new UploadState()).Retry(3)
+    .WithSchema(ScratchKeys.Schema)
+    .Build();
+```
+
+> **Anti-pattern:** don't use `Dictionary<string, object>` as a context — every access pays string hashing plus boxing. A `BlackboardKey<T>` slot is a schema-checked array read: type-safe, allocation-free, and serializable (see `BlackboardSerializer` in `NxGraph.Serialization` — each board is its own durability artifact alongside the graph payload and machine snapshot; Node boards are transient and never serialize).
 
 Like the state machines, a blackboard is owned by a single runner at a time (not thread-safe).
 
@@ -431,7 +457,7 @@ public class FsmRunner : MonoBehaviour
             .To(new AlertState()).SetName("Alert")
             .To(new AttackState()).SetName("Attack")
             .ToStateMachine();
-        _fsm.SetResetPolicy(RestartPolicy.Ignore);
+        _fsm.SetRestartPolicy(RestartPolicy.Ignore);
     }
 
     void Update()
@@ -507,6 +533,16 @@ Graph flow = GraphBuilder
     .Build();
 ```
 
+The sync twin takes a `ParallelStepMode` (the same enum the parallel composites use): `.SubGraph(mode, child)` nests the child as a sync `StateMachine` node, `.SubGraph(mode, child, history: true)` builds a sync `HistoryState`. `RunToJoin` completes the child within one tick (and is therefore also runnable under the async machine via the sync-logic adapter); `RoundPerTick` advances one child node per parent tick, sync runtime only:
+
+```csharp
+Graph flow = GraphBuilder
+    .StartWith(() => Result.Success)
+    .SubGraph(ParallelStepMode.RoundPerTick, child, history: true)
+    .To(() => Result.Success)
+    .Build();
+```
+
 **Parallel regions (AND-states).** `.Parallel(regions...)` runs N region graphs via **cooperative interleaving**: each round advances every still-running region by one node, and the composite joins when all regions reach a terminal result — `Success` only if every region succeeded, otherwise `Failure` through the parent's fault model (failure edges, retries). This is deliberately not thread-concurrent, which keeps the hot path allocation-free:
 
 ```csharp
@@ -577,6 +613,7 @@ while (result == Result.InProgress)
 - `Suspend()` is legal between `StepAsync()`/`Execute()` calls of a stepped run, or on an idle/terminal machine; it captures the current node, status, retry attempts, and `LastOutcome`.
 - `Resume(snapshot)` requires a graph that is structurally equivalent (same node indices); re-attach agents/blackboards before continuing.
 - A fully durable flow persists three artifacts: the graph payload (`GraphSerializer`), the snapshot, and one `BlackboardSerializer` payload per bound board — see [Serialization](#serialization).
+- Node-scoped blackboards are transient by definition and are **not** part of the durable flow: `Resume(snapshot)` restores Node keys to their registered defaults — a node suspended mid-visit loses its scratch.
 - Composite-internal progress (positions inside parallel regions or history children) is not part of the flat snapshot; a resumed composite starts its visit fresh.
 
 ### Restart policy
@@ -590,7 +627,7 @@ Control what happens after the machine reaches a terminal status (`Completed`, `
 | `RestartPolicy.Ignore` | Stays terminal; further `Execute()` calls are no-ops that return the cached result |
 
 ```csharp
-fsm.SetResetPolicy(RestartPolicy.Auto);
+fsm.SetRestartPolicy(RestartPolicy.Auto);
 
 // Backwards-compatible alias:
 fsm.SetAutoReset(true);  // maps to RestartPolicy.Auto


### PR DESCRIPTION
- Blackboard Node scope: machine-owned per-visit scratch boards auto-created from Graph.NodeSchema; reset exactly where the attempt counter resets (success transition, failure reroute, run start, Reset, Resume) while in-place retries keep the scratch; parent Node slots stripped at machine boundaries via BlackboardContext.WithoutNode(); transient across Resume.
- Sync composites: .SubGraph(mode, child) nests a sync StateMachine, .SubGraph(mode, child, history: true) builds the sync HistoryState; machine-level StepMode (SetStepMode) with RunToJoin/RoundPerTick.
- Sync timing twins: .WaitFor(TimeSpan) multi-tick wait (WaitState) and .ToWithTimeout(timeout, ...) (TimeoutState), both with an optional Func<long> clock seam; all timeout overloads now take the timeout first (old logic-first orders kept as [Obsolete] forwarding aliases).
- Serialization payload version 3: "SyncStateMachine" wire marker so sync-authored nested machines round-trip sync-runnable.
- StrictAsyncCompatible validator option lints sync-only RoundPerTick composites under the async runtime.
- README: Node scope, sync timing twins, sync SubGraph modes; public API baseline updated.