### PR TITLE
Token runtime with fork/join, stable node UIDs, and serialization payload v6

### DIFF
--- a/NxFSM.Examples/Program.cs
+++ b/NxFSM.Examples/Program.cs
@@ -84,6 +84,8 @@ Console.WriteLine();
 await FeatureExamples.RunAsync();
 Console.WriteLine();
 await FanOutExamples.RunAsync();
+Console.WriteLine();
+await TokenRunnerExamples.RunAsync();
 
 return 0;
 

--- a/NxFSM.Examples/ReadmeExamples/TokenRunnerExamples.cs
+++ b/NxFSM.Examples/ReadmeExamples/TokenRunnerExamples.cs
@@ -1,0 +1,155 @@
+using NxGraph;
+using NxGraph.Authoring;
+using NxGraph.Diagnostics.Export;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxFSM.Examples.ReadmeExamples;
+
+/// <summary>
+/// Runnable version of the README "Token runtime: fork, join, and mid-graph merge" section:
+/// the fork/join diamond on both token machines, an Any-join used as a mid-graph merge, and
+/// an M-of-N quorum whose late leftover absorbs benignly.
+/// </summary>
+public static class TokenRunnerExamples
+{
+    public static async ValueTask RunAsync()
+    {
+        ForkJoinDiamond();
+        await ForkJoinDiamondAsync();
+        AnyJoinMerge();
+        QuorumJoin();
+        MermaidExport();
+    }
+
+    // ── The README snippet: fork(2) → All-join → shared tail ─────────────
+
+    static void ForkJoinDiamond()
+    {
+        Console.WriteLine("=== Token runtime: fork/join diamond (sync) ===");
+
+        JoinState join = new(JoinPolicy.All(2)); // or JoinPolicy.Any (merge), JoinPolicy.Quorum(m)
+
+        Graph graph = GraphBuilder
+            .StartWith(() => Step("Load", "read the save file")).SetName("Load")
+            .ForkTo(
+                b => b.To(() => Step("Audio", "warm the mixer"))   // branch 0 continues the arriving token
+                    .To(join)                                      // converge by routing chains to the same JoinState
+                    .To(() => Step("Ready", "enter the scene")),   // the surviving token carries on past the join
+                b => b.To(() => Step("Terrain", "stream chunks"))  // every other branch spawns a new token
+                    .To(join))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine();   // sync twin; frame-stepped like StateMachine
+        machine.SetStepMode(ParallelStepMode.RunToJoin); // or RoundPerTick (default): one round per Execute()
+        Result result = machine.Execute();
+        Console.WriteLine($"  Joined: {result}");
+    }
+
+    static async ValueTask ForkJoinDiamondAsync()
+    {
+        Console.WriteLine("=== Token runtime: fork/join diamond (async) ===");
+
+        JoinState join = new(JoinPolicy.All(2));
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => StepAsync("Load", "read the save file"))
+            .ForkTo(
+                b => b.ToAsync(_ => StepAsync("Audio", "warm the mixer"))
+                    .To(join)
+                    .ToAsync(_ => StepAsync("Ready", "enter the scene")),
+                b => b.ToAsync(_ => StepAsync("Terrain", "stream chunks"))
+                    .To(join))
+            .Build();
+
+        AsyncTokenMachine asyncMachine = graph.ToAsyncTokenMachine(); // async twin: ExecuteAsync / StepAsync
+        Result result = await asyncMachine.ExecuteAsync();
+        Console.WriteLine($"  Joined: {result}");
+    }
+
+    // ── Any-join: every token passes through — a mid-graph merge point ───
+
+    static void AnyJoinMerge()
+    {
+        Console.WriteLine("=== Token runtime: Any-join as a mid-graph merge ===");
+
+        JoinState merge = new(JoinPolicy.Any);
+        Graph graph = GraphBuilder
+            .StartWith(() => Step("Intake", "accept two work items"))
+            .ForkTo(
+                b => b.To(() => Step("Lane A", "process")).To(merge)
+                    .To(() => Step("Ship", "one shared tail, entered per token")),
+                b => b.To(() => Step("Lane B", "process")).To(merge))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+        Console.WriteLine($"  Merged: {machine.Execute()}");
+    }
+
+    // ── Quorum: fire at 2-of-3; the straggler absorbs benignly at run end ─
+
+    static void QuorumJoin()
+    {
+        Console.WriteLine("=== Token runtime: 2-of-3 quorum join ===");
+
+        JoinState quorum = new(JoinPolicy.Quorum(2));
+        Graph graph = GraphBuilder
+            .StartWith(() => Step("Scatter", "ask three replicas"))
+            .ForkTo(
+                b => b.To(() => Step("Replica 1", "answer fast")).To(quorum)
+                    .To(() => Step("Commit", "two answers are enough")),
+                b => b.To(() => Step("Replica 2", "answer fast")).To(quorum),
+                b => b.To(() => Step("Replica 3", "answer slowly"))
+                    .To(() => Step("Replica 3", "still working..."))
+                    .To(quorum))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+        Console.WriteLine($"  Quorum run: {machine.Execute()} (the late replica's token absorbs)");
+    }
+
+    // ── Mermaid: fork/join render first-class (bars, labeled AND-split edges) ─
+
+    static void MermaidExport()
+    {
+        Console.WriteLine("=== Token runtime: Mermaid export ===");
+
+        JoinState join = new(JoinPolicy.All(2));
+        StateToken start = GraphBuilder.StartWith(() => Result.Success);
+        start.Builder.SetName(start.Id, "Load");
+        ForkToken fork = start.ForkTo(
+            b =>
+            {
+                StateToken audio = b.To(() => Result.Success);
+                audio.Builder.SetName(audio.Id, "Audio");
+                StateToken joined = audio.To(join);
+                joined.Builder.SetName(joined.Id, "Join");
+                StateToken ready = joined.To(() => Result.Success);
+                ready.Builder.SetName(ready.Id, "Ready");
+                return ready;
+            },
+            b =>
+            {
+                StateToken terrain = b.To(() => Result.Success);
+                terrain.Builder.SetName(terrain.Id, "Terrain");
+                return terrain.To(join);
+            });
+        Graph graph = fork.SetName("Fork").Build();
+
+        Console.WriteLine(graph.ToMermaid());
+    }
+
+    static Result Step(string who, string what)
+    {
+        Console.WriteLine($"  {who,-9} {what}");
+        return Result.Success;
+    }
+
+    static ValueTask<Result> StepAsync(string who, string what)
+    {
+        Console.WriteLine($"  {who,-9} {what}");
+        return ResultHelpers.Success;
+    }
+}

--- a/NxGraph.Serialization.Abstraction/IContainerCodec.cs
+++ b/NxGraph.Serialization.Abstraction/IContainerCodec.cs
@@ -1,0 +1,51 @@
+using NxGraph.Graphs;
+
+namespace NxGraph.Serialization.Abstraction;
+
+/// <summary>
+/// Non-generic marker for container codecs — mirrors <see cref="ILogicCodec"/>. A container
+/// codec (payload version 6) serializes custom <see cref="ISubGraphProvider"/> containers
+/// (including <c>AsyncCompositeState</c> subclasses) that the graph serializer has no
+/// built-in recipe for.
+/// </summary>
+public interface IContainerCodec;
+
+/// <summary>
+/// Division of labor with the graph serializer: the <b>serializer</b> owns child-graph
+/// recursion — it walks the container's <see cref="ISubGraphProvider.SubGraphs"/> onto the
+/// wire and rebuilds them on read; the <b>codec</b> owns the reconstruction recipe — its
+/// opaque payload rides in the node's ordinary logic slot (typically a key plus config,
+/// reusing the user's logic-codec keys for any non-graph children).
+/// <para>
+/// Order contract (normative): <see cref="ISubGraphProvider.SubGraphs"/> enumeration order
+/// = wire order = the <c>children</c> order passed to
+/// <see cref="Deserialize"/> — order is identity, exactly as region order is for
+/// <c>RegionMask</c> bits. The rebuilt container must surface the <b>new</b>
+/// <see cref="Graph"/> instances via its own <c>SubGraphs</c> and keep
+/// <c>IBlackboardSettable</c> forwarding — those walks are what agent stamping and
+/// blackboard binding reach (the standing user-container contract). A container that hides
+/// graphs from <c>SubGraphs</c> serializes without them; such a container is already broken
+/// for stamping, and the serializer inherits that contract rather than validating it.
+/// </para>
+/// <para>
+/// <see cref="Serialize"/> receives the <b>unwrapped</b> container (a sync-only container
+/// is unwrapped from its <c>SyncLogicAdapter</c> first); a codec rebuilding a sync-only
+/// container must wrap the result in the public <c>SyncLogicAdapter</c> itself so the node
+/// stays sync-runnable.
+/// </para>
+/// </summary>
+/// <typeparam name="TWire">
+/// The wire type — must match the logic codec's wire type, because the container payload
+/// rides in the same node DTO slot; the graph serializer rejects a mismatch at construction.
+/// </typeparam>
+public interface IContainerCodec<TWire> : IContainerCodec
+{
+    /// <summary>Encodes the reconstruction recipe for <paramref name="container"/> (not its child graphs).</summary>
+    TWire Serialize(ISubGraphProvider container);
+
+    /// <summary>
+    /// Rebuilds the container from its <paramref name="payload"/> and the already-rebuilt
+    /// <paramref name="children"/> (in <c>SubGraphs</c> enumeration order). Must not return null.
+    /// </summary>
+    IAsyncLogic Deserialize(TWire payload, IReadOnlyList<Graph> children);
+}

--- a/NxGraph.Serialization.Abstraction/IRegionSelectorRegistry.cs
+++ b/NxGraph.Serialization.Abstraction/IRegionSelectorRegistry.cs
@@ -1,0 +1,31 @@
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+
+namespace NxGraph.Serialization.Abstraction;
+
+/// <summary>
+/// Maps dynamic-parallel region selectors to stable string keys so they can ride the graph
+/// payload (payload version 6): the write side turns the authored delegate into a key, the
+/// read side turns the key back into a delegate. Delegates themselves cannot ride a wire
+/// payload — the registry is the durable identity for them, analogous to how an
+/// <see cref="ILogicCodec"/> keys node logic.
+/// <para>
+/// Both lookups follow the try-pattern so the serializer owns the error messages and can
+/// include node context. The trust model matches <see cref="ILogicCodec"/>: the registry
+/// restores <i>a</i> delegate for the key — nothing verifies it behaves like the delegate
+/// the graph was authored with; that contract belongs to the user.
+/// </para>
+/// <para>
+/// Delegate identity is reference identity: two lambdas with identical bodies are distinct
+/// delegates, so the graph must be authored with the <b>registered instance</b> for the
+/// write-side lookup to succeed.
+/// </para>
+/// </summary>
+public interface IRegionSelectorRegistry
+{
+    /// <summary>Write side: resolves the key an authored selector was registered under.</summary>
+    bool TryGetKey(Func<BlackboardContext, RegionMask> selector, out string key);
+
+    /// <summary>Read side: resolves the selector registered under a payload key.</summary>
+    bool TryGetSelector(string key, out Func<BlackboardContext, RegionMask> selector);
+}

--- a/NxGraph.Serialization.Tests/CompositeSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/CompositeSerializationTests.cs
@@ -546,7 +546,7 @@ public class CompositeSerializationTests
     // ── Versioning and back-compat ───────────────────────────────────────
 
     [Test]
-    public async Task Composite_payload_carries_version_4_and_the_kind_marker()
+    public async Task Composite_payload_carries_the_current_version_and_the_kind_marker()
     {
         RegistryCodec codec = new();
         Graph region = GraphBuilder
@@ -560,7 +560,7 @@ public class CompositeSerializationTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(json, Does.Contain("\"version\": 4"));
+            Assert.That(json, Does.Contain($"\"version\": {SerializationVersion.Version}"));
             Assert.That(json, Does.Contain("ParallelState"));
         });
     }
@@ -654,10 +654,10 @@ public class CompositeSerializationTests
         });
     }
 
-    // ── What still throws ────────────────────────────────────────────────
+    // ── What still throws (unconfigured options) ─────────────────────────
 
     [Test]
-    public void Async_dynamic_parallel_still_throws_the_targeted_error()
+    public void Async_dynamic_parallel_without_a_selector_registry_throws_the_targeted_error()
     {
         RegistryCodec codec = new();
         Graph region = GraphBuilder
@@ -673,14 +673,14 @@ public class CompositeSerializationTests
             async () => await serializer.ToJsonAsync(graph, new MemoryStream()));
         Assert.Multiple(() =>
         {
-            Assert.That(ex!.Message, Does.Contain("AsyncDynamicParallelState"));
-            Assert.That(ex.Message, Does.Contain("history composites"),
-                "The targeted error names the supported set post-v4.");
+            Assert.That(ex!.Message, Does.Contain("dynamic parallel composite"));
+            Assert.That(ex.Message, Does.Contain("GraphSerializerOptions.SelectorRegistry"),
+                "The targeted error names the option that unlocks the feature.");
         });
     }
 
     [Test]
-    public void Custom_subgraph_provider_containers_still_throw_the_targeted_error()
+    public void Custom_subgraph_provider_containers_without_a_container_codec_throw_the_targeted_error()
     {
         RegistryCodec codec = new();
         Graph child = GraphBuilder
@@ -693,7 +693,12 @@ public class CompositeSerializationTests
         GraphSerializer serializer = new(codec);
         NotSupportedException? ex = Assert.ThrowsAsync<NotSupportedException>(
             async () => await serializer.ToJsonAsync(graph, new MemoryStream()));
-        Assert.That(ex!.Message, Does.Contain("AsyncCompositeState"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Message, Does.Contain("AsyncCompositeState"));
+            Assert.That(ex.Message, Does.Contain("GraphSerializerOptions.ContainerCodec"),
+                "The targeted error names the option that unlocks the feature.");
+        });
     }
 
     // ── Agent and blackboard walks on deserialized composites ───────────

--- a/NxGraph.Serialization.Tests/ContainerCodecSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/ContainerCodecSerializationTests.cs
@@ -1,0 +1,477 @@
+using System.Text;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// Payload version 6, part C: custom <see cref="ISubGraphProvider"/> containers (including
+/// <see cref="AsyncCompositeState"/> subclasses) on the wire via a user container codec. The
+/// serializer owns child-graph recursion (SubGraphs enumeration order = wire order = the
+/// children order handed to the codec); the codec owns the reconstruction recipe, riding in
+/// the node's ordinary logic slot. Container claims are markerless — the claim itself routes
+/// the payload.
+/// </summary>
+[TestFixture]
+[Category("serialization")]
+public class ContainerCodecSerializationTests
+{
+    // ── Test doubles ─────────────────────────────────────────────────────
+
+    private interface IKeyed
+    {
+        string Key { get; }
+    }
+
+    private sealed class KeyedState(string key, Func<Result> body) : IAsyncLogic, ILogic, IKeyed
+    {
+        public string Key => key;
+        public Result Execute() => body();
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => new(body());
+    }
+
+    private sealed class TestAgent;
+
+    private sealed class KeyedAgentState(string key) : IAsyncLogic, ILogic, IKeyed, IAgentSettable<TestAgent>
+    {
+        public string Key => key;
+        public TestAgent? Received;
+        public void SetAgent(TestAgent agent) => Received = agent;
+        public Result Execute() => Result.Success;
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => ResultHelpers.Success;
+    }
+
+    private sealed class KeyedBlackboardWriterState(string key, BlackboardKey<int> bbKey, int value)
+        : IAsyncLogic, ILogic, IKeyed, IBlackboardSettable
+    {
+        private BlackboardContext _bb;
+        public string Key => key;
+        void IBlackboardSettable.SetBlackboards(in BlackboardContext context) => _bb = context;
+
+        public Result Execute()
+        {
+            _bb.Set(bbKey, value);
+            return Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => new(Execute());
+    }
+
+    private sealed class RegistryCodec : ILogicTextCodec
+    {
+        private readonly Dictionary<string, IAsyncLogic> _byKey = new();
+
+        public T Register<T>(string key, T logic) where T : IAsyncLogic
+        {
+            _byKey[key] = logic;
+            return logic;
+        }
+
+        public KeyedState Log(string key, List<string> log)
+            => Register(key, new KeyedState(key, () =>
+            {
+                log.Add(key);
+                return Result.Success;
+            }));
+
+        public string Serialize(IAsyncLogic data) => ((IKeyed)data).Key;
+
+        public IAsyncLogic Deserialize(string s) => _byKey.TryGetValue(s, out IAsyncLogic? logic)
+            ? logic
+            : throw new InvalidOperationException($"Unknown logic key '{s}'.");
+    }
+
+    /// <summary>
+    /// A user container: runs its child machines sequentially, surfaces their graphs via
+    /// <see cref="ISubGraphProvider"/> (enumeration order = region order), and forwards the
+    /// blackboard context — the standing user-container contract the rebuilt instance must
+    /// keep for agent stamping and blackboard walks to reach its children.
+    /// </summary>
+    private sealed class SequentialContainer : IAsyncLogic, ISubGraphProvider, IBlackboardSettable
+    {
+        private readonly AsyncStateMachine[] _children;
+
+        public SequentialContainer(params Graph[] children)
+        {
+            _children = new AsyncStateMachine[children.Length];
+            for (int i = 0; i < children.Length; i++)
+            {
+                _children[i] = new AsyncStateMachine(children[i]);
+            }
+        }
+
+        public IEnumerable<Graph> SubGraphs
+        {
+            get
+            {
+                foreach (AsyncStateMachine child in _children)
+                {
+                    yield return child.Graph;
+                }
+            }
+        }
+
+        void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+        {
+            foreach (AsyncStateMachine child in _children)
+            {
+                ((IBlackboardSettable)child).SetBlackboards(in context);
+            }
+        }
+
+        public async ValueTask<Result> ExecuteAsync(CancellationToken ct = default)
+        {
+            foreach (AsyncStateMachine child in _children)
+            {
+                Result result = await child.ExecuteAsync(ct).ConfigureAwait(false);
+                if (!result.IsSuccess)
+                {
+                    return result;
+                }
+            }
+
+            return Result.Success;
+        }
+    }
+
+    /// <summary>A container with no child graphs: it wraps a plain (non-graph) logic instance.</summary>
+    private sealed class LeafContainer(IAsyncLogic inner) : IAsyncLogic, ISubGraphProvider
+    {
+        public IAsyncLogic Inner => inner;
+        public IEnumerable<Graph> SubGraphs => [];
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => inner.ExecuteAsync(ct);
+    }
+
+    /// <summary>
+    /// An <see cref="AsyncCompositeState"/> subclass. The protected <c>Child</c> accessor is
+    /// how a user codec reads back what the primary constructor captured.
+    /// </summary>
+    private sealed class WrapperComposite(IAsyncLogic child) : AsyncCompositeState(child)
+    {
+        public IAsyncLogic ChildForCodec => Child;
+    }
+
+    /// <summary>
+    /// Test container codec: the payload is a small "<c>shape</c>" recipe string; non-graph
+    /// children reuse the logic codec's keys, graph children are rebuilt by the serializer
+    /// and handed over in wire order.
+    /// </summary>
+    private sealed class TestContainerCodec(RegistryCodec logicCodec) : IContainerTextCodec
+    {
+        public string Serialize(ISubGraphProvider container) => container switch
+        {
+            SequentialContainer => "seq",
+            LeafContainer leaf => "leaf:" + logicCodec.Serialize(leaf.Inner),
+            WrapperComposite => "wrapper",
+            _ => throw new NotSupportedException($"Unknown container type '{container.GetType().Name}'.")
+        };
+
+        public IAsyncLogic Deserialize(string payload, IReadOnlyList<Graph> children)
+        {
+            if (payload == "seq")
+            {
+                return new SequentialContainer(children.ToArray());
+            }
+
+            if (payload.StartsWith("leaf:", StringComparison.Ordinal))
+            {
+                return new LeafContainer(logicCodec.Deserialize(payload["leaf:".Length..]));
+            }
+
+            if (payload == "wrapper")
+            {
+                return new WrapperComposite(new AsyncStateMachine(children[0]));
+            }
+
+            throw new InvalidOperationException($"Unknown container payload '{payload}'.");
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static async Task<Graph> RoundTrip(GraphSerializer serializer, Graph graph, bool binary)
+    {
+        await using MemoryStream stream = new();
+        if (binary)
+        {
+            await serializer.ToBinaryAsync(graph, stream);
+            stream.Position = 0;
+            return await serializer.FromBinaryAsync(stream);
+        }
+
+        await serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+        return await serializer.FromJsonAsync(stream);
+    }
+
+    private static async Task<Graph> FromJson(GraphSerializer serializer, string json)
+    {
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        return await serializer.FromJsonAsync(source);
+    }
+
+    private static GraphSerializer SerializerWith(RegistryCodec codec)
+        => new(codec, new GraphSerializerOptions { ContainerCodec = new TestContainerCodec(codec) });
+
+    // ── Round-trips ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Custom_container_with_two_children_roundtrips_with_order_pinned([Values] bool binary)
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+
+        Graph c0 = GraphBuilder.StartWithAsync(codec.Log("c0", log)).Build();
+        Graph c1 = GraphBuilder.StartWithAsync(codec.Log("c1", log)).Build();
+        Graph parent = GraphBuilder
+            .StartWithAsync(codec.Log("p0", log))
+            .ToAsync(new SequentialContainer(c0, c1))
+            .Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec), parent, binary);
+        LogicNode containerNode = (LogicNode)rebuilt.GetNodeByIndex(1);
+        Result result = await rebuilt.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(containerNode.AsyncLogic, Is.InstanceOf<SequentialContainer>(),
+                "The container claim routed the payload to the container codec.");
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "p0", "c0", "c1" }),
+                "SubGraphs enumeration order = wire order = Deserialize children order.");
+        });
+    }
+
+    [Test]
+    public async Task Zero_subgraph_container_with_a_non_graph_child_roundtrips([Values] bool binary)
+    {
+        // The container has no child graphs at all; its payload encodes the non-graph child
+        // via the logic codec's key ("leaf:inner").
+        List<string> log = [];
+        RegistryCodec codec = new();
+        KeyedState inner = codec.Log("inner", log);
+
+        Graph parent = GraphBuilder
+            .StartWithAsync(new LeafContainer(inner))
+            .Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec), parent, binary);
+        LogicNode node = (LogicNode)rebuilt.StartNode;
+        Result result = await rebuilt.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.AsyncLogic, Is.InstanceOf<LeafContainer>());
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "inner" }));
+        });
+    }
+
+    [Test]
+    public async Task AsyncCompositeState_subclass_roundtrips_through_a_user_codec_reading_Child(
+        [Values] bool binary)
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+        Graph child = GraphBuilder.StartWithAsync(codec.Log("c0", log)).Build();
+
+        Graph parent = GraphBuilder
+            .StartWithAsync(new WrapperComposite(new AsyncStateMachine(child)))
+            .Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec), parent, binary);
+        LogicNode node = (LogicNode)rebuilt.StartNode;
+        Result result = await rebuilt.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.AsyncLogic, Is.InstanceOf<WrapperComposite>());
+            Assert.That(((WrapperComposite)node.AsyncLogic).ChildForCodec, Is.InstanceOf<AsyncStateMachine>(),
+                "The subclass read the protected Child accessor to rebuild the wrapped machine.");
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "c0" }));
+        });
+    }
+
+    // ── Agent and blackboard walks on rebuilt containers ─────────────────
+
+    [Test]
+    public async Task Agent_stamping_reaches_nodes_inside_rebuilt_container_children()
+    {
+        RegistryCodec codec = new();
+        KeyedAgentState agentState = codec.Register("agent", new KeyedAgentState("agent"));
+
+        Graph child = GraphBuilder.StartWithAsync(agentState).Build();
+        Graph parent = GraphBuilder.StartWithAsync(new SequentialContainer(child)).Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec), parent, binary: false);
+
+        TestAgent agent = new();
+        rebuilt.SetAgent(agent);
+
+        Assert.That(agentState.Received, Is.SameAs(agent),
+            "The rebuilt container surfaces its new child graphs via SubGraphs, so the agent walk reaches them.");
+    }
+
+    [Test]
+    public async Task Blackboard_forwarding_reaches_rebuilt_container_children()
+    {
+        BlackboardSchema schema = new("test");
+        BlackboardKey<int> key = schema.Register<int>("value");
+
+        RegistryCodec codec = new();
+        Graph child = GraphBuilder
+            .StartWithAsync(codec.Register("writer", new KeyedBlackboardWriterState("writer", key, 42)))
+            .Build();
+        Graph parent = GraphBuilder.StartWithAsync(new SequentialContainer(child)).Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec), parent, binary: false);
+
+        Blackboard board = new(schema);
+        Result result = await rebuilt.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(board.Get(key), Is.EqualTo(42),
+                "The rebuilt container keeps IBlackboardSettable forwarding into its children.");
+        });
+    }
+
+    // ── Setup and spoof failures ─────────────────────────────────────────
+
+    private sealed class BinaryContainerCodec : IContainerBinaryCodec
+    {
+        public ReadOnlyMemory<byte> Serialize(ISubGraphProvider container) => ReadOnlyMemory<byte>.Empty;
+        public IAsyncLogic Deserialize(ReadOnlyMemory<byte> payload, IReadOnlyList<Graph> children)
+            => throw new NotSupportedException();
+    }
+
+    [Test]
+    public void Wire_type_mismatch_between_logic_and_container_codec_fails_at_construction()
+    {
+        RegistryCodec textLogicCodec = new();
+        Assert.Throws<ArgumentException>(() => _ = new GraphSerializer(textLogicCodec,
+                new GraphSerializerOptions { ContainerCodec = new BinaryContainerCodec() }),
+            "A text logic codec cannot pair with a binary container codec — same node DTO slot.");
+    }
+
+    [Test]
+    public void Container_claim_with_no_codec_configured_throws_the_targeted_error()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "seq" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [], "composites": [],
+              "containers": [ { "ownerIndex": 0, "children": [] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        RegistryCodec codec = new();
+        GraphSerializer serializer = new(codec);
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(serializer, json));
+        Assert.That(ex!.Message, Does.Contain("GraphSerializerOptions.ContainerCodec"));
+    }
+
+    [Test]
+    public void A_claim_added_onto_an_ordinary_node_routes_its_payload_to_the_container_codec_which_rejects_it()
+    {
+        // Spoof direction 1: a crafted claim on an ordinary node routes the ordinary payload
+        // to the container codec, which fails loud on the unknown recipe.
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "a" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [], "composites": [],
+              "containers": [ { "ownerIndex": 0, "children": [] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        RegistryCodec codec = new();
+        codec.Register("a", new KeyedState("a", () => Result.Success));
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(SerializerWith(codec), json));
+        Assert.That(ex!.Message, Does.Contain("Unknown container payload 'a'"));
+    }
+
+    [Test]
+    public void A_deleted_claim_routes_the_container_payload_to_the_logic_codec_which_rejects_it()
+    {
+        // Spoof direction 2: with the claim removed, the container recipe string is ordinary
+        // payload for the logic codec, which fails loud on the unknown key.
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "seq" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [], "composites": [],
+              "containers": [],
+              "name": null, "index": -1
+            }
+            """;
+
+        RegistryCodec codec = new();
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(SerializerWith(codec), json));
+        Assert.That(ex!.Message, Does.Contain("Unknown logic key 'seq'"));
+    }
+
+    [Test]
+    public void Out_of_range_container_owner_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "a" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [], "composites": [],
+              "containers": [ { "ownerIndex": 5, "children": [] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        RegistryCodec codec = new();
+        codec.Register("a", new KeyedState("a", () => Result.Success));
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(SerializerWith(codec), json));
+        Assert.That(ex!.Message, Does.Contain("out of range"));
+    }
+
+    [Test]
+    public void Null_from_the_container_codec_is_guarded()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "null" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [], "composites": [],
+              "containers": [ { "ownerIndex": 0, "children": [] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        RegistryCodec codec = new();
+        GraphSerializer serializer = new(codec,
+            new GraphSerializerOptions { ContainerCodec = new NullReturningContainerCodec() });
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(serializer, json));
+        Assert.That(ex!.Message, Does.Contain("returned null"));
+    }
+
+    private sealed class NullReturningContainerCodec : IContainerTextCodec
+    {
+        public string Serialize(ISubGraphProvider container) => "null";
+        public IAsyncLogic Deserialize(string payload, IReadOnlyList<Graph> children) => null!;
+    }
+}

--- a/NxGraph.Serialization.Tests/DynamicParallelSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/DynamicParallelSerializationTests.cs
@@ -1,0 +1,576 @@
+using System.Text;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// Payload version 6, part B: dynamic parallel composites on the wire. Region graphs and step
+/// mode ride like the static kinds; the selector delegate rides as a named key resolved
+/// through <see cref="RegionSelectorRegistry"/>. Covers selector re-resolution and
+/// blackboard-driven selection after the trip, step-mode preservation, vacuous joins, region
+/// order, nesting, agent stamping, and the negative fixtures for keys and claims.
+/// </summary>
+[TestFixture]
+[Category("serialization")]
+public class DynamicParallelSerializationTests
+{
+    // ── Test doubles (CompositeSerializationTests pattern) ───────────────
+
+    private interface IKeyed
+    {
+        string Key { get; }
+    }
+
+    private sealed class KeyedState(string key, Func<Result> body) : IAsyncLogic, ILogic, IKeyed
+    {
+        public string Key => key;
+        public Result Execute() => body();
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => new(body());
+    }
+
+    private sealed class TestAgent;
+
+    private sealed class KeyedAgentState(string key) : IAsyncLogic, ILogic, IKeyed, IAgentSettable<TestAgent>
+    {
+        public string Key => key;
+        public TestAgent? Received;
+        public void SetAgent(TestAgent agent) => Received = agent;
+        public Result Execute() => Result.Success;
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => ResultHelpers.Success;
+    }
+
+    private sealed class KeyedBlackboardWriterState(string key, BlackboardKey<int> bbKey, int value)
+        : IAsyncLogic, ILogic, IKeyed, IBlackboardSettable
+    {
+        private BlackboardContext _bb;
+        public string Key => key;
+        void IBlackboardSettable.SetBlackboards(in BlackboardContext context) => _bb = context;
+
+        public Result Execute()
+        {
+            _bb.Set(bbKey, value);
+            return Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => new(Execute());
+    }
+
+    private sealed class RegistryCodec : ILogicTextCodec
+    {
+        private readonly Dictionary<string, IAsyncLogic> _byKey = new();
+
+        public T Register<T>(string key, T logic) where T : IAsyncLogic
+        {
+            _byKey[key] = logic;
+            return logic;
+        }
+
+        public KeyedState Log(string key, List<string> log)
+            => Register(key, new KeyedState(key, () =>
+            {
+                log.Add(key);
+                return Result.Success;
+            }));
+
+        public string Serialize(IAsyncLogic data) => ((IKeyed)data).Key;
+
+        public IAsyncLogic Deserialize(string s) => _byKey.TryGetValue(s, out IAsyncLogic? logic)
+            ? logic
+            : throw new InvalidOperationException($"Unknown logic key '{s}'.");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static async Task<Graph> RoundTrip(GraphSerializer serializer, Graph graph, bool binary)
+    {
+        await using MemoryStream stream = new();
+        if (binary)
+        {
+            await serializer.ToBinaryAsync(graph, stream);
+            stream.Position = 0;
+            return await serializer.FromBinaryAsync(stream);
+        }
+
+        await serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+        return await serializer.FromJsonAsync(stream);
+    }
+
+    private static Result RunSyncToCompletion(StateMachine machine, out int inProgressTicks)
+    {
+        inProgressTicks = 0;
+        Result result = Result.InProgress;
+        for (int guard = 0; guard < 1_000 && result == Result.InProgress; guard++)
+        {
+            result = machine.Execute();
+            if (result == Result.InProgress)
+            {
+                inProgressTicks++;
+            }
+        }
+
+        return result;
+    }
+
+    private static async Task<Graph> FromJson(GraphSerializer serializer, string json)
+    {
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        return await serializer.FromJsonAsync(source);
+    }
+
+    private static GraphSerializer SerializerWith(RegistryCodec codec, RegionSelectorRegistry registry)
+        => new(codec, new GraphSerializerOptions { SelectorRegistry = registry });
+
+    // ── Round-trips with behavioral equivalence ──────────────────────────
+
+    [Test]
+    public async Task Async_dynamic_parallel_roundtrips_and_reselects_via_the_registry([Values] bool binary)
+    {
+        BlackboardSchema schema = new("dyn");
+        BlackboardKey<int> which = schema.Register<int>("which");
+
+        List<string> log = [];
+        RegistryCodec codec = new();
+        RegionSelectorRegistry registry = new();
+        Func<BlackboardContext, RegionMask> selector =
+            registry.Register("pick-one", ctx => RegionMask.Bit(ctx.Get(which)));
+
+        Graph r0 = GraphBuilder.StartWithAsync(codec.Log("r0", log)).Build();
+        Graph r1 = GraphBuilder.StartWithAsync(codec.Log("r1", log)).Build();
+        Graph parent = GraphBuilder.Start().Parallel(selector, r0, r1).Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec, registry), parent, binary);
+        LogicNode composite = (LogicNode)rebuilt.StartNode;
+
+        Blackboard board = new(schema);
+        board.Set(which, 1);
+        Result result = await rebuilt.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(composite.AsyncLogic, Is.InstanceOf<AsyncDynamicParallelState>(),
+                "The dynamic marker must rebuild an AsyncDynamicParallelState.");
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "r1" }),
+                "The re-resolved selector read the blackboard and selected only region 1 — " +
+                "mask bit i still targets original region i.");
+        });
+    }
+
+    [Test]
+    public async Task Sync_dynamic_parallel_RoundPerTick_survives_the_trip_and_still_spreads_rounds(
+        [Values] bool binary)
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+        RegionSelectorRegistry registry = new();
+        Func<BlackboardContext, RegionMask> selector = registry.Register("all", _ => RegionMask.All(2));
+
+        Graph rA = GraphBuilder
+            .StartWith((ILogic)codec.Log("a0", log))
+            .To((ILogic)codec.Log("a1", log))
+            .Build();
+        Graph rB = GraphBuilder
+            .StartWith((ILogic)codec.Log("b0", log))
+            .To((ILogic)codec.Log("b1", log))
+            .Build();
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RoundPerTick, selector, rA, rB)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec, registry), parent, binary);
+        LogicNode composite = (LogicNode)rebuilt.StartNode;
+
+        Assert.That(composite.Logic, Is.InstanceOf<DynamicParallelState>(),
+            "The sync dynamic marker must rebuild a sync DynamicParallelState behind the adapter.");
+        Assert.That(((DynamicParallelState)composite.Logic!).Mode, Is.EqualTo(ParallelStepMode.RoundPerTick),
+            "The step mode is structure and must survive the trip.");
+
+        Result result = RunSyncToCompletion(new StateMachine(rebuilt), out int inProgressTicks);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(inProgressTicks, Is.GreaterThanOrEqualTo(1),
+                "RoundPerTick still spreads rounds across Execute() calls after the trip.");
+            Assert.That(log, Is.EqualTo(new[] { "a0", "b0", "a1", "b1" }));
+        });
+    }
+
+    [Test]
+    public async Task Sync_dynamic_parallel_RunToJoin_roundtrips_and_joins_in_one_tick()
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+        RegionSelectorRegistry registry = new();
+        Func<BlackboardContext, RegionMask> selector = registry.Register("all", _ => RegionMask.All(2));
+
+        Graph rA = GraphBuilder.StartWith((ILogic)codec.Log("a0", log)).Build();
+        Graph rB = GraphBuilder.StartWith((ILogic)codec.Log("b0", log)).Build();
+        Graph parent = GraphBuilder
+            .Start()
+            .Parallel(ParallelStepMode.RunToJoin, selector, rA, rB)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec, registry), parent, binary: false);
+        LogicNode composite = (LogicNode)rebuilt.StartNode;
+
+        Assert.That(((DynamicParallelState)composite.Logic!).Mode, Is.EqualTo(ParallelStepMode.RunToJoin));
+
+        Result result = RunSyncToCompletion(new StateMachine(rebuilt), out _);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "a0", "b0" }));
+        });
+    }
+
+    [Test]
+    public async Task Empty_mask_selector_is_a_vacuous_join_after_the_trip()
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+        RegionSelectorRegistry registry = new();
+        Func<BlackboardContext, RegionMask> selector = registry.Register("none", _ => RegionMask.None);
+
+        Graph r0 = GraphBuilder.StartWithAsync(codec.Log("r0", log)).Build();
+        Graph parent = GraphBuilder.Start().Parallel(selector, r0).Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec, registry), parent, binary: false);
+        Result result = await rebuilt.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.Empty, "No region was stepped — the empty mask is a vacuous join.");
+        });
+    }
+
+    // ── Nesting both ways ────────────────────────────────────────────────
+
+    [Test]
+    public async Task Dynamic_parallel_containing_a_nested_machine_roundtrips([Values] bool binary)
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+        RegionSelectorRegistry registry = new();
+        Func<BlackboardContext, RegionMask> selector = registry.Register("all", _ => RegionMask.All(1));
+
+        Graph grandchild = GraphBuilder.StartWithAsync(codec.Log("g0", log)).Build();
+        Graph region = GraphBuilder
+            .StartWithAsync(codec.Log("r0", log))
+            .SubGraph(grandchild)
+            .Build();
+        Graph parent = GraphBuilder.Start().Parallel(selector, region).Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec, registry), parent, binary);
+        Result result = await rebuilt.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "r0", "g0" }));
+        });
+    }
+
+    [Test]
+    public async Task Static_composite_containing_a_dynamic_parallel_region_roundtrips()
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+        RegionSelectorRegistry registry = new();
+        Func<BlackboardContext, RegionMask> selector = registry.Register("all", _ => RegionMask.All(1));
+
+        Graph inner = GraphBuilder.StartWithAsync(codec.Log("i0", log)).Build();
+        Graph region = GraphBuilder.Start().Parallel(selector, inner).Build();
+        Graph parent = GraphBuilder.Start().Parallel(region).Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec, registry), parent, binary: false);
+        Result result = await rebuilt.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "i0" }));
+        });
+    }
+
+    [Test]
+    public async Task Agent_stamping_reaches_nodes_inside_rebuilt_dynamic_parallel_regions()
+    {
+        RegistryCodec codec = new();
+        RegionSelectorRegistry registry = new();
+        Func<BlackboardContext, RegionMask> selector = registry.Register("all", _ => RegionMask.All(1));
+        KeyedAgentState agentState = codec.Register("agent", new KeyedAgentState("agent"));
+
+        Graph region = GraphBuilder.StartWithAsync(agentState).Build();
+        Graph parent = GraphBuilder.Start().Parallel(selector, region).Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec, registry), parent, binary: false);
+
+        TestAgent agent = new();
+        rebuilt.SetAgent(agent);
+
+        Assert.That(agentState.Received, Is.SameAs(agent),
+            "The ISubGraphProvider walk must reach nodes inside the rebuilt dynamic composite's regions.");
+    }
+
+    [Test]
+    public async Task Blackboard_forwarding_reaches_nodes_inside_rebuilt_dynamic_parallel_regions()
+    {
+        BlackboardSchema schema = new("dyn-fwd");
+        BlackboardKey<int> key = schema.Register<int>("value");
+
+        RegistryCodec codec = new();
+        RegionSelectorRegistry registry = new();
+        Func<BlackboardContext, RegionMask> selector = registry.Register("all", _ => RegionMask.All(1));
+
+        Graph region = GraphBuilder
+            .StartWithAsync(codec.Register("writer", new KeyedBlackboardWriterState("writer", key, 7)))
+            .Build();
+        Graph parent = GraphBuilder.Start().Parallel(selector, region).Build();
+
+        Graph rebuilt = await RoundTrip(SerializerWith(codec, registry), parent, binary: false);
+
+        Blackboard board = new(schema);
+        Result result = await rebuilt.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(board.Get(key), Is.EqualTo(7),
+                "The rebuilt dynamic composite keeps IBlackboardSettable forwarding into its region machines.");
+        });
+    }
+
+    // ── Write-side failures ──────────────────────────────────────────────
+
+    [Test]
+    public void Unregistered_delegate_on_write_throws_the_targeted_error()
+    {
+        RegistryCodec codec = new();
+        RegionSelectorRegistry registry = new();
+        registry.Register("other", _ => RegionMask.None);
+
+        Graph region = GraphBuilder
+            .StartWithAsync(codec.Register("r0", new KeyedState("r0", () => Result.Success)))
+            .Build();
+        Graph graph = GraphBuilder.Start().Parallel(_ => RegionMask.Bit(0), region).Build();
+
+        GraphSerializer serializer = SerializerWith(codec, registry);
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await serializer.ToJsonAsync(graph, new MemoryStream()));
+        Assert.That(ex!.Message, Does.Contain("same delegate instance"),
+            "The error tells the user to author the graph with the registered delegate instance.");
+    }
+
+    [Test]
+    public void Duplicate_registry_key_or_delegate_fails_at_setup()
+    {
+        RegionSelectorRegistry registry = new();
+        Func<BlackboardContext, RegionMask> selector = registry.Register("a", _ => RegionMask.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentException>(() => registry.Register("a", _ => RegionMask.None),
+                "Duplicate key fails at registration, not at save time.");
+            Assert.Throws<ArgumentException>(() => registry.Register("b", selector),
+                "Duplicate delegate fails at registration, not at save time.");
+        });
+    }
+
+    // ── Read-side failures and spoof defense ─────────────────────────────
+
+    private const string MinimalChildJson = """
+        { "version": 6,
+          "nodes": [ { "$type": "txt", "index": 0, "name": "c0", "logic": "c0" } ],
+          "transitions": [ { "destination": -1 } ],
+          "subGraphs": [], "composites": [], "name": null, "index": -1 }
+        """;
+
+    private static RegistryCodec CodecWithBasics()
+    {
+        RegistryCodec codec = new();
+        codec.Register("a", new KeyedState("a", () => Result.Success));
+        codec.Register("c0", new KeyedState("c0", () => Result.Success));
+        return codec;
+    }
+
+    [Test]
+    public void Dynamic_kind_without_a_selector_key_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "DynamicParallelState" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "composites": [ { "ownerIndex": 0, "kind": 4, "mode": 0, "children": [ {{MinimalChildJson}} ] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        RegionSelectorRegistry registry = new();
+        registry.Register("any", _ => RegionMask.None);
+        GraphSerializer serializer = SerializerWith(CodecWithBasics(), registry);
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(serializer, json));
+        Assert.That(ex!.Message, Does.Contain("must carry a selector key"));
+    }
+
+    [Test]
+    public void Selector_key_smuggled_onto_a_static_kind_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "ParallelState" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "composites": [ { "ownerIndex": 0, "kind": 2, "mode": 0, "selectorKey": "sneaky",
+                                "children": [ {{MinimalChildJson}} ] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        RegionSelectorRegistry registry = new();
+        registry.Register("sneaky", _ => RegionMask.None);
+        GraphSerializer serializer = SerializerWith(CodecWithBasics(), registry);
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(serializer, json));
+        Assert.That(ex!.Message, Does.Contain("only dynamic parallel kinds"));
+    }
+
+    [Test]
+    public void Unknown_selector_key_on_read_names_the_key_and_node()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "DynamicParallelState" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "composites": [ { "ownerIndex": 0, "kind": 4, "mode": 0, "selectorKey": "missing",
+                                "children": [ {{MinimalChildJson}} ] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        RegionSelectorRegistry registry = new();
+        registry.Register("present", _ => RegionMask.None);
+        GraphSerializer serializer = SerializerWith(CodecWithBasics(), registry);
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(serializer, json));
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Message, Does.Contain("'missing'"));
+            Assert.That(ex.Message, Does.Contain("node 0"));
+        });
+    }
+
+    [Test]
+    public void Dynamic_kind_without_a_registry_on_read_throws_the_targeted_error()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "DynamicParallelState" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "composites": [ { "ownerIndex": 0, "kind": 4, "mode": 0, "selectorKey": "any",
+                                "children": [ {{MinimalChildJson}} ] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        GraphSerializer serializer = new(CodecWithBasics());
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(serializer, json));
+        Assert.That(ex!.Message, Does.Contain("GraphSerializerOptions.SelectorRegistry"));
+    }
+
+    [Test]
+    public async Task Dynamic_marker_string_in_ordinary_logic_is_not_honored()
+    {
+        RegistryCodec codec = new();
+        codec.Register("DynamicParallelState", new KeyedState("DynamicParallelState", () => Result.Success));
+
+        Graph graph = GraphBuilder
+            .StartWithAsync(codec.Deserialize("DynamicParallelState"))
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), graph, binary: false);
+        LogicNode node = (LogicNode)rebuilt.StartNode;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(node.AsyncLogic, Is.Not.InstanceOf<AsyncDynamicParallelState>());
+            Assert.That(((IKeyed)node.AsyncLogic).Key, Is.EqualTo("DynamicParallelState"));
+        });
+    }
+
+    // ── Back-compat ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task V5_payload_without_the_new_sections_still_reads()
+    {
+        // Mirrors v4_payload_without_uids_still_reads: a v5 JSON payload omits forks, joins,
+        // and containers entirely — the GraphDto ctor defaults apply.
+        string json = """
+            {
+              "version": 5,
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "a" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [], "composites": [],
+              "uids": [ { "index": 0, "uid": "0f8fad5b-d9cb-469f-a165-70867728950e" } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        Graph rebuilt = await FromJson(new GraphSerializer(CodecWithBasics()), json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rebuilt.NodeCount, Is.EqualTo(1));
+            Assert.That(rebuilt.TryGetNodeByUid(Guid.Parse("0f8fad5b-d9cb-469f-a165-70867728950e"), out _),
+                Is.True);
+        });
+    }
+
+    [Test]
+    public async Task A_four_element_composite_dto_still_reads_over_messagepack()
+    {
+        // Structural back-compat proof for the MessagePack CompositeDto count 4→5 change:
+        // the reader accepts the 4-element (pre-v6) form with SelectorKey = null. Exercised
+        // through a real v6 static-composite trip plus the JSON twin below; the 4-element
+        // form itself is pinned by reading a v4-style JSON composite without selectorKey.
+        string json = """
+            {
+              "version": 4,
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "ParallelState" } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "composites": [ { "ownerIndex": 0, "kind": 2, "mode": 0, "children": [
+                { "version": 4,
+                  "nodes": [ { "$type": "txt", "index": 0, "name": "c0", "logic": "c0" } ],
+                  "transitions": [ { "destination": -1 } ],
+                  "subGraphs": [], "composites": [], "name": null, "index": -1 }
+              ] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        Graph rebuilt = await FromJson(new GraphSerializer(CodecWithBasics()), json);
+        LogicNode composite = (LogicNode)rebuilt.StartNode;
+
+        Assert.That(composite.AsyncLogic, Is.InstanceOf<AsyncParallelState>(),
+            "A composite without a selector key (pre-v6 shape) reads as the static kind.");
+    }
+}

--- a/NxGraph.Serialization.Tests/ForkJoinSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/ForkJoinSerializationTests.cs
@@ -1,0 +1,516 @@
+using System.Text;
+using NxGraph.Authoring;
+using NxGraph.Diagnostics.Export;
+using NxGraph.Diagnostics.Validations;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// Payload version 6, part A: token fork/join nodes on the wire. Fork branch arrays and join
+/// policies are plain structure and serialize unconditionally — no options needed. Covers
+/// round-trips per join policy (JSON + MessagePack) re-run under both token machines, branch
+/// order, nesting, UID coexistence, marker-spoof defense, and negative fixtures.
+/// </summary>
+[TestFixture]
+[Category("serialization")]
+public class ForkJoinSerializationTests
+{
+    // ── Test doubles (CompositeSerializationTests pattern) ───────────────
+
+    private interface IKeyed
+    {
+        string Key { get; }
+    }
+
+    private sealed class KeyedState(string key, Func<Result> body) : IAsyncLogic, ILogic, IKeyed
+    {
+        public string Key => key;
+        public Result Execute() => body();
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => new(body());
+    }
+
+    private sealed class RegistryCodec : ILogicTextCodec
+    {
+        private readonly Dictionary<string, IAsyncLogic> _byKey = new();
+
+        public T Register<T>(string key, T logic) where T : IAsyncLogic
+        {
+            _byKey[key] = logic;
+            return logic;
+        }
+
+        public KeyedState Log(string key, List<string> log)
+            => Register(key, new KeyedState(key, () =>
+            {
+                log.Add(key);
+                return Result.Success;
+            }));
+
+        public string Serialize(IAsyncLogic data) => ((IKeyed)data).Key;
+
+        public IAsyncLogic Deserialize(string s) => _byKey.TryGetValue(s, out IAsyncLogic? logic)
+            ? logic
+            : throw new InvalidOperationException($"Unknown logic key '{s}'.");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static async Task<Graph> RoundTrip(GraphSerializer serializer, Graph graph, bool binary)
+    {
+        await using MemoryStream stream = new();
+        if (binary)
+        {
+            await serializer.ToBinaryAsync(graph, stream);
+            stream.Position = 0;
+            return await serializer.FromBinaryAsync(stream);
+        }
+
+        await serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+        return await serializer.FromJsonAsync(stream);
+    }
+
+    private static Result RunSyncToCompletion(TokenMachine machine)
+    {
+        Result result = Result.InProgress;
+        for (int guard = 0; guard < 1_000 && result == Result.InProgress; guard++)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+
+    private static async Task<Graph> FromJson(GraphSerializer serializer, string json)
+    {
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        return await serializer.FromJsonAsync(source);
+    }
+
+    /// <summary>load → fork(a → join → finish, b → join), async-authored.</summary>
+    private static Graph Diamond(RegistryCodec codec, List<string> log, JoinPolicy policy)
+    {
+        JoinState join = new(policy);
+        return GraphBuilder.StartWithAsync(codec.Log("load", log))
+            .ForkTo(
+                b => b.ToAsync(codec.Log("a", log)).To(join).ToAsync(codec.Log("finish", log)),
+                b => b.ToAsync(codec.Log("b", log)).To(join))
+            .Build();
+    }
+
+    // ── Round-trips, re-run under both runtimes ──────────────────────────
+
+    [Test]
+    public async Task Fork_join_diamond_roundtrips_and_reruns_under_the_async_token_machine([Values] bool binary)
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+        Graph graph = Diamond(codec, log, JoinPolicy.All(2));
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), graph, binary);
+
+        // Diamond indexing: 0=load, branch heads build first (1=a, 2=join, 3=finish, 4=b),
+        // the fork node itself is added last (5).
+        LogicNode forkNode = (LogicNode)rebuilt.GetNodeByIndex(5);
+        ForkState fork = (forkNode.Logic as ForkState ?? forkNode.AsyncLogic as ForkState)!;
+        Result result = await rebuilt.ToAsyncTokenMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fork.Branches, Has.Count.EqualTo(2), "Both branches survived the trip.");
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b", "finish" }),
+                "Both branch states executed and the joined token ran the tail — branch 0 " +
+                "continues the arriving token, so 'a' precedes 'b' in the round interleaving.");
+        });
+    }
+
+    [Test]
+    public async Task Fork_join_diamond_roundtrips_and_reruns_under_the_sync_token_machine([Values] bool binary)
+    {
+        // Sync-authored: branch heads and the join arrive through the ForkBranch.To(ILogic)
+        // path (join wrapped in SyncLogicAdapter on the wire side). One marker per kind — the
+        // rebuilt join carries no adapter, which is semantics-preserving because fork/join
+        // never execute and populate both logic slots.
+        List<string> log = [];
+        RegistryCodec codec = new();
+        JoinState join = new(JoinPolicy.All(2));
+        Graph graph = GraphBuilder.StartWith((ILogic)codec.Log("load", log))
+            .ForkTo(
+                b => b.To((ILogic)codec.Log("a", log)).To(join).To((ILogic)codec.Log("finish", log)),
+                b => b.To((ILogic)codec.Log("b", log)).To(join))
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), graph, binary);
+        Result result = RunSyncToCompletion(rebuilt.ToTokenMachine());
+
+        LogicNode joinNode = (LogicNode)rebuilt.GetNodeByIndex(2);
+        Assert.Multiple(() =>
+        {
+            Assert.That(joinNode.Logic, Is.InstanceOf<JoinState>(),
+                "The rebuilt join populates the sync logic slot, so it stays sync-runnable.");
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b", "finish" }));
+        });
+    }
+
+    [TestCase((byte)JoinKind.All, 2)]
+    [TestCase((byte)JoinKind.Any, 1)]
+    [TestCase((byte)JoinKind.Quorum, 2)]
+    public async Task Join_policy_roundtrips_with_exact_kind_and_count(byte kind, int count)
+    {
+        JoinPolicy policy = (JoinKind)kind switch
+        {
+            JoinKind.All => JoinPolicy.All(count),
+            JoinKind.Any => JoinPolicy.Any,
+            _ => JoinPolicy.Quorum(count),
+        };
+
+        List<string> log = [];
+        RegistryCodec codec = new();
+        Graph graph = Diamond(codec, log, policy);
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), graph, binary: true);
+        LogicNode joinNode = (LogicNode)rebuilt.GetNodeByIndex(2);
+        JoinState join = (joinNode.Logic as JoinState ?? joinNode.AsyncLogic as JoinState)!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(join.Policy.Kind, Is.EqualTo((JoinKind)kind));
+            Assert.That(join.Policy.Count, Is.EqualTo(count));
+        });
+    }
+
+    [Test]
+    public async Task Fork_as_start_node_roundtrips([Values] bool binary)
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+        JoinState join = new(JoinPolicy.All(2));
+        Graph graph = GraphBuilder.Start()
+            .ForkTo(
+                b => b.ToAsync(codec.Log("a", log)).To(join),
+                b => b.ToAsync(codec.Log("b", log)).To(join))
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), graph, binary);
+        LogicNode startNode = (LogicNode)rebuilt.StartNode;
+        Result result = await rebuilt.ToAsyncTokenMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(startNode.Logic as ForkState ?? startNode.AsyncLogic as ForkState, Is.Not.Null,
+                "The start node is a fork — the root token fans out immediately at run start.");
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "a", "b" }));
+        });
+    }
+
+    // ── Nesting and section coexistence ──────────────────────────────────
+
+    [Test]
+    public async Task Fork_join_inside_a_subgraph_payload_roundtrips([Values] bool binary)
+    {
+        // Sections are per-GraphDto and recurse for free — the nested machine's payload
+        // carries its own fork/join sections.
+        List<string> log = [];
+        RegistryCodec codec = new();
+        Graph child = Diamond(codec, log, JoinPolicy.All(2));
+        Graph parent = GraphBuilder
+            .StartWithAsync(codec.Log("p0", log))
+            .SubGraph(child)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), parent, binary);
+        LogicNode owner = (LogicNode)rebuilt.GetNodeByIndex(1);
+        Graph rebuiltChild = ((NxGraph.Fsm.Async.AsyncStateMachine)owner.AsyncLogic).Graph;
+        Result result = await rebuiltChild.ToAsyncTokenMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b", "finish" }));
+        });
+    }
+
+    [Test]
+    public async Task Fork_join_inside_a_composite_region_roundtrips()
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+        Graph region = Diamond(codec, log, JoinPolicy.All(2));
+        Graph parent = GraphBuilder.Start().Parallel(region).Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), parent, binary: false);
+        LogicNode composite = (LogicNode)rebuilt.StartNode;
+        var parallel = (NxGraph.Fsm.Async.AsyncParallelState)composite.AsyncLogic;
+        Result result = await parallel.Regions[0].Graph.ToAsyncTokenMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b", "finish" }));
+        });
+    }
+
+    [Test]
+    public async Task Fork_node_carrying_a_uid_roundtrips()
+    {
+        Guid uid = Guid.NewGuid();
+        List<string> log = [];
+        RegistryCodec codec = new();
+        JoinState join = new(JoinPolicy.All(2));
+        StateToken load = GraphBuilder.StartWithAsync(codec.Log("load", log));
+        ForkToken fork = load.ForkTo(
+            b => b.ToAsync(codec.Log("a", log)).To(join),
+            b => b.ToAsync(codec.Log("b", log)).To(join));
+        fork.Builder.SetUid(fork.Id, uid);
+        Graph graph = fork.Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), graph, binary: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rebuilt.TryGetNodeByUid(uid, out INode node), Is.True,
+                "The sparse uid section coexists with the fork section on the same node index.");
+            Assert.That(((LogicNode)node).Logic as ForkState ?? ((LogicNode)node).AsyncLogic as ForkState,
+                Is.Not.Null, "The uid-carrying node is the rebuilt fork.");
+        });
+    }
+
+    [Test]
+    public async Task Deserialized_fork_keeps_its_empty_transition_slot_and_matches_lints_and_mermaid()
+    {
+        List<string> log = [];
+        RegistryCodec codec = new();
+        Graph graph = Diamond(codec, log, JoinPolicy.All(2));
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), graph, binary: false);
+
+        GraphValidationResult originalReport = graph.Validate();
+        GraphValidationResult rebuiltReport = rebuilt.Validate();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rebuilt.GetTransitionByIndex(5).IsEmpty, Is.True,
+                "The fork's transition slot stays empty — branches replace the success edge.");
+            Assert.That(rebuiltReport.Diagnostics.Select(i => i.ToString()),
+                Is.EqualTo(originalReport.Diagnostics.Select(i => i.ToString())),
+                "The validator token lints on the rebuilt graph match the original.");
+            Assert.That(rebuilt.ToMermaid(), Is.EqualTo(graph.ToMermaid()),
+                "Mermaid output (fork bars, branch edges, policy-labeled join) survives the trip.");
+        });
+    }
+
+    // ── Marker-spoof defense and negative fixtures ───────────────────────
+
+    [Test]
+    public async Task Fork_marker_string_in_ordinary_logic_is_not_honored()
+    {
+        // A codec legitimately emitting "ForkState"/"JoinState" for ordinary logic must
+        // round-trip as ordinary logic: markers are honored only when the matching section
+        // claims the node index.
+        RegistryCodec codec = new();
+        codec.Register("ForkState", new KeyedState("ForkState", () => Result.Success));
+        codec.Register("JoinState", new KeyedState("JoinState", () => Result.Success));
+
+        Graph graph = GraphBuilder
+            .StartWithAsync(codec.Deserialize("ForkState"))
+            .ToAsync(codec.Deserialize("JoinState"))
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), graph, binary: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(((LogicNode)rebuilt.StartNode).AsyncLogic, Is.Not.InstanceOf<ForkState>());
+            Assert.That(((IKeyed)((LogicNode)rebuilt.StartNode).AsyncLogic).Key, Is.EqualTo("ForkState"));
+            Assert.That(((IKeyed)((LogicNode)rebuilt.GetNodeByIndex(1)).AsyncLogic).Key, Is.EqualTo("JoinState"));
+        });
+    }
+
+    private const string TwoPlainNodesJson = """
+          "nodes": [
+            { "$type": "txt", "index": 0, "name": "a", "logic": "ForkState" },
+            { "$type": "txt", "index": 1, "name": "b", "logic": "b" }
+          ],
+          "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+          "subGraphs": [], "composites": [],
+        """;
+
+    private static GraphSerializer PlainSerializer()
+    {
+        RegistryCodec codec = new();
+        codec.Register("a", new KeyedState("a", () => Result.Success));
+        codec.Register("b", new KeyedState("b", () => Result.Success));
+        return new GraphSerializer(codec);
+    }
+
+    [Test]
+    public void Fork_claim_on_a_non_marker_node_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": "a" },
+                { "$type": "txt", "index": 1, "name": "b", "logic": "b" }
+              ],
+              "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+              "subGraphs": [], "composites": [],
+              "forks": [ { "ownerIndex": 0, "branches": [ 1 ] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("does not reference a fork marker"));
+    }
+
+    [Test]
+    public void Duplicate_fork_owner_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+            {{TwoPlainNodesJson}}
+              "forks": [
+                { "ownerIndex": 0, "branches": [ 1 ] },
+                { "ownerIndex": 0, "branches": [ 1 ] }
+              ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("duplicated"));
+    }
+
+    [Test]
+    public void Cross_section_claim_overlap_throws()
+    {
+        // The same node index claimed by Forks and Joins: with markerless container claims in
+        // the format, section disjointness is checked explicitly.
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+            {{TwoPlainNodesJson}}
+              "forks": [ { "ownerIndex": 0, "branches": [ 1 ] } ],
+              "joins": [ { "ownerIndex": 0, "kind": 1, "count": 1 } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("claimed by both"));
+    }
+
+    [Test]
+    public void Out_of_range_fork_owner_throws()
+    {
+        // Both nodes are ordinary payload — the out-of-range claim is the only defect, so the
+        // rebuild pass's range check is what fires (not a codec decode failure).
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": "a" },
+                { "$type": "txt", "index": 1, "name": "b", "logic": "b" }
+              ],
+              "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+              "subGraphs": [], "composites": [],
+              "forks": [ { "ownerIndex": 9, "branches": [ 1 ] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("out of range"));
+    }
+
+    [Test]
+    public void Out_of_range_branch_index_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+            {{TwoPlainNodesJson}}
+              "forks": [ { "ownerIndex": 0, "branches": [ 7 ] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("branch index 7 out of range"));
+    }
+
+    [Test]
+    public void Empty_branch_array_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+            {{TwoPlainNodesJson}}
+              "forks": [ { "ownerIndex": 0, "branches": [] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("at least one branch"));
+    }
+
+    [TestCase(3, 1, Description = "unknown kind")]
+    [TestCase(0, 0, Description = "All with count 0 (default-struct policy)")]
+    [TestCase(1, 2, Description = "Any must have count 1")]
+    public void Invalid_join_policy_throws(int kind, int count)
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": "JoinState" },
+                { "$type": "txt", "index": 1, "name": "b", "logic": "b" }
+              ],
+              "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+              "subGraphs": [], "composites": [],
+              "joins": [ { "ownerIndex": 0, "kind": {{kind}}, "count": {{count}} } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("invalid policy"));
+    }
+
+    [Test]
+    public void New_marker_strings_collide_with_no_existing_marker()
+    {
+        string[] markers =
+        [
+            NodeId.Default.Name, // legacy "Default" alias
+            NodeId.StateMachineMarker.Name,
+            NodeId.SyncStateMachineMarker.Name,
+            NodeId.HistoryStateMarker.Name,
+            NodeId.SyncHistoryStateMarker.Name,
+            NodeId.ParallelStateMarker.Name,
+            NodeId.SyncParallelStateMarker.Name,
+            NodeId.ForkStateMarker.Name,
+            NodeId.JoinStateMarker.Name,
+            NodeId.DynamicParallelStateMarker.Name,
+            NodeId.SyncDynamicParallelStateMarker.Name,
+        ];
+
+        Assert.That(markers, Is.Unique, "Every wire marker string must be distinct.");
+    }
+}

--- a/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
+++ b/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
@@ -239,11 +239,11 @@ public class GraphSerializerTestsTextCodec
     }
 
     [Test]
-    public void Dynamic_parallel_composites_still_throw_a_targeted_error()
+    public void Dynamic_parallel_composites_without_a_selector_registry_throw_a_targeted_error()
     {
-        // Since v4 the history/parallel composites ride the payload; the dynamic variants
-        // cannot (their region selector is a delegate) and must keep the targeted error,
-        // which now names the supported set.
+        // Since v6 the dynamic parallel composites ride the payload, but only with a selector
+        // registry configured — a plain GraphSerializer(codec) keeps a targeted error that
+        // points at the option unlocking the feature.
         Graph region = GraphBuilder
             .StartWith(new DummyState { Data = "r0" })
             .Build();
@@ -257,9 +257,9 @@ public class GraphSerializerTestsTextCodec
             async () => await _serializer.ToJsonAsync(withDynamicParallel, new MemoryStream()));
         Assert.Multiple(() =>
         {
-            Assert.That(ex!.Message, Does.Contain("DynamicParallelState"));
-            Assert.That(ex.Message, Does.Contain("history composites"),
-                "The targeted error names what is supported post-v4.");
+            Assert.That(ex!.Message, Does.Contain("dynamic parallel composite"));
+            Assert.That(ex.Message, Does.Contain("GraphSerializerOptions.SelectorRegistry"),
+                "The targeted error names the option that unlocks the feature.");
         });
     }
 

--- a/NxGraph.Serialization.Tests/NodeUidSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/NodeUidSerializationTests.cs
@@ -1,0 +1,224 @@
+using System.Text;
+using NxGraph.Authoring;
+using NxGraph.Graphs;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// Per-node stable UIDs on the wire: a sparse <c>uids</c> section shipped with payload
+/// version 5. Absence encodes "no uid" — pre-v5 payloads read back as uid-free graphs.
+/// </summary>
+[TestFixture]
+[Category("serialization")]
+public class NodeUidSerializationTests
+{
+    private readonly GraphSerializer _serializer = new(new DummyLogicTextCodec());
+
+    // A JSON-encoded DummyState payload for hand-written node literals.
+    private const string DummyLogic = "\"{\\\"Data\\\":\\\"x\\\"}\"";
+
+    private static Graph BuildGraphWithUids(Guid startUid, Guid nextUid)
+    {
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode((IAsyncLogic)new DummyState { Data = "start" }, isStart: true);
+        NodeId next = builder.AddNode((IAsyncLogic)new DummyState { Data = "next" });
+        NodeId last = builder.AddNode((IAsyncLogic)new DummyState { Data = "last" });
+        builder.AddTransition(start, next);
+        builder.AddTransition(next, last);
+        builder.SetUid(start, startUid);
+        builder.SetUid(next, nextUid);
+        return builder.Build(throwOnError: false);
+    }
+
+    private static async Task<Graph> FromJson(GraphSerializer serializer, string json)
+    {
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        return await serializer.FromJsonAsync(source);
+    }
+
+    [Test]
+    public async Task json_roundtrip_preserves_uids()
+    {
+        Guid startUid = Guid.NewGuid();
+        Guid nextUid = Guid.NewGuid();
+        Graph graph = BuildGraphWithUids(startUid, nextUid);
+
+        await using MemoryStream stream = new();
+        await _serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+        Graph roundTripped = await _serializer.FromJsonAsync(stream);
+
+        Assert.That(roundTripped.Uids, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(roundTripped.Uids![0], Is.EqualTo(startUid));
+            Assert.That(roundTripped.Uids[1], Is.EqualTo(nextUid));
+            Assert.That(roundTripped.Uids[2], Is.EqualTo(Guid.Empty), "Node without a uid stays uid-free.");
+            Assert.That(roundTripped.TryGetNodeByUid(nextUid, out INode node), Is.True);
+            Assert.That(node.Id.Index, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task binary_roundtrip_preserves_uids()
+    {
+        Guid startUid = Guid.NewGuid();
+        Guid nextUid = Guid.NewGuid();
+        Graph graph = BuildGraphWithUids(startUid, nextUid);
+
+        await using MemoryStream stream = new();
+        await _serializer.ToBinaryAsync(graph, stream);
+        stream.Position = 0;
+        Graph roundTripped = await _serializer.FromBinaryAsync(stream);
+
+        Assert.That(roundTripped.Uids, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(roundTripped.Uids![0], Is.EqualTo(startUid));
+            Assert.That(roundTripped.Uids[1], Is.EqualTo(nextUid));
+            Assert.That(roundTripped.Uids[2], Is.EqualTo(Guid.Empty), "Node without a uid stays uid-free.");
+        });
+    }
+
+    [Test]
+    public async Task graph_without_uids_roundtrips_with_none()
+    {
+        GraphBuilder builder = new();
+        builder.AddNode((IAsyncLogic)new DummyState { Data = "only" }, isStart: true);
+        Graph graph = builder.Build(throwOnError: false);
+
+        await using MemoryStream jsonStream = new();
+        await _serializer.ToJsonAsync(graph, jsonStream);
+        jsonStream.Position = 0;
+        Graph fromJson = await _serializer.FromJsonAsync(jsonStream);
+
+        await using MemoryStream binaryStream = new();
+        await _serializer.ToBinaryAsync(graph, binaryStream);
+        binaryStream.Position = 0;
+        Graph fromBinary = await _serializer.FromBinaryAsync(binaryStream);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fromJson.Uids, Is.Null);
+            Assert.That(fromBinary.Uids, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task uid_payload_carries_the_current_version_and_a_uids_section()
+    {
+        Guid uid = Guid.NewGuid();
+        Graph graph = BuildGraphWithUids(uid, Guid.NewGuid());
+
+        await using MemoryStream stream = new();
+        await _serializer.ToJsonAsync(graph, stream);
+        string json = Encoding.UTF8.GetString(stream.ToArray());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain($"\"version\": {SerializationVersion.Version}"));
+            Assert.That(json, Does.Contain("\"uids\""));
+            Assert.That(json, Does.Contain(uid.ToString("D")), "Uids ride as canonical \"D\" strings.");
+        });
+    }
+
+    [Test]
+    public async Task v4_payload_without_uids_still_reads()
+    {
+        string json = $$"""
+            {
+              "version": 4,
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": {{DummyLogic}} } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "composites": [],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        Graph rebuilt = await FromJson(_serializer, json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rebuilt.NodeCount, Is.EqualTo(1));
+            Assert.That(rebuilt.Uids, Is.Null, "Pre-v5 payloads read as uid-free graphs.");
+        });
+    }
+
+    [Test]
+    public async Task nested_subgraph_uids_roundtrip_independently()
+    {
+        // Uid uniqueness is per-graph: parent and child may carry the same uid, and each
+        // nesting level rides its own uids section on the wire.
+        Guid shared = Guid.NewGuid();
+
+        Graph child = GraphBuilder
+            .StartWithAsync((IAsyncLogic)new DummyState { Data = "child" })
+            .WithUid(shared)
+            .Build();
+        Graph parent = GraphBuilder
+            .StartWithAsync((IAsyncLogic)new DummyState { Data = "parent" })
+            .WithUid(shared)
+            .SubGraph(child)
+            .Build();
+
+        await using MemoryStream stream = new();
+        await _serializer.ToJsonAsync(parent, stream);
+        stream.Position = 0;
+        Graph rebuilt = await _serializer.FromJsonAsync(stream);
+
+        LogicNode owner = (LogicNode)rebuilt.GetNodeByIndex(1);
+        Graph rebuiltChild = ((ISubGraphProvider)owner.AsyncLogic).SubGraphs.First();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rebuilt.TryGetNodeByUid(shared, out INode parentNode), Is.True);
+            Assert.That(parentNode.Id.Index, Is.EqualTo(0));
+            Assert.That(rebuiltChild.TryGetNodeByUid(shared, out INode childNode), Is.True);
+            Assert.That(childNode.Id.Index, Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void uid_dto_with_out_of_range_index_is_rejected()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": {{DummyLogic}} } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "composites": [],
+              "uids": [ { "index": 5, "uid": "{{Guid.NewGuid():D}}" } ],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(_serializer, json));
+        Assert.That(ex!.Message, Does.Contain("out of range"));
+    }
+
+    [Test]
+    public void uid_dto_with_empty_guid_is_rejected()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": {{DummyLogic}} } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "composites": [],
+              "uids": [ { "index": 0, "uid": "00000000-0000-0000-0000-000000000000" } ],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(_serializer, json));
+        Assert.That(ex!.Message, Does.Contain("Guid.Empty"));
+    }
+}

--- a/NxGraph.Serialization.Tests/TokenNodeSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/TokenNodeSerializationTests.cs
@@ -1,0 +1,50 @@
+using NxGraph.Tokens;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// The machine state (<see cref="TokenMachineSnapshot"/>) is a plain record and serializes
+/// independently with any serializer, which the round-trip test below pins. The graph-payload
+/// wire format for fork/join nodes (payload version 6) is covered by
+/// <see cref="ForkJoinSerializationTests"/>.
+/// </summary>
+[TestFixture]
+public class TokenNodeSerializationTests
+{
+    [Test]
+    public void token_machine_snapshot_round_trips_through_plain_json()
+    {
+        TokenMachineSnapshot snapshot = new(
+            Fsm.ExecutionStatus.Running,
+            MidRun: true,
+            NextTokenId: 3,
+            Tokens:
+            [
+                new TokenRecord(0, 2, 0, false, TokenPhase.Parked),
+                new TokenRecord(2, 4, 1, true, TokenPhase.Runnable),
+            ],
+            JoinArrivals: [0, 0, 1, 0, 0, 0])
+        {
+            AnyTokenDied = true,
+            JoinsFired = [false, false, true, false, false, false],
+        };
+
+        string json = System.Text.Json.JsonSerializer.Serialize(snapshot);
+        TokenMachineSnapshot? rebuilt =
+            System.Text.Json.JsonSerializer.Deserialize<TokenMachineSnapshot>(json);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rebuilt, Is.Not.Null);
+            Assert.That(rebuilt!.Status, Is.EqualTo(Fsm.ExecutionStatus.Running));
+            Assert.That(rebuilt.MidRun, Is.True);
+            Assert.That(rebuilt.NextTokenId, Is.EqualTo(3));
+            Assert.That(rebuilt.AnyTokenDied, Is.True);
+            Assert.That(rebuilt.Tokens, Has.Length.EqualTo(2));
+            Assert.That(rebuilt.Tokens[0].Phase, Is.EqualTo(TokenPhase.Parked));
+            Assert.That(rebuilt.Tokens[1].Attempts, Is.EqualTo(1));
+            Assert.That(rebuilt.JoinArrivals[2], Is.EqualTo(1));
+            Assert.That(rebuilt.JoinsFired[2], Is.True);
+        });
+    }
+}

--- a/NxGraph.Serialization/CompositeDto.cs
+++ b/NxGraph.Serialization/CompositeDto.cs
@@ -2,8 +2,9 @@ namespace NxGraph.Serialization;
 
 /// <summary>
 /// Discriminates the machine-wrapping composite kinds that ride the graph payload
-/// (payload version 4). The sync kinds carry their <c>ParallelStepMode</c> in
-/// <see cref="CompositeDto.Mode"/>; for async kinds the mode is written as zero and ignored.
+/// (payload version 4; the dynamic kinds arrived with version 6). The sync kinds carry
+/// their <c>ParallelStepMode</c> in <see cref="CompositeDto.Mode"/>; for async kinds the
+/// mode is written as zero and ignored.
 /// </summary>
 internal enum CompositeKind : byte
 {
@@ -11,6 +12,8 @@ internal enum CompositeKind : byte
     SyncHistory = 1,
     AsyncParallel = 2,
     SyncParallel = 3,
+    AsyncDynamicParallel = 4,
+    SyncDynamicParallel = 5,
 }
 
 /// <summary>
@@ -19,5 +22,13 @@ internal enum CompositeKind : byte
 /// get their own section so pre-v4 readers reject the payload via the version gate instead of
 /// misreading it. <paramref name="Children"/> holds the child/region graphs in region order
 /// (order is identity for <c>RegionMask</c> bits); history kinds carry exactly one child.
+/// <paramref name="SelectorKey"/> (payload version 6) names the region selector of the
+/// dynamic kinds, resolved through the configured <c>IRegionSelectorRegistry</c> — it is
+/// required for kinds 4–5 and must be null for kinds 0–3.
 /// </summary>
-internal sealed record CompositeDto(int OwnerIndex, CompositeKind Kind, byte Mode, GraphDto[] Children);
+internal sealed record CompositeDto(
+    int OwnerIndex,
+    CompositeKind Kind,
+    byte Mode,
+    GraphDto[] Children,
+    string? SelectorKey = null);

--- a/NxGraph.Serialization/CompositeDtoFormatter.cs
+++ b/NxGraph.Serialization/CompositeDtoFormatter.cs
@@ -9,30 +9,36 @@ internal sealed class CompositeDtoFormatter : GraphEntityFormatter<CompositeDto>
     public override void Serialize(ref MessagePackWriter writer, CompositeDto value,
         MessagePackSerializerOptions options)
     {
-        // [OwnerIndex, Kind, Mode, Children[]]
-        writer.WriteArrayHeader(4);
+        // [OwnerIndex, Kind, Mode, Children[], SelectorKey] — SelectorKey (v6) is appended
+        // after Children so the v4/v5 4-element prefix parse is untouched.
+        writer.WriteArrayHeader(5);
         writer.Write(value.OwnerIndex);
         writer.Write((byte)value.Kind);
         writer.Write(value.Mode);
         writer.WriteArrayHeader(value.Children.Length);
         for (int i = 0; i < value.Children.Length; i++)
             GraphDtoFormatter.Instance.Serialize(ref writer, value.Children[i], options);
+        writer.Write(value.SelectorKey);
     }
 
     public override CompositeDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
     {
+        // 4 elements = pre-v6 payload (no SelectorKey); old readers never see the 5-element
+        // form — the strict-greater version gate rejects v6 payloads first.
         int count = reader.ReadArrayHeader();
-        if (count != 4) throw new InvalidOperationException($"CompositeDto: expected 4 elements, got {count}");
+        if (count is not (4 or 5))
+            throw new InvalidOperationException($"CompositeDto: expected 4 or 5 elements, got {count}");
         int owner = reader.ReadInt32();
         byte kind = reader.ReadByte();
-        if (kind > (byte)CompositeKind.SyncParallel)
+        if (kind > (byte)CompositeKind.SyncDynamicParallel)
             throw new InvalidOperationException($"CompositeDto: unknown composite kind {kind}.");
         byte mode = reader.ReadByte();
         int childCount = reader.ReadArrayHeader();
         GraphDto[] children = new GraphDto[childCount];
         for (int i = 0; i < childCount; i++)
             children[i] = GraphDtoFormatter.Instance.Deserialize(ref reader, options);
-        return new CompositeDto(owner, (CompositeKind)kind, mode, children);
+        string? selectorKey = count >= 5 ? reader.ReadString() : null;
+        return new CompositeDto(owner, (CompositeKind)kind, mode, children, selectorKey);
     }
 }
 

--- a/NxGraph.Serialization/ContainerDto.cs
+++ b/NxGraph.Serialization/ContainerDto.cs
@@ -1,0 +1,63 @@
+using MessagePack;
+
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// Payload entry for a container-codec node (payload version 6): the child graphs the
+/// serializer recursed into, in <c>ISubGraphProvider.SubGraphs</c> enumeration order
+/// (order is identity — the codec's <c>Deserialize</c> receives them in the same order).
+/// There is no marker string for containers: the claim itself is the discriminator that
+/// routes the node's ordinary logic payload to the container codec instead of the logic
+/// codec.
+/// </summary>
+internal sealed record ContainerDto(int OwnerIndex, GraphDto[] Children);
+
+internal sealed class ContainerDtoFormatter : GraphEntityFormatter<ContainerDto>
+{
+    public static readonly ContainerDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, ContainerDto value,
+        MessagePackSerializerOptions options)
+    {
+        // [OwnerIndex, Children[]]
+        writer.WriteArrayHeader(2);
+        writer.Write(value.OwnerIndex);
+        writer.WriteArrayHeader(value.Children.Length);
+        for (int i = 0; i < value.Children.Length; i++)
+            GraphDtoFormatter.Instance.Serialize(ref writer, value.Children[i], options);
+    }
+
+    public override ContainerDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        if (count != 2) throw new InvalidOperationException($"ContainerDto: expected 2 elements, got {count}");
+        int owner = reader.ReadInt32();
+        int childCount = reader.ReadArrayHeader();
+        GraphDto[] children = new GraphDto[childCount];
+        for (int i = 0; i < childCount; i++)
+            children[i] = GraphDtoFormatter.Instance.Deserialize(ref reader, options);
+        return new ContainerDto(owner, children);
+    }
+}
+
+internal sealed class ContainerArrayDtoFormatter : GraphEntityFormatter<ContainerDto[]>
+{
+    public static readonly ContainerArrayDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, ContainerDto[] value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(value.Length);
+        for (int i = 0; i < value.Length; i++)
+            ContainerDtoFormatter.Instance.Serialize(ref writer, value[i], options);
+    }
+
+    public override ContainerDto[] Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        ContainerDto[] arr = new ContainerDto[count];
+        for (int i = 0; i < count; i++)
+            arr[i] = ContainerDtoFormatter.Instance.Deserialize(ref reader, options);
+        return arr;
+    }
+}

--- a/NxGraph.Serialization/ForkDto.cs
+++ b/NxGraph.Serialization/ForkDto.cs
@@ -1,0 +1,61 @@
+using MessagePack;
+
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// Payload entry for a token fork node (payload version 6). <paramref name="Branches"/>
+/// holds the branch-head node indexes in declaration order — branch 0 continues the arriving
+/// token (normative). Fork branch edges are not transitions: the owner's transition slot
+/// stays empty on the wire, exactly as it is in the live graph.
+/// </summary>
+internal sealed record ForkDto(int OwnerIndex, int[] Branches);
+
+internal sealed class ForkDtoFormatter : GraphEntityFormatter<ForkDto>
+{
+    public static readonly ForkDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, ForkDto value,
+        MessagePackSerializerOptions options)
+    {
+        // [OwnerIndex, [branch, ...]] — hand-rolled to pin the payload shape.
+        writer.WriteArrayHeader(2);
+        writer.Write(value.OwnerIndex);
+        writer.WriteArrayHeader(value.Branches.Length);
+        for (int i = 0; i < value.Branches.Length; i++)
+            writer.Write(value.Branches[i]);
+    }
+
+    public override ForkDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        if (count != 2) throw new InvalidOperationException($"ForkDto: expected 2 elements, got {count}");
+        int owner = reader.ReadInt32();
+        int branchCount = reader.ReadArrayHeader();
+        int[] branches = new int[branchCount];
+        for (int i = 0; i < branchCount; i++)
+            branches[i] = reader.ReadInt32();
+        return new ForkDto(owner, branches);
+    }
+}
+
+internal sealed class ForkArrayDtoFormatter : GraphEntityFormatter<ForkDto[]>
+{
+    public static readonly ForkArrayDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, ForkDto[] value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(value.Length);
+        for (int i = 0; i < value.Length; i++)
+            ForkDtoFormatter.Instance.Serialize(ref writer, value[i], options);
+    }
+
+    public override ForkDto[] Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        ForkDto[] arr = new ForkDto[count];
+        for (int i = 0; i < count; i++)
+            arr[i] = ForkDtoFormatter.Instance.Deserialize(ref reader, options);
+        return arr;
+    }
+}

--- a/NxGraph.Serialization/GraphDto.cs
+++ b/NxGraph.Serialization/GraphDto.cs
@@ -12,7 +12,8 @@ internal sealed class GraphDto
     /// </summary>
     public GraphDto(INodeDto[] nodes, TransitionDto[] transitions, SubGraphDto[]? subGraphs = null, int index = -1,
         string? name = null, RetryPolicyDto[]? retryPolicies = null, OutcomeCodeDto[]? outcomeCodes = null,
-        OutcomeNameDto[]? outcomeNames = null, CompositeDto[]? composites = null)
+        OutcomeNameDto[]? outcomeNames = null, CompositeDto[]? composites = null, UidDto[]? uids = null,
+        ForkDto[]? forks = null, JoinDto[]? joins = null, ContainerDto[]? containers = null)
     {
         if (nodes.Length != transitions.Length)
             throw new ArgumentException("Nodes and transitions must have the same length.", nameof(transitions));
@@ -25,6 +26,10 @@ internal sealed class GraphDto
         OutcomeCodes = outcomeCodes ?? [];
         OutcomeNames = outcomeNames ?? [];
         Composites = composites ?? [];
+        Uids = uids ?? [];
+        Forks = forks ?? [];
+        Joins = joins ?? [];
+        Containers = containers ?? [];
     }
 
     /// <summary>
@@ -44,5 +49,9 @@ internal sealed class GraphDto
     public OutcomeCodeDto[] OutcomeCodes { get; set; }
     public OutcomeNameDto[] OutcomeNames { get; set; }
     public CompositeDto[] Composites { get; set; }
+    public UidDto[] Uids { get; set; }
+    public ForkDto[] Forks { get; set; }
+    public JoinDto[] Joins { get; set; }
+    public ContainerDto[] Containers { get; set; }
 
 }

--- a/NxGraph.Serialization/GraphDtoFormatter.cs
+++ b/NxGraph.Serialization/GraphDtoFormatter.cs
@@ -10,12 +10,15 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
     private const int VersionOneHeaderCount = 6;
     private const int VersionTwoHeaderCount = 9;
     private const int VersionFourHeaderCount = 10;
+    private const int VersionFiveHeaderCount = 11;
+    private const int VersionSixHeaderCount = 14;
 
     public override void Serialize(ref MessagePackWriter writer, GraphDto value, MessagePackSerializerOptions options)
     {
         // [0.Version 1.Index, 2.Name, 3.Nodes[], 4.Transitions[], 5.SubGraphs[],
-        //  6.RetryPolicies[], 7.OutcomeCodes[], 8.OutcomeNames[], 9.Composites[]]
-        writer.WriteArrayHeader(VersionFourHeaderCount);
+        //  6.RetryPolicies[], 7.OutcomeCodes[], 8.OutcomeNames[], 9.Composites[], 10.Uids[],
+        //  11.Forks[], 12.Joins[], 13.Containers[]]
+        writer.WriteArrayHeader(VersionSixHeaderCount);
         writer.Write(value.Version);
         writer.Write(value.Index);
         writer.Write(value.Name);
@@ -30,6 +33,14 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
             .Serialize(ref writer, value.OutcomeNames, options);
         options.Resolver.GetFormatterWithVerify<CompositeDto[]>()
             .Serialize(ref writer, value.Composites, options);
+        options.Resolver.GetFormatterWithVerify<UidDto[]>()
+            .Serialize(ref writer, value.Uids, options);
+        options.Resolver.GetFormatterWithVerify<ForkDto[]>()
+            .Serialize(ref writer, value.Forks, options);
+        options.Resolver.GetFormatterWithVerify<JoinDto[]>()
+            .Serialize(ref writer, value.Joins, options);
+        options.Resolver.GetFormatterWithVerify<ContainerDto[]>()
+            .Serialize(ref writer, value.Containers, options);
     }
 
     public override GraphDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
@@ -56,6 +67,12 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
             case 4 when count < VersionFourHeaderCount:
                 throw new InvalidOperationException(
                     $"GraphDto: expected at least {VersionFourHeaderCount} elements, got {count}");
+            case 5 when count < VersionFiveHeaderCount:
+                throw new InvalidOperationException(
+                    $"GraphDto: expected at least {VersionFiveHeaderCount} elements, got {count}");
+            case 6 when count < VersionSixHeaderCount:
+                throw new InvalidOperationException(
+                    $"GraphDto: expected at least {VersionSixHeaderCount} elements, got {count}");
         }
 
         int index = reader.ReadInt32();
@@ -88,9 +105,31 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
                 .Deserialize(ref reader, options);
         }
 
+        // Pre-v5 payloads end after Composites; the uid section arrived with version 5.
+        UidDto[] uids = [];
+        if (count >= VersionFiveHeaderCount)
+        {
+            uids = options.Resolver.GetFormatterWithVerify<UidDto[]>()
+                .Deserialize(ref reader, options);
+        }
+
+        // Pre-v6 payloads end after Uids; forks, joins, and containers arrived with version 6.
+        ForkDto[] forks = [];
+        JoinDto[] joins = [];
+        ContainerDto[] containers = [];
+        if (count >= VersionSixHeaderCount)
+        {
+            forks = options.Resolver.GetFormatterWithVerify<ForkDto[]>()
+                .Deserialize(ref reader, options);
+            joins = options.Resolver.GetFormatterWithVerify<JoinDto[]>()
+                .Deserialize(ref reader, options);
+            containers = options.Resolver.GetFormatterWithVerify<ContainerDto[]>()
+                .Deserialize(ref reader, options);
+        }
+
         reader.Depth--;
 
         return new GraphDto(nodes, transitions, subGraphs, index, name, retryPolicies, outcomeCodes, outcomeNames,
-            composites) { Version = version };
+            composites, uids, forks, joins, containers) { Version = version };
     }
 }

--- a/NxGraph.Serialization/GraphFormatterResolver.cs
+++ b/NxGraph.Serialization/GraphFormatterResolver.cs
@@ -109,6 +109,54 @@ internal sealed class GraphFormatterResolver : IFormatterResolver
                 return;
             }
 
+            if (typeof(T) == typeof(UidDto))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)UidDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(UidDto[]))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)UidArrayDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(ForkDto))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)ForkDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(ForkDto[]))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)ForkArrayDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(JoinDto))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)JoinDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(JoinDto[]))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)JoinArrayDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(ContainerDto))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)ContainerDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(ContainerDto[]))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)ContainerArrayDtoFormatter.Instance;
+                return;
+            }
+
             Formatter = null;
         }
     }

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -3,10 +3,12 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using MessagePack;
 using MessagePack.Resolvers;
+using NxGraph.Blackboards;
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
 using NxGraph.Serialization.Abstraction;
+using NxGraph.Tokens;
 
 namespace NxGraph.Serialization;
 
@@ -22,13 +24,39 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
     private const string LegacyStateMachineMarkerName = "Default";
 
     private readonly ILogicCodec _codec;
+    private readonly IRegionSelectorRegistry? _selectorRegistry;
+    private readonly IContainerCodec? _containerCodec;
     private readonly MessagePackSerializerOptions _options;
 
     private readonly JsonSerializerOptions _jsonOptions;
 
     public GraphSerializer(ILogicCodec codec)
+        : this(codec, options: null)
+    {
+    }
+
+    public GraphSerializer(ILogicCodec codec, GraphSerializerOptions? options)
     {
         ArgumentNullException.ThrowIfNull(codec);
+        _selectorRegistry = options?.SelectorRegistry;
+        _containerCodec = options?.ContainerCodec;
+
+        // Wire-type coherence: the container codec's payload rides in the same node DTO slot
+        // as the logic codec's, so their wire types must match. Fail at setup, not save time.
+        if (_containerCodec is not null)
+        {
+            bool containerText = _containerCodec is IContainerCodec<string>;
+            bool containerBinary = _containerCodec is IContainerCodec<ReadOnlyMemory<byte>>;
+            bool wireTypesMatch = (containerText && codec is ILogicCodec<string>) ||
+                                  (containerBinary && codec is ILogicCodec<ReadOnlyMemory<byte>>);
+            if (!wireTypesMatch)
+            {
+                throw new ArgumentException(
+                    "GraphSerializerOptions.ContainerCodec must use the same wire type as the ILogicCodec " +
+                    "(text with text, binary with binary) — the container payload rides in the same node DTO slot.",
+                    nameof(options));
+            }
+        }
         IFormatterResolver resolver = CompositeResolver.Create(
             formatters: [],
             resolvers:
@@ -162,6 +190,9 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         int nodeCount = graph.NodeCount;
         List<SubGraphDto> subGraphs = [];
         List<CompositeDto> composites = [];
+        List<ForkDto> forks = [];
+        List<JoinDto> joins = [];
+        List<ContainerDto> containers = [];
         INodeDto[] nodes = new INodeDto[nodeCount];
         for (int index = 0; index < nodeCount; index++)
         {
@@ -169,6 +200,28 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             switch (node)
             {
                 case LogicNode logicNode:
+                    // Token-runtime structural nodes (spec 007/009) ride as sparse sections:
+                    // branch arrays and join policies are plain structure, no configuration
+                    // needed. This check stays first in the dispatch — fork/join implement
+                    // both logic interfaces and must not fall through to any later branch.
+                    // TokenMachineSnapshot is a plain record and serializes independently.
+                    if ((logicNode.Logic as ForkState ?? logicNode.AsyncLogic as ForkState) is { } fork)
+                    {
+                        int[] branchIndexes = new int[fork.Branches.Count];
+                        for (int b = 0; b < branchIndexes.Length; b++)
+                            branchIndexes[b] = fork.Branches[b].Index;
+                        forks.Add(new ForkDto(index, branchIndexes));
+                        nodes[index] = new NodeTextDto(index, node.Id.Name, LogicNode.ForkStateMarker.Id.Name);
+                        break;
+                    }
+
+                    if ((logicNode.Logic as JoinState ?? logicNode.AsyncLogic as JoinState) is { } join)
+                    {
+                        joins.Add(new JoinDto(index, (byte)join.Policy.Kind, join.Policy.Count));
+                        nodes[index] = new NodeTextDto(index, node.Id.Name, LogicNode.JoinStateMarker.Id.Name);
+                        break;
+                    }
+
                     if (logicNode.AsyncLogic is AsyncStateMachine stateMachine)
                     {
                         // Serialize state machine as sub-graph
@@ -233,27 +286,75 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                         break;
                     }
 
-                    // Remaining composites carry child graphs a user codec structurally cannot
-                    // serialize — only GraphSerializer can recurse into them. Dynamic parallel
-                    // composites hold a selector delegate that cannot ride the wire (a named-
-                    // selector registry is a deliberate non-feature until someone needs durable
-                    // dynamic fan-out), and custom ISubGraphProvider containers have no stable
-                    // reconstruction recipe. Fail with a targeted error instead of handing the
-                    // composite to the codec, which would either throw an opaque cast error or
-                    // silently drop the children.
-                    if (logicNode.AsyncLogic is ISubGraphProvider || logicNode.Logic is ISubGraphProvider)
+                    // Dynamic parallel composites (payload version 6) are first-class: region
+                    // graphs and step mode ride exactly like the static kinds; only the
+                    // selector delegate needs user help, riding as a named key resolved
+                    // through the configured selector registry.
+                    if (logicNode.AsyncLogic is AsyncDynamicParallelState asyncDynamic)
                     {
-                        // Name the actual composite: sync composites sit behind a
-                        // SyncLogicAdapter, whose type name would only obscure the error.
-                        string compositeName = logicNode.Logic is ISubGraphProvider
-                            ? logicNode.Logic.GetType().Name
-                            : logicNode.AsyncLogic.GetType().Name;
-                        throw new NotSupportedException(
-                            $"Node '{node.Id}' holds composite logic '{compositeName}' " +
-                            "which is not serializable. GraphSerializer supports plain nested state machines " +
-                            "(.SubGraph(...), async or sync), history composites (.SubGraph(..., history: true)), " +
-                            "and static parallel composites (.Parallel(...)); dynamic parallel composites " +
-                            "(their region selector is a delegate) and custom ISubGraphProvider containers do not ride the wire.");
+                        GraphDto[] children = new GraphDto[asyncDynamic.Regions.Count];
+                        for (int r = 0; r < children.Length; r++)
+                            children[r] = ToDto(asyncDynamic.Regions[r].Graph, depth + 1);
+                        composites.Add(new CompositeDto(index, CompositeKind.AsyncDynamicParallel, Mode: 0,
+                            children, ResolveSelectorKey(node.Id, asyncDynamic.Selector)));
+                        nodes[index] = new NodeTextDto(index, node.Id.Name,
+                            LogicNode.DynamicParallelStateMarker.Id.Name);
+                        break;
+                    }
+
+                    if (logicNode.Logic is DynamicParallelState syncDynamic)
+                    {
+                        GraphDto[] children = new GraphDto[syncDynamic.Regions.Count];
+                        for (int r = 0; r < children.Length; r++)
+                            children[r] = ToDto(syncDynamic.Regions[r].Graph, depth + 1);
+                        composites.Add(new CompositeDto(index, CompositeKind.SyncDynamicParallel,
+                            (byte)syncDynamic.Mode, children, ResolveSelectorKey(node.Id, syncDynamic.Selector)));
+                        nodes[index] = new NodeTextDto(index, node.Id.Name,
+                            LogicNode.SyncDynamicParallelStateMarker.Id.Name);
+                        break;
+                    }
+
+                    // Remaining ISubGraphProvider containers (AsyncCompositeState subclasses,
+                    // custom user containers) carry child graphs a plain logic codec
+                    // structurally cannot serialize — only GraphSerializer can recurse. With a
+                    // container codec configured, the serializer owns the child-graph
+                    // recursion (SubGraphs enumeration order = wire order) and the codec owns
+                    // the reconstruction recipe, riding in the node's ordinary logic slot.
+                    // Without one, fail with a targeted error instead of handing the container
+                    // to the logic codec, which would silently drop the children.
+                    if ((logicNode.Logic as ISubGraphProvider ??
+                         logicNode.AsyncLogic as ISubGraphProvider) is { } container)
+                    {
+                        if (_containerCodec is null)
+                        {
+                            // Name the actual container: sync containers sit behind a
+                            // SyncLogicAdapter, whose type name would only obscure the error.
+                            string containerName = container.GetType().Name;
+                            throw new NotSupportedException(
+                                $"Node '{node.Id}' holds container logic '{containerName}' " +
+                                "which has no built-in wire format. Configure " +
+                                "GraphSerializerOptions.ContainerCodec with an IContainerCodec that owns its " +
+                                "reconstruction recipe; the serializer recurses into its SubGraphs itself.");
+                        }
+
+                        List<GraphDto> childDtos = [];
+                        foreach (Graph childGraph in container.SubGraphs)
+                        {
+                            childDtos.Add(ToDto(childGraph, depth + 1));
+                        }
+
+                        containers.Add(new ContainerDto(index, childDtos.ToArray()));
+                        nodes[index] = _containerCodec switch
+                        {
+                            IContainerCodec<string> t => new NodeTextDto(index, node.Id.Name,
+                                t.Serialize(container)),
+                            IContainerCodec<ReadOnlyMemory<byte>> b => new NodeBinaryDto(index, node.Id.Name,
+                                b.Serialize(container)),
+                            _ => throw new InvalidOperationException(
+                                "ContainerCodec implements neither IContainerCodec<string> nor " +
+                                "IContainerCodec<ReadOnlyMemory<byte>>.")
+                        };
+                        break;
                     }
 
                     // Unwrap SyncLogicAdapter so the codec receives the actual IAsyncLogic/ILogic,
@@ -327,8 +428,48 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             outcomeNames = entries.ToArray();
         }
 
+        UidDto[]? uids = null;
+        if (graph.Uids is { } uidArray)
+        {
+            List<UidDto> entries = [];
+            for (int index = 0; index < uidArray.Length; index++)
+            {
+                if (uidArray[index] != Guid.Empty)
+                {
+                    entries.Add(new UidDto(index, uidArray[index]));
+                }
+            }
+
+            uids = entries.ToArray();
+        }
+
         return new GraphDto(nodes, transitions, subGraphs.ToArray(), graph.Id.Index, graph.Id.Name, retryPolicies,
-            outcomeCodes, outcomeNames, composites.ToArray());
+            outcomeCodes, outcomeNames, composites.ToArray(), uids, forks.ToArray(), joins.ToArray(),
+            containers.ToArray());
+    }
+
+    /// <summary>
+    /// Maps a dynamic-parallel selector delegate to its registered key. Selector identity is
+    /// reference identity — the graph must be authored with the registered delegate instance
+    /// (the default registry's <c>Register</c> returns it for exactly that reason).
+    /// </summary>
+    private string ResolveSelectorKey(NodeId nodeId, Func<BlackboardContext, RegionMask> selector)
+    {
+        if (_selectorRegistry is null)
+        {
+            throw new NotSupportedException(
+                $"Node '{nodeId}' is a dynamic parallel composite — its region selector rides the wire " +
+                "as a named key. Configure GraphSerializerOptions.SelectorRegistry to serialize it.");
+        }
+
+        if (!_selectorRegistry.TryGetKey(selector, out string key))
+        {
+            throw new InvalidOperationException(
+                $"Node '{nodeId}': the dynamic parallel composite's selector delegate is not registered in " +
+                "the selector registry. Register the same delegate instance the graph was authored with.");
+        }
+
+        return key;
     }
 
     private Graph FromDto(GraphDto dto) => FromDto(dto, depth: 0);
@@ -374,6 +515,49 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             if (!compositeOwners.TryAdd(compositeDto.OwnerIndex, compositeDto))
                 throw new InvalidOperationException(
                     $"Composite DTO owner index {compositeDto.OwnerIndex} is duplicated in the payload.");
+        }
+
+        // Claim-first for the v6 token sections: fork/join markers are only honored when the
+        // matching section claims the node index.
+        Dictionary<int, ForkDto>? forkOwners = null;
+        foreach (ForkDto forkDto in dto.Forks)
+        {
+            forkOwners ??= new Dictionary<int, ForkDto>();
+            if (!forkOwners.TryAdd(forkDto.OwnerIndex, forkDto))
+                throw new InvalidOperationException(
+                    $"Fork DTO owner index {forkDto.OwnerIndex} is duplicated in the payload.");
+        }
+
+        Dictionary<int, JoinDto>? joinOwners = null;
+        foreach (JoinDto joinDto in dto.Joins)
+        {
+            joinOwners ??= new Dictionary<int, JoinDto>();
+            if (!joinOwners.TryAdd(joinDto.OwnerIndex, joinDto))
+                throw new InvalidOperationException(
+                    $"Join DTO owner index {joinDto.OwnerIndex} is duplicated in the payload.");
+        }
+
+        // Container claims (v6) carry no marker string — the claim itself routes the node's
+        // logic payload to the container codec instead of the logic codec.
+        Dictionary<int, ContainerDto>? containerOwners = null;
+        foreach (ContainerDto containerDto in dto.Containers)
+        {
+            containerOwners ??= new Dictionary<int, ContainerDto>();
+            if (!containerOwners.TryAdd(containerDto.OwnerIndex, containerDto))
+                throw new InvalidOperationException(
+                    $"Container DTO owner index {containerDto.OwnerIndex} is duplicated in the payload.");
+        }
+
+        // A node index may be claimed by at most one section. Before markerless container
+        // claims this was implicit via marker matching; now it must be explicit — an
+        // overlapping claim is a corrupt or crafted payload, not something to route by luck.
+        {
+            Dictionary<int, string>? claimedBy = null;
+            AddClaims(ref claimedBy, subGraphOwners, "SubGraphs");
+            AddClaims(ref claimedBy, compositeOwners?.Keys, "Composites");
+            AddClaims(ref claimedBy, forkOwners?.Keys, "Forks");
+            AddClaims(ref claimedBy, joinOwners?.Keys, "Joins");
+            AddClaims(ref claimedBy, containerOwners?.Keys, "Containers");
         }
 
         INode[] nodes = new INode[nodesLength];
@@ -426,6 +610,32 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                         break;
                     }
 
+                    // Token fork/join markers (v6): honored only when the matching section
+                    // claims this node index — an unclaimed marker string is ordinary payload
+                    // that falls through to the codec.
+                    if (textDto.Logic == LogicNode.ForkStateMarker.Id.Name &&
+                        forkOwners is not null && forkOwners.ContainsKey(nodeDto.Index))
+                    {
+                        nodes[nodeDto.Index] = LogicNode.ForkStateMarker;
+                        break;
+                    }
+
+                    if (textDto.Logic == LogicNode.JoinStateMarker.Id.Name &&
+                        joinOwners is not null && joinOwners.ContainsKey(nodeDto.Index))
+                    {
+                        nodes[nodeDto.Index] = LogicNode.JoinStateMarker;
+                        break;
+                    }
+
+                    // Container claims (v6) are markerless — the claim routes this node's
+                    // payload to the container codec. Decode is deferred until the child
+                    // graphs are rebuilt; the placeholder sentinel never rides the wire.
+                    if (containerOwners is not null && containerOwners.ContainsKey(nodeDto.Index))
+                    {
+                        nodes[nodeDto.Index] = ContainerPlaceholderMarker;
+                        break;
+                    }
+
                     if (textCodec is null)
                         throw new InvalidOperationException(
                             "GraphSerializer has no ILogicCodec<string> configured, cannot decode text nodes.");
@@ -437,6 +647,12 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     break;
 
                 case NodeBinaryDto binaryDto:
+                    if (containerOwners is not null && containerOwners.ContainsKey(nodeDto.Index))
+                    {
+                        nodes[nodeDto.Index] = ContainerPlaceholderMarker;
+                        break;
+                    }
+
                     if (binaryCodec is null)
                         throw new InvalidOperationException(
                             "GraphSerializer has no ILogicCodec<ReadOnlyMemory<byte>> configured, cannot decode binary nodes.");
@@ -539,10 +755,24 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     $"Composite DTO for node {compositeDto.OwnerIndex} is a parallel composite and must carry " +
                     "at least one region graph.");
 
-            bool isSyncKind = compositeDto.Kind is CompositeKind.SyncHistory or CompositeKind.SyncParallel;
+            bool isSyncKind = compositeDto.Kind is CompositeKind.SyncHistory or CompositeKind.SyncParallel
+                or CompositeKind.SyncDynamicParallel;
             if (isSyncKind && compositeDto.Mode > (byte)ParallelStepMode.RoundPerTick)
                 throw new InvalidOperationException(
                     $"Composite DTO for node {compositeDto.OwnerIndex} has unknown step mode {compositeDto.Mode}.");
+
+            // SelectorKey is exclusive to the dynamic kinds: required there, forbidden
+            // elsewhere (a key smuggled onto a static kind is a crafted or corrupt payload).
+            bool isDynamicKind = compositeDto.Kind is CompositeKind.AsyncDynamicParallel
+                or CompositeKind.SyncDynamicParallel;
+            if (isDynamicKind && string.IsNullOrEmpty(compositeDto.SelectorKey))
+                throw new InvalidOperationException(
+                    $"Composite DTO for node {compositeDto.OwnerIndex} is a dynamic parallel composite and " +
+                    "must carry a selector key.");
+            if (!isDynamicKind && compositeDto.SelectorKey is not null)
+                throw new InvalidOperationException(
+                    $"Composite DTO for node {compositeDto.OwnerIndex} has kind '{compositeDto.Kind}' but " +
+                    "carries a selector key — only dynamic parallel kinds may.");
 
             Graph[] childGraphs = new Graph[compositeDto.Children.Length];
             for (int c = 0; c < childGraphs.Length; c++)
@@ -558,6 +788,11 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                 CompositeKind.AsyncParallel => new AsyncParallelState(childGraphs),
                 CompositeKind.SyncParallel => new SyncLogicAdapter(
                     new ParallelState((ParallelStepMode)compositeDto.Mode, childGraphs)),
+                CompositeKind.AsyncDynamicParallel => new AsyncDynamicParallelState(
+                    ResolveSelector(compositeDto.SelectorKey!, compositeDto.OwnerIndex), childGraphs),
+                CompositeKind.SyncDynamicParallel => new SyncLogicAdapter(new DynamicParallelState(
+                    (ParallelStepMode)compositeDto.Mode,
+                    ResolveSelector(compositeDto.SelectorKey!, compositeDto.OwnerIndex), childGraphs)),
                 _ => throw new InvalidOperationException(
                     $"Composite DTO for node {compositeDto.OwnerIndex} has unknown kind {(byte)compositeDto.Kind}.")
             };
@@ -571,6 +806,125 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
 
             nodes[compositeDto.OwnerIndex] =
                 new LogicNode(new NodeId(compositeDto.OwnerIndex, compositeNodeName), compositeLogic);
+        }
+
+        // Rebuild token fork/join nodes (v6) through the public constructors so their
+        // validation re-runs. Branch ids are rebuilt as bare indexes — exactly what the live
+        // instance held pre-Build (equality is index-only; names resolve through the graph at
+        // runtime). Never read nodes[branch].Id here: a branch pointing at a not-yet-rebuilt
+        // owner would capture a negative sentinel id and silently corrupt routing.
+        foreach (ForkDto forkDto in dto.Forks)
+        {
+            if (forkDto.OwnerIndex < 0 || forkDto.OwnerIndex >= nodesLength)
+                throw new InvalidOperationException(
+                    $"Fork DTO owner index {forkDto.OwnerIndex} is out of range (0..{nodesLength - 1}).");
+            if (!ReferenceEquals(nodes[forkDto.OwnerIndex], LogicNode.ForkStateMarker))
+                throw new InvalidOperationException(
+                    $"Fork DTO owner index {forkDto.OwnerIndex} does not reference a fork marker node.");
+            if (forkDto.Branches.Length == 0)
+                throw new InvalidOperationException(
+                    $"Fork DTO for node {forkDto.OwnerIndex} must carry at least one branch.");
+
+            NodeId[] branchIds = new NodeId[forkDto.Branches.Length];
+            for (int b = 0; b < branchIds.Length; b++)
+            {
+                int branchIndex = forkDto.Branches[b];
+                if (branchIndex < 0 || branchIndex >= nodesLength)
+                    throw new InvalidOperationException(
+                        $"Fork DTO for node {forkDto.OwnerIndex} has branch index {branchIndex} out of range " +
+                        $"(0..{nodesLength - 1}).");
+                branchIds[b] = new NodeId(branchIndex);
+            }
+
+            string forkNodeName = dto.Nodes[forkDto.OwnerIndex] switch
+            {
+                NodeTextDto nt => nt.Name,
+                NodeBinaryDto nb => nb.Name,
+                _ => $"Node_{forkDto.OwnerIndex}"
+            };
+
+            // Installed as IAsyncLogic — ForkState implements both logic interfaces, so both
+            // node slots populate and the rebuilt node runs under either token machine. A
+            // sync-authored fork/join round-trips without its SyncLogicAdapter wrapper: the
+            // trip is semantics-preserving, not wrapper-identical (fork/join never execute).
+            nodes[forkDto.OwnerIndex] = new LogicNode(new NodeId(forkDto.OwnerIndex, forkNodeName),
+                new ForkState(branchIds));
+        }
+
+        foreach (JoinDto joinDto in dto.Joins)
+        {
+            if (joinDto.OwnerIndex < 0 || joinDto.OwnerIndex >= nodesLength)
+                throw new InvalidOperationException(
+                    $"Join DTO owner index {joinDto.OwnerIndex} is out of range (0..{nodesLength - 1}).");
+            if (!ReferenceEquals(nodes[joinDto.OwnerIndex], LogicNode.JoinStateMarker))
+                throw new InvalidOperationException(
+                    $"Join DTO owner index {joinDto.OwnerIndex} does not reference a join marker node.");
+
+            // Reconstruct the policy through its factories, pre-checked so a corrupt or
+            // crafted payload fails with an error naming the node instead of an
+            // ArgumentOutOfRangeException from the factory.
+            JoinPolicy policy = (JoinKind)joinDto.Kind switch
+            {
+                JoinKind.All when joinDto.Count >= 1 => JoinPolicy.All(joinDto.Count),
+                JoinKind.Any when joinDto.Count == 1 => JoinPolicy.Any,
+                JoinKind.Quorum when joinDto.Count >= 1 => JoinPolicy.Quorum(joinDto.Count),
+                _ => throw new InvalidOperationException(
+                    $"Join DTO for node {joinDto.OwnerIndex} has invalid policy " +
+                    $"(kind {joinDto.Kind}, count {joinDto.Count}).")
+            };
+
+            string joinNodeName = dto.Nodes[joinDto.OwnerIndex] switch
+            {
+                NodeTextDto nt => nt.Name,
+                NodeBinaryDto nb => nb.Name,
+                _ => $"Node_{joinDto.OwnerIndex}"
+            };
+
+            nodes[joinDto.OwnerIndex] = new LogicNode(new NodeId(joinDto.OwnerIndex, joinNodeName),
+                new JoinState(policy));
+        }
+
+        // Rebuild container-codec nodes (v6): children first (in wire order = SubGraphs
+        // enumeration order), then the node's ordinary logic payload routes to the container
+        // codec, which owns the reconstruction recipe.
+        foreach (ContainerDto containerDto in dto.Containers)
+        {
+            if (containerDto.OwnerIndex < 0 || containerDto.OwnerIndex >= nodesLength)
+                throw new InvalidOperationException(
+                    $"Container DTO owner index {containerDto.OwnerIndex} is out of range (0..{nodesLength - 1}).");
+            if (_containerCodec is null)
+                throw new InvalidOperationException(
+                    $"Container DTO claims node {containerDto.OwnerIndex} but no " +
+                    "GraphSerializerOptions.ContainerCodec is configured.");
+
+            Graph[] childGraphs = new Graph[containerDto.Children.Length];
+            for (int c = 0; c < childGraphs.Length; c++)
+            {
+                childGraphs[c] = FromDto(containerDto.Children[c], depth + 1);
+            }
+
+            IAsyncLogic? containerLogic = (dto.Nodes[containerDto.OwnerIndex], _containerCodec) switch
+            {
+                (NodeTextDto nt, IContainerCodec<string> t) => t.Deserialize(nt.Logic, childGraphs),
+                (NodeBinaryDto nb, IContainerCodec<ReadOnlyMemory<byte>> b) => b.Deserialize(nb.Logic, childGraphs),
+                _ => throw new InvalidOperationException(
+                    $"Container DTO for node {containerDto.OwnerIndex}: the node payload's wire type does not " +
+                    "match the configured ContainerCodec.")
+            };
+
+            if (containerLogic is null)
+                throw new InvalidOperationException(
+                    $"ContainerCodec.Deserialize returned null for node {containerDto.OwnerIndex}.");
+
+            string containerNodeName = dto.Nodes[containerDto.OwnerIndex] switch
+            {
+                NodeTextDto nt => nt.Name,
+                NodeBinaryDto nb => nb.Name,
+                _ => $"Node_{containerDto.OwnerIndex}"
+            };
+
+            nodes[containerDto.OwnerIndex] =
+                new LogicNode(new NodeId(containerDto.OwnerIndex, containerNodeName), containerLogic);
         }
 
         int transitionsLength = dto.Transitions.Length;
@@ -638,8 +992,75 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             }
         }
 
+        Guid[]? uids = null;
+        if (dto.Uids is { Length: > 0 })
+        {
+            uids = new Guid[nodesLength];
+            foreach (UidDto entry in dto.Uids)
+            {
+                if (entry.Index < 0 || entry.Index >= nodesLength)
+                    throw new InvalidOperationException(
+                        $"Uid DTO index {entry.Index} is out of range (0..{nodesLength - 1}).");
+                if (entry.Uid == Guid.Empty)
+                    throw new InvalidOperationException(
+                        $"Uid DTO for node {entry.Index} cannot be Guid.Empty (absence encodes 'no uid').");
+
+                uids[entry.Index] = entry.Uid;
+            }
+        }
+
         NodeId graphId = new(dto.Index, dto.Name);
-        return new Graph(graphId, nodes, transitions, logic: null, retryPolicies, outcomeCodes, outcomeNames);
+        return new Graph(graphId, nodes, transitions, logic: null, retryPolicies, outcomeCodes, outcomeNames,
+            uids: uids);
+    }
+
+    /// <summary>
+    /// In-memory placeholder for container-claimed nodes between the node loop and the
+    /// container rebuild pass (children rebuild first). Purely internal — unlike the
+    /// composite markers it never rides the wire, because container claims are markerless.
+    /// </summary>
+    private static readonly LogicNode ContainerPlaceholderMarker =
+        new(new NodeId(-12, "ContainerPlaceholder"), new EmptyAsyncLogic());
+
+    /// <summary>
+    /// Maps a payload selector key back to the registered delegate. The registry restores
+    /// <i>a</i> delegate for the key; whether it behaves like the authored one is the user's
+    /// contract — the same trust model the logic codec has for node logic.
+    /// </summary>
+    private Func<BlackboardContext, RegionMask> ResolveSelector(string key, int ownerIndex)
+    {
+        if (_selectorRegistry is null)
+        {
+            throw new InvalidOperationException(
+                $"Composite DTO for node {ownerIndex} is a dynamic parallel composite — configure " +
+                "GraphSerializerOptions.SelectorRegistry to deserialize it.");
+        }
+
+        if (!_selectorRegistry.TryGetSelector(key, out Func<BlackboardContext, RegionMask> selector))
+        {
+            throw new InvalidOperationException(
+                $"Composite DTO for node {ownerIndex} names selector key '{key}', which is not registered " +
+                "in the selector registry.");
+        }
+
+        return selector;
+    }
+
+    /// <summary>
+    /// Folds one section's claimed owner indexes into the shared claim map, throwing on the
+    /// first index already claimed by another section.
+    /// </summary>
+    private static void AddClaims(ref Dictionary<int, string>? claimedBy, IEnumerable<int>? owners, string section)
+    {
+        if (owners is null) return;
+        claimedBy ??= new Dictionary<int, string>();
+        foreach (int owner in owners)
+        {
+            if (!claimedBy.TryAdd(owner, section))
+                throw new InvalidOperationException(
+                    $"Node index {owner} is claimed by both the '{claimedBy[owner]}' and '{section}' payload " +
+                    "sections — a node may be claimed by at most one.");
+        }
     }
 
     /// <summary>
@@ -654,6 +1075,9 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         if (logic == LogicNode.SyncHistoryStateMarker.Id.Name) return LogicNode.SyncHistoryStateMarker;
         if (logic == LogicNode.ParallelStateMarker.Id.Name) return LogicNode.ParallelStateMarker;
         if (logic == LogicNode.SyncParallelStateMarker.Id.Name) return LogicNode.SyncParallelStateMarker;
+        if (logic == LogicNode.DynamicParallelStateMarker.Id.Name) return LogicNode.DynamicParallelStateMarker;
+        if (logic == LogicNode.SyncDynamicParallelStateMarker.Id.Name)
+            return LogicNode.SyncDynamicParallelStateMarker;
         return null;
     }
 
@@ -664,6 +1088,8 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         CompositeKind.SyncHistory => LogicNode.SyncHistoryStateMarker,
         CompositeKind.AsyncParallel => LogicNode.ParallelStateMarker,
         CompositeKind.SyncParallel => LogicNode.SyncParallelStateMarker,
+        CompositeKind.AsyncDynamicParallel => LogicNode.DynamicParallelStateMarker,
+        CompositeKind.SyncDynamicParallel => LogicNode.SyncDynamicParallelStateMarker,
         _ => throw new InvalidOperationException($"Unknown composite kind {(byte)kind}.")
     };
 

--- a/NxGraph.Serialization/GraphSerializerOptions.cs
+++ b/NxGraph.Serialization/GraphSerializerOptions.cs
@@ -1,0 +1,27 @@
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// Optional extension points for <see cref="GraphSerializer"/> (payload version 6). With
+/// both left null the serializer behaves exactly like the single-argument constructor:
+/// dynamic-parallel composites and custom containers fail with targeted errors naming the
+/// option that unlocks them. Token fork/join nodes need no configuration — their structure
+/// is plain data and always rides.
+/// </summary>
+public sealed class GraphSerializerOptions
+{
+    /// <summary>
+    /// Resolves dynamic-parallel region selectors to named keys (write) and back (read).
+    /// Required to serialize or deserialize graphs containing
+    /// <c>AsyncDynamicParallelState</c> / <c>DynamicParallelState</c> nodes.
+    /// </summary>
+    public IRegionSelectorRegistry? SelectorRegistry { get; init; }
+
+    /// <summary>
+    /// Owns the reconstruction recipe for custom <c>ISubGraphProvider</c> containers
+    /// (including <c>AsyncCompositeState</c> subclasses). Its wire type must match the
+    /// logic codec's — the container payload rides in the same node DTO slot.
+    /// </summary>
+    public IContainerCodec? ContainerCodec { get; init; }
+}

--- a/NxGraph.Serialization/IContainerBinaryCodec.cs
+++ b/NxGraph.Serialization/IContainerBinaryCodec.cs
@@ -1,0 +1,5 @@
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization;
+
+public interface IContainerBinaryCodec : IContainerCodec<ReadOnlyMemory<byte>>;

--- a/NxGraph.Serialization/IContainerTextCodec.cs
+++ b/NxGraph.Serialization/IContainerTextCodec.cs
@@ -1,0 +1,5 @@
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization;
+
+public interface IContainerTextCodec : IContainerCodec<string>;

--- a/NxGraph.Serialization/JoinDto.cs
+++ b/NxGraph.Serialization/JoinDto.cs
@@ -1,0 +1,58 @@
+using MessagePack;
+
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// Payload entry for a token join node (payload version 6): the <c>JoinPolicy</c> as raw
+/// <paramref name="Kind"/>/<paramref name="Count"/>. The deserializer reconstructs the
+/// policy through its public factories so their validation re-runs — the wire itself stays
+/// minimal, like the other sparse sections.
+/// </summary>
+internal sealed record JoinDto(int OwnerIndex, byte Kind, int Count);
+
+internal sealed class JoinDtoFormatter : GraphEntityFormatter<JoinDto>
+{
+    public static readonly JoinDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, JoinDto value,
+        MessagePackSerializerOptions options)
+    {
+        // [OwnerIndex, Kind, Count]
+        writer.WriteArrayHeader(3);
+        writer.Write(value.OwnerIndex);
+        writer.Write(value.Kind);
+        writer.Write(value.Count);
+    }
+
+    public override JoinDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        if (count != 3) throw new InvalidOperationException($"JoinDto: expected 3 elements, got {count}");
+        int owner = reader.ReadInt32();
+        byte kind = reader.ReadByte();
+        int policyCount = reader.ReadInt32();
+        return new JoinDto(owner, kind, policyCount);
+    }
+}
+
+internal sealed class JoinArrayDtoFormatter : GraphEntityFormatter<JoinDto[]>
+{
+    public static readonly JoinArrayDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, JoinDto[] value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(value.Length);
+        for (int i = 0; i < value.Length; i++)
+            JoinDtoFormatter.Instance.Serialize(ref writer, value[i], options);
+    }
+
+    public override JoinDto[] Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        JoinDto[] arr = new JoinDto[count];
+        for (int i = 0; i < count; i++)
+            arr[i] = JoinDtoFormatter.Instance.Deserialize(ref reader, options);
+        return arr;
+    }
+}

--- a/NxGraph.Serialization/RegionSelectorRegistry.cs
+++ b/NxGraph.Serialization/RegionSelectorRegistry.cs
@@ -1,0 +1,71 @@
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// Default <see cref="IRegionSelectorRegistry"/>: a bidirectional key ↔ delegate map built
+/// at registration time. Delegate identity is reference identity, so author the graph with
+/// the instance <see cref="Register"/> returns:
+/// <code>
+/// var sel = registry.Register("battle", ctx => ...);
+/// ... .Parallel(sel, region1, region2)
+/// </code>
+/// Two lambdas with identical bodies are distinct delegates — a graph authored with an
+/// unregistered twin fails the write-side lookup.
+/// </summary>
+public sealed class RegionSelectorRegistry : IRegionSelectorRegistry
+{
+    private readonly Dictionary<string, Func<BlackboardContext, RegionMask>> _byKey = new();
+    private readonly Dictionary<Func<BlackboardContext, RegionMask>, string> _byDelegate = new();
+
+    /// <summary>
+    /// Registers <paramref name="selector"/> under <paramref name="key"/> and returns the
+    /// delegate, so authoring uses the registered instance naturally. Duplicate keys and
+    /// duplicate delegates fail here, at setup, rather than at save time.
+    /// </summary>
+    public Func<BlackboardContext, RegionMask> Register(string key, Func<BlackboardContext, RegionMask> selector)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        ArgumentNullException.ThrowIfNull(selector);
+        if (_byKey.ContainsKey(key))
+        {
+            throw new ArgumentException($"A selector is already registered under key '{key}'.", nameof(key));
+        }
+
+        if (_byDelegate.TryGetValue(selector, out string? existingKey))
+        {
+            throw new ArgumentException(
+                $"This selector delegate is already registered under key '{existingKey}'.", nameof(selector));
+        }
+
+        _byKey.Add(key, selector);
+        _byDelegate.Add(selector, key);
+        return selector;
+    }
+
+    public bool TryGetKey(Func<BlackboardContext, RegionMask> selector, out string key)
+    {
+        if (_byDelegate.TryGetValue(selector, out string? found))
+        {
+            key = found;
+            return true;
+        }
+
+        key = string.Empty;
+        return false;
+    }
+
+    public bool TryGetSelector(string key, out Func<BlackboardContext, RegionMask> selector)
+    {
+        if (_byKey.TryGetValue(key, out Func<BlackboardContext, RegionMask>? found))
+        {
+            selector = found;
+            return true;
+        }
+
+        selector = null!;
+        return false;
+    }
+}

--- a/NxGraph.Serialization/SerializationVersion.cs
+++ b/NxGraph.Serialization/SerializationVersion.cs
@@ -8,6 +8,11 @@ public static class SerializationVersion
     // v4: history/parallel composites (CompositeDto section + "HistoryState"/"SyncHistoryState"/
     //     "ParallelState"/"SyncParallelState" markers) — older readers reject v4 payloads via
     //     the version gate instead of misreading the composite section.
-    public const int Version = 4;
+    // v5: per-node stable UIDs (sparse UidDto section) — editor-tooling identity metadata.
+    // v6: token fork/join sections ("ForkState"/"JoinState" markers), dynamic-parallel
+    //     composite kinds + SelectorKey ("DynamicParallelState"/"SyncDynamicParallelState"
+    //     markers, selector resolved via IRegionSelectorRegistry), container section
+    //     (markerless claims routed to the configured IContainerCodec).
+    public const int Version = 6;
 }
 

--- a/NxGraph.Serialization/UidDto.cs
+++ b/NxGraph.Serialization/UidDto.cs
@@ -1,0 +1,60 @@
+using MessagePack;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization;
+
+/// <summary>Sparse per-node stable UID entry (shipped with payload version 5).</summary>
+internal sealed record UidDto(int Index, Guid Uid);
+
+internal sealed class UidDtoFormatter : GraphEntityFormatter<UidDto>
+{
+    public static readonly UidDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, UidDto value,
+        MessagePackSerializerOptions options)
+    {
+        // The uid rides as the canonical "D" string — identical to the JSON representation,
+        // stable across MessagePack-CSharp versions, and readable in payload dumps.
+        writer.WriteArrayHeader(2);
+        writer.Write(value.Index);
+        writer.Write(value.Uid.ToString("D"));
+    }
+
+    public override UidDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        if (count != 2) throw new InvalidOperationException($"UidDto: expected 2 elements, got {count}");
+
+        int index = reader.ReadInt32();
+        string uidText = reader.ReadString() ??
+                         throw new InvalidOperationException("UidDto: uid cannot be null.");
+        return new UidDto(index, Guid.ParseExact(uidText, "D"));
+    }
+}
+
+internal sealed class UidArrayDtoFormatter : GraphEntityFormatter<UidDto[]>
+{
+    public static readonly UidArrayDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, UidDto[] value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(value.Length);
+        for (int index = 0; index < value.Length; index++)
+        {
+            options.Resolver.GetFormatterWithVerify<UidDto>().Serialize(ref writer, value[index], options);
+        }
+    }
+
+    public override UidDto[] Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        UidDto[] uids = new UidDto[count];
+        for (int i = 0; i < count; i++)
+        {
+            uids[i] = options.Resolver.GetFormatterWithVerify<UidDto>().Deserialize(ref reader, options);
+        }
+
+        return uids;
+    }
+}

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -166,6 +166,28 @@ public class AllocationGateTests
     }
 
     [Test]
+    public async Task async_run_over_uid_bearing_graph_is_allocation_free()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success).WithUid(Guid.NewGuid())
+            .ToAsync(_ => ResultHelpers.Success).WithUid(Guid.NewGuid())
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine());
+    }
+
+    [Test]
+    public void sync_run_over_uid_bearing_graph_is_allocation_free()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).WithUid(Guid.NewGuid())
+            .To(() => Result.Success).WithUid(Guid.NewGuid())
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine());
+    }
+
+    [Test]
     public async Task async_stepped_execution_is_allocation_free()
     {
         AsyncStateMachine machine = AsyncChain(10).ToAsyncStateMachine();
@@ -649,5 +671,147 @@ public class AllocationGateTests
         }
 
         AssertZeroAlloc(token.ToStateMachine(new NoopSyncObserver()));
+    }
+
+    // ── Token runtime (spec 007): pooled tokens, fork/join, per-token scratch ──
+
+    private static void AssertZeroAllocTokens(NxGraph.Tokens.TokenMachine machine)
+    {
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+        for (int i = 0; i < 50; i++)
+        {
+            machine.Execute();
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < Iterations; i++)
+        {
+            machine.Execute();
+        }
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.That(allocated, Is.Zero,
+            $"Sync token hot path allocated {allocated} B over {Iterations} runs.");
+    }
+
+    private static async Task AssertZeroAllocTokensAsync(NxGraph.Tokens.AsyncTokenMachine machine)
+    {
+        for (int i = 0; i < 50; i++)
+        {
+            await machine.ExecuteAsync();
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < Iterations; i++)
+        {
+            await machine.ExecuteAsync();
+        }
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.That(allocated, Is.Zero,
+            $"Async token hot path allocated {allocated} B over {Iterations} runs.");
+    }
+
+    /// <summary>load → fork(a, b) → join(All 2) → finish, sync logic throughout.</summary>
+    private static Graph TokenDiamond()
+    {
+        NxGraph.Tokens.JoinState join = new(NxGraph.Tokens.JoinPolicy.All(2));
+        return GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success).To(join).To(() => Result.Success),
+                b => b.To(() => Result.Success).To(join))
+            .Build();
+    }
+
+    [Test]
+    public void sync_token_fork_join_diamond_is_allocation_free()
+    {
+        AssertZeroAllocTokens(TokenDiamond().ToTokenMachine());
+    }
+
+    [Test]
+    public async Task async_token_fork_join_diamond_is_allocation_free()
+    {
+        await AssertZeroAllocTokensAsync(TokenDiamond().ToAsyncTokenMachine());
+    }
+
+    [Test]
+    public void sync_token_any_merge_is_allocation_free()
+    {
+        NxGraph.Tokens.JoinState merge = new(NxGraph.Tokens.JoinPolicy.Any);
+        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success).To(merge).To(() => Result.Success),
+                b => b.To(() => Result.Success).To(merge))
+            .Build();
+
+        AssertZeroAllocTokens(graph.ToTokenMachine());
+    }
+
+    [Test]
+    public void sync_token_retry_without_backoff_is_allocation_free()
+    {
+        int calls = 0;
+        NxGraph.Tokens.JoinState join = new(NxGraph.Tokens.JoinPolicy.All(2));
+        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => ++calls % 2 == 0 ? Result.Success : Result.Failure)
+                    .Retry(2)
+                    .To(join),
+                b => b.To(() => Result.Success).To(join))
+            .Build();
+
+        AssertZeroAllocTokens(graph.ToTokenMachine());
+    }
+
+    [Test]
+    public void sync_token_node_scope_scratch_is_allocation_free()
+    {
+        BlackboardSchema nodeSchema = new("token-scratch", BlackboardScope.Node);
+        BlackboardKey<int> counter = nodeSchema.Register("counter", 0);
+
+        NxGraph.Tokens.JoinState join = new(NxGraph.Tokens.JoinPolicy.All(2));
+        StateToken start = GraphBuilder.StartWith(() => Result.Success);
+        Graph graph = start.ForkTo(
+                b => b.To(bb =>
+                {
+                    bb.Set(counter, bb.Get(counter) + 1);
+                    return Result.Success;
+                }).To(join).To(() => Result.Success),
+                b => b.To(bb =>
+                {
+                    bb.Set(counter, bb.Get(counter) + 1);
+                    return Result.Success;
+                }).To(join))
+            .Builder.WithSchema(nodeSchema).Build();
+
+        AssertZeroAllocTokens(graph.ToTokenMachine());
+    }
+
+    [Test]
+    public async Task async_token_with_observer_is_allocation_free()
+    {
+        await AssertZeroAllocTokensAsync(TokenDiamond().ToAsyncTokenMachine(new NoopAsyncTokenObserver()));
+    }
+
+    private sealed class NoopAsyncTokenObserver : NxGraph.Tokens.IAsyncTokenMachineObserver
+    {
+        public ValueTask OnStateEntered(int tokenId, NodeId id, CancellationToken ct = default) =>
+            ValueTask.CompletedTask;
+
+        public ValueTask OnStateExited(int tokenId, NodeId id, CancellationToken ct = default) =>
+            ValueTask.CompletedTask;
+
+        public ValueTask OnTransition(int tokenId, NodeId from, NodeId to, CancellationToken ct = default) =>
+            ValueTask.CompletedTask;
+
+        public ValueTask OnTokenSpawned(int tokenId, int parentTokenId, NodeId at, CancellationToken ct = default) =>
+            ValueTask.CompletedTask;
+
+        public ValueTask OnTokenRetired(int tokenId, NodeId at, NxGraph.Tokens.TokenRetireReason reason,
+            CancellationToken ct = default) => ValueTask.CompletedTask;
+
+        public ValueTask OnJoinFired(NodeId joinNode, int survivingTokenId, CancellationToken ct = default) =>
+            ValueTask.CompletedTask;
     }
 }

--- a/NxGraph.Tests/GraphValidatorTests.cs
+++ b/NxGraph.Tests/GraphValidatorTests.cs
@@ -173,4 +173,52 @@ public class GraphValidatorTests
             Assert.That(falseBranchFlagged, Is.False, "False branch is reachable via director — should not be flagged.");
         });
     }
+
+    [Test]
+    public void DuplicateUid_ShouldBeError()
+    {
+        Guid shared = Guid.NewGuid();
+
+        GraphBuilder builder = new();
+        NodeId a = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success), isStart: true);
+        NodeId b = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success));
+        builder.AddTransition(a, b);
+        builder.SetUid(a, shared);
+        builder.SetUid(b, shared);
+
+        Graph graph = builder.Build(throwOnError: false);
+        GraphValidationResult res = graph.Validate();
+
+        GraphDiagnostic[] duplicates = res.Diagnostics
+            .Where(d => d.Severity == Severity.Error &&
+                        d.Message.Contains("Duplicate node UID", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(duplicates, Has.Length.EqualTo(2), "Every node claiming the UID gets its own Error.");
+            Assert.That(duplicates.Select(d => d.Node.Index), Is.EquivalentTo(new[] { a.Index, b.Index }));
+        });
+    }
+
+    [Test]
+    public void DistinctUids_ProduceNoUidDiagnostics()
+    {
+        GraphBuilder builder = new();
+        NodeId a = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success), isStart: true);
+        NodeId b = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success));
+        builder.AddTransition(a, b);
+        builder.SetUid(a, Guid.NewGuid());
+        builder.SetUid(b, Guid.NewGuid());
+
+        Graph graph = builder.Build(throwOnError: false);
+        GraphValidationResult res = graph.Validate(new GraphValidationOptions { AllNodes = builder.GetAllNodeIds() });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(res.HasErrors, Is.False);
+            Assert.That(res.Diagnostics.Any(d => d.Message.Contains("UID", StringComparison.Ordinal)), Is.False,
+                "Distinct UIDs must not produce any uid diagnostic.");
+        });
+    }
 }

--- a/NxGraph.Tests/NodeUidTests.cs
+++ b/NxGraph.Tests/NodeUidTests.cs
@@ -1,0 +1,197 @@
+using NxGraph.Authoring;
+using NxGraph.Diagnostics.Validations;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Per-node stable UIDs: authoring-time identity metadata for external tooling.
+/// UIDs live in a sidecar array on <see cref="Graph"/> (never in <see cref="NodeId"/>),
+/// are never read by any runtime, and resolve via <see cref="Graph.TryGetNodeByUid"/>.
+/// </summary>
+[TestFixture]
+public class NodeUidTests
+{
+    private static AsyncRelayState Noop() => new(_ => ResultHelpers.Success);
+
+    [Test]
+    public void set_uid_rejects_guid_empty()
+    {
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(Noop(), isStart: true);
+
+        Assert.Throws<ArgumentException>(() => builder.SetUid(start, Guid.Empty));
+    }
+
+    [Test]
+    public void set_uid_requires_existing_node()
+    {
+        GraphBuilder builder = new();
+        builder.AddNode(Noop(), isStart: true);
+
+        Assert.Throws<InvalidOperationException>(() => builder.SetUid(new NodeId(42), Guid.NewGuid()));
+    }
+
+    [Test]
+    public void set_uid_overwrites_on_same_node()
+    {
+        Guid first = Guid.NewGuid();
+        Guid second = Guid.NewGuid();
+
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(Noop(), isStart: true);
+        builder.SetUid(start, first);
+        builder.SetUid(start, second);
+        Graph graph = builder.Build(throwOnError: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(graph.Uids![0], Is.EqualTo(second));
+            Assert.That(graph.TryGetNodeByUid(first, out _), Is.False,
+                "The overwritten uid must no longer resolve.");
+            Assert.That(graph.TryGetNodeByUid(second, out _), Is.True);
+        });
+    }
+
+    [Test]
+    public void with_uid_on_start_node_lands_at_index_zero()
+    {
+        Guid uid = Guid.NewGuid();
+
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .WithUid(uid)
+            .Build();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(graph.Uids, Is.Not.Null);
+            Assert.That(graph.Uids![0], Is.EqualTo(uid));
+        });
+    }
+
+    [Test]
+    public void uids_materialize_as_dense_array_with_empty_for_unassigned()
+    {
+        Guid uid = Guid.NewGuid();
+
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .ToAsync(Noop()).WithUid(uid)
+            .ToAsync(Noop())
+            .Build();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(graph.Uids, Is.Not.Null);
+            Assert.That(graph.Uids!.Length, Is.EqualTo(graph.NodeCount));
+            Assert.That(graph.Uids[0], Is.EqualTo(Guid.Empty), "Unassigned node stays uid-free.");
+            Assert.That(graph.Uids[1], Is.EqualTo(uid));
+            Assert.That(graph.Uids[2], Is.EqualTo(Guid.Empty), "Unassigned node stays uid-free.");
+        });
+    }
+
+    [Test]
+    public void graph_without_uids_has_null_uid_array()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        Assert.That(graph.Uids, Is.Null);
+    }
+
+    [Test]
+    public void try_get_node_by_uid_finds_the_node()
+    {
+        Guid uid = Guid.NewGuid();
+
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(Noop(), isStart: true);
+        NodeId target = builder.AddNode(Noop());
+        builder.AddTransition(start, target);
+        builder.SetUid(target, uid);
+        Graph graph = builder.Build(throwOnError: false);
+
+        bool found = graph.TryGetNodeByUid(uid, out INode node);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(found, Is.True);
+            Assert.That(node.Id.Index, Is.EqualTo(target.Index));
+        });
+    }
+
+    [Test]
+    public void try_get_node_by_uid_miss_returns_false()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .WithUid(Guid.NewGuid())
+            .Build();
+
+        Assert.That(graph.TryGetNodeByUid(Guid.NewGuid(), out INode node), Is.False);
+        Assert.That(node, Is.EqualTo(LogicNode.Empty));
+    }
+
+    [Test]
+    public void try_get_node_by_uid_on_uidless_graph_returns_false()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        Assert.That(graph.TryGetNodeByUid(Guid.NewGuid(), out _), Is.False);
+    }
+
+    [Test]
+    public void try_get_node_by_uid_with_guid_empty_returns_false()
+    {
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .WithUid(Guid.NewGuid())
+            .ToAsync(Noop()) // uid-free node occupies an Empty slot in the sidecar
+            .Build();
+
+        Assert.That(graph.TryGetNodeByUid(Guid.Empty, out _), Is.False,
+            "Guid.Empty encodes 'no uid' and must never match a node.");
+    }
+
+    [Test]
+    public void graph_ctor_rejects_uid_array_length_mismatch()
+    {
+        Graph valid = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+        INode[] nodes = [valid.StartNode];
+        Transition[] edges = [Transition.Empty];
+
+        Assert.Throws<ArgumentException>(() =>
+            _ = new Graph(new NodeId(1), nodes, edges, uids: new Guid[2]));
+    }
+
+    [Test]
+    public void nested_subgraph_may_reuse_a_parent_uid()
+    {
+        Guid shared = Guid.NewGuid();
+
+        Graph child = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .WithUid(shared)
+            .Build();
+
+        StateToken parentStart = GraphBuilder
+            .StartWithAsync(_ => ResultHelpers.Success)
+            .WithUid(shared);
+        Graph parent = parentStart.SubGraph(child).Build();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parent.TryGetNodeByUid(shared, out INode parentNode), Is.True);
+            Assert.That(parentNode.Id.Index, Is.EqualTo(0), "Parent lookup resolves within the parent graph only.");
+            Assert.That(child.TryGetNodeByUid(shared, out INode childNode), Is.True);
+            Assert.That(childNode.Id.Index, Is.EqualTo(0), "Child lookup resolves within the child graph only.");
+            Assert.That(parent.Validate().HasErrors, Is.False,
+                "Uid uniqueness is per-graph; reuse across nesting levels is legal.");
+        });
+    }
+}

--- a/NxGraph.Tests/PublicApi/NxGraph.Serialization.Abstraction.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.Serialization.Abstraction.approved.txt
@@ -7,6 +7,10 @@ interface NxGraph.Serialization.Abstraction.IBlackboardBinarySerializer
 interface NxGraph.Serialization.Abstraction.IBlackboardJsonSerializer
   method System.Threading.Tasks.ValueTask RestoreFromJsonAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, NxGraph.Serialization.Abstraction.BlackboardMismatchPolicy, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask ToJsonAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, System.Threading.CancellationToken)
+interface NxGraph.Serialization.Abstraction.IContainerCodec
+interface NxGraph.Serialization.Abstraction.IContainerCodec`1 : NxGraph.Serialization.Abstraction.IContainerCodec
+  method NxGraph.Graphs.IAsyncLogic Deserialize(TWire, System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.Graph])
+  method TWire Serialize(NxGraph.Graphs.ISubGraphProvider)
 interface NxGraph.Serialization.Abstraction.IGraphBinarySerializer : NxGraph.Serialization.Abstraction.IGraphSerializer
   method System.Threading.Tasks.ValueTask ToBinaryAsync(NxGraph.Graphs.Graph, System.IO.Stream, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.Graph] FromBinaryAsync(System.IO.Stream, System.Threading.CancellationToken)
@@ -18,3 +22,6 @@ interface NxGraph.Serialization.Abstraction.ILogicCodec
 interface NxGraph.Serialization.Abstraction.ILogicCodec`1 : NxGraph.Serialization.Abstraction.ILogicCodec
   method NxGraph.Graphs.IAsyncLogic Deserialize(TWire)
   method TWire Serialize(NxGraph.Graphs.IAsyncLogic)
+interface NxGraph.Serialization.Abstraction.IRegionSelectorRegistry
+  method Boolean TryGetKey(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], System.String ByRef)
+  method Boolean TryGetSelector(System.String, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask] ByRef)

--- a/NxGraph.Tests/PublicApi/NxGraph.Serialization.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.Serialization.approved.txt
@@ -6,13 +6,25 @@ sealed class NxGraph.Serialization.BlackboardSerializer : NxGraph.Serialization.
   method System.Threading.Tasks.ValueTask ToJsonAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, System.Threading.CancellationToken)
 sealed class NxGraph.Serialization.GraphSerializer : NxGraph.Serialization.Abstraction.IGraphBinarySerializer, NxGraph.Serialization.Abstraction.IGraphJsonSerializer, NxGraph.Serialization.Abstraction.IGraphSerializer
   ctor Void .ctor(NxGraph.Serialization.Abstraction.ILogicCodec)
+  ctor Void .ctor(NxGraph.Serialization.Abstraction.ILogicCodec, NxGraph.Serialization.GraphSerializerOptions)
   method NxGraph.Serialization.Abstraction.IGraphBinarySerializer AsBinarySerializer()
   method NxGraph.Serialization.Abstraction.IGraphJsonSerializer AsJsonSerializer()
   method System.Threading.Tasks.ValueTask ToBinaryAsync(NxGraph.Graphs.Graph, System.IO.Stream, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask ToJsonAsync(NxGraph.Graphs.Graph, System.IO.Stream, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.Graph] FromBinaryAsync(System.IO.Stream, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.Graph] FromJsonAsync(System.IO.Stream, System.Threading.CancellationToken)
+sealed class NxGraph.Serialization.GraphSerializerOptions
+  ctor Void .ctor()
+  property NxGraph.Serialization.Abstraction.IContainerCodec ContainerCodec { get; set; }
+  property NxGraph.Serialization.Abstraction.IRegionSelectorRegistry SelectorRegistry { get; set; }
+interface NxGraph.Serialization.IContainerBinaryCodec : NxGraph.Serialization.Abstraction.IContainerCodec, NxGraph.Serialization.Abstraction.IContainerCodec`1[[System.ReadOnlyMemory`1[[System.Byte, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
+interface NxGraph.Serialization.IContainerTextCodec : NxGraph.Serialization.Abstraction.IContainerCodec, NxGraph.Serialization.Abstraction.IContainerCodec`1[[System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 interface NxGraph.Serialization.ILogicBinaryCodec : NxGraph.Serialization.Abstraction.ILogicCodec, NxGraph.Serialization.Abstraction.ILogicCodec`1[[System.ReadOnlyMemory`1[[System.Byte, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 interface NxGraph.Serialization.ILogicTextCodec : NxGraph.Serialization.Abstraction.ILogicCodec, NxGraph.Serialization.Abstraction.ILogicCodec`1[[System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
+sealed class NxGraph.Serialization.RegionSelectorRegistry : NxGraph.Serialization.Abstraction.IRegionSelectorRegistry
+  ctor Void .ctor()
+  method Boolean TryGetKey(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], System.String ByRef)
+  method Boolean TryGetSelector(System.String, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask] ByRef)
+  method System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask] Register(System.String, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask])
 static class NxGraph.Serialization.SerializationVersion
   field static System.Int32 Version

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -144,6 +144,19 @@ struct NxGraph.Authoring.Dsl+SwitchBuilder`1
   method SwitchBuilder`1 CaseAsync(TKey, NxGraph.Graphs.IAsyncLogic)
   method SwitchBuilder`1 Default(NxGraph.Graphs.ILogic)
   method SwitchBuilder`1 DefaultAsync(NxGraph.Graphs.IAsyncLogic)
+sealed class NxGraph.Authoring.ForkBranch
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken)
+  method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken To(System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken ToAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+struct NxGraph.Authoring.ForkToken
+  method NxGraph.Authoring.ForkToken SetName(System.String)
+  method NxGraph.Graphs.Graph Build()
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
 struct NxGraph.Authoring.GotoToken
   method NxGraph.Graphs.Graph Build()
   property NxGraph.Authoring.GraphBuilder Builder { get; }
@@ -156,6 +169,7 @@ sealed class NxGraph.Authoring.GraphBuilder
   method NxGraph.Authoring.GraphBuilder SetExitAction(NxGraph.Graphs.NodeId, System.Action)
   method NxGraph.Authoring.GraphBuilder SetOutcome(NxGraph.Graphs.NodeId, Int32, System.String)
   method NxGraph.Authoring.GraphBuilder SetRetryPolicy(NxGraph.Graphs.NodeId, NxGraph.Fsm.RetryPolicy)
+  method NxGraph.Authoring.GraphBuilder SetUid(NxGraph.Graphs.NodeId, System.Guid)
   method NxGraph.Authoring.GraphBuilder WithSchema(NxGraph.Blackboards.BlackboardSchema)
   method NxGraph.Authoring.StartToken Start()
   method NxGraph.Authoring.StateToken StartWith(NxGraph.Graphs.ILogic)
@@ -203,9 +217,17 @@ struct NxGraph.Authoring.StateToken
   method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
   method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
   method NxGraph.Authoring.StateToken WithOutcome(Int32, System.String)
+  method NxGraph.Authoring.StateToken WithUid(System.Guid)
   method NxGraph.Graphs.Graph Build()
   property NxGraph.Authoring.GraphBuilder Builder { get; }
   property NxGraph.Graphs.NodeId Id { get; }
+static class NxGraph.Authoring.TokenDsl
+  method NxGraph.Authoring.ForkToken ForkTo(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Authoring.ForkBranch,NxGraph.Authoring.StateToken][])
+  method NxGraph.Authoring.ForkToken ForkTo(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Authoring.ForkBranch,NxGraph.Authoring.StateToken][])
+  method NxGraph.Tokens.AsyncTokenMachine ToAsyncTokenMachine(NxGraph.Graphs.Graph, NxGraph.Tokens.IAsyncTokenMachineObserver, Int32)
+  method NxGraph.Tokens.AsyncTokenMachine`1[TAgent] ToAsyncTokenMachine[TAgent](NxGraph.Graphs.Graph, NxGraph.Tokens.IAsyncTokenMachineObserver, Int32)
+  method NxGraph.Tokens.TokenMachine ToTokenMachine(NxGraph.Graphs.Graph, NxGraph.Tokens.ITokenMachineObserver, Int32)
+  method NxGraph.Tokens.TokenMachine`1[TAgent] ToTokenMachine[TAgent](NxGraph.Graphs.Graph, NxGraph.Tokens.ITokenMachineObserver, Int32)
 sealed class NxGraph.Blackboards.Blackboard
   ctor Void .ctor(NxGraph.Blackboards.BlackboardSchema)
   method Boolean TryGet[T](NxGraph.Blackboards.BlackboardKey`1[T], T ByRef)
@@ -370,10 +392,12 @@ sealed class NxGraph.Fsm.Async.AsyncChoiceState : NxGraph.Blackboards.IBlackboar
 class NxGraph.Fsm.Async.AsyncCompositeState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.IAsyncLogic)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  property NxGraph.Graphs.IAsyncLogic Child { get; }
 sealed class NxGraph.Fsm.Async.AsyncDynamicParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
   property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.Async.AsyncStateMachine] Regions { get; }
+  property System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask] Selector { get; }
 sealed class NxGraph.Fsm.Async.AsyncHistoryState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
@@ -455,6 +479,7 @@ sealed class NxGraph.Fsm.DynamicParallelState : NxGraph.Blackboards.IBlackboardS
   method NxGraph.Result Execute()
   property NxGraph.Fsm.ParallelStepMode Mode { get; }
   property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.StateMachine] Regions { get; }
+  property System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask] Selector { get; }
 enum NxGraph.Fsm.ExecutionStatus : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
   Cancelled = 6
   Completed = 4
@@ -648,9 +673,10 @@ sealed class NxGraph.Graphs.EmptyLogic : NxGraph.Graphs.ILogic
   ctor Void .ctor()
   method NxGraph.Result Execute()
 sealed class NxGraph.Graphs.Graph : NxGraph.Graphs.IGraph, NxGraph.Graphs.INode
-  ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode[], NxGraph.Graphs.Transition[], NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.RetryPolicy[], Int32[], System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String], NxGraph.Blackboards.BlackboardSchema, NxGraph.Blackboards.BlackboardSchema, NxGraph.Blackboards.BlackboardSchema)
+  ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode[], NxGraph.Graphs.Transition[], NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.RetryPolicy[], Int32[], System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String], NxGraph.Blackboards.BlackboardSchema, NxGraph.Blackboards.BlackboardSchema, NxGraph.Blackboards.BlackboardSchema, System.Guid[])
   method Boolean TryGetNode(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode ByRef)
   method Boolean TryGetNodeByIndex(Int32, NxGraph.Graphs.INode ByRef)
+  method Boolean TryGetNodeByUid(System.Guid, NxGraph.Graphs.INode ByRef)
   method Boolean TryGetTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.Transition ByRef)
   method NxGraph.Graphs.INode GetNodeByIndex(Int32)
   method NxGraph.Graphs.Transition GetTransitionByIndex(Int32)
@@ -668,6 +694,7 @@ sealed class NxGraph.Graphs.Graph : NxGraph.Graphs.IGraph, NxGraph.Graphs.INode
   property NxGraph.Graphs.INode StartNode { get; }
   property NxGraph.Graphs.NodeId Id { get; }
   property System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String] OutcomeNames { get; }
+  property System.Guid[] Uids { get; }
 interface NxGraph.Graphs.IAsyncLogic
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
 interface NxGraph.Graphs.IGraph
@@ -688,10 +715,14 @@ interface NxGraph.Graphs.ISubGraphProvider
   property System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.Graph] SubGraphs { get; }
 class NxGraph.Graphs.LogicNode : NxGraph.Graphs.INode
   ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.IAsyncLogic, System.Action, System.Action)
+  field static readonly NxGraph.Graphs.LogicNode DynamicParallelStateMarker
   field static readonly NxGraph.Graphs.LogicNode Empty
+  field static readonly NxGraph.Graphs.LogicNode ForkStateMarker
   field static readonly NxGraph.Graphs.LogicNode HistoryStateMarker
+  field static readonly NxGraph.Graphs.LogicNode JoinStateMarker
   field static readonly NxGraph.Graphs.LogicNode ParallelStateMarker
   field static readonly NxGraph.Graphs.LogicNode StateMachineMarker
+  field static readonly NxGraph.Graphs.LogicNode SyncDynamicParallelStateMarker
   field static readonly NxGraph.Graphs.LogicNode SyncHistoryStateMarker
   field static readonly NxGraph.Graphs.LogicNode SyncParallelStateMarker
   field static readonly NxGraph.Graphs.LogicNode SyncStateMachineMarker
@@ -714,10 +745,14 @@ struct NxGraph.Graphs.NodeId : System.IEquatable`1[[NxGraph.Graphs.NodeId, NxGra
   operator Boolean op_Inequality(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
   property Int32 Index { get; }
   property NxGraph.Graphs.NodeId Default { get; }
+  property NxGraph.Graphs.NodeId DynamicParallelStateMarker { get; }
+  property NxGraph.Graphs.NodeId ForkStateMarker { get; }
   property NxGraph.Graphs.NodeId HistoryStateMarker { get; }
+  property NxGraph.Graphs.NodeId JoinStateMarker { get; }
   property NxGraph.Graphs.NodeId ParallelStateMarker { get; }
   property NxGraph.Graphs.NodeId Start { get; }
   property NxGraph.Graphs.NodeId StateMachineMarker { get; }
+  property NxGraph.Graphs.NodeId SyncDynamicParallelStateMarker { get; }
   property NxGraph.Graphs.NodeId SyncHistoryStateMarker { get; }
   property NxGraph.Graphs.NodeId SyncParallelStateMarker { get; }
   property NxGraph.Graphs.NodeId SyncStateMachineMarker { get; }
@@ -764,3 +799,125 @@ static class NxGraph.ResultHelpers
   field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]] Failure
   field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]] InProgress
   field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]] Success
+class NxGraph.Tokens.AsyncTokenMachine : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Tokens.IAsyncTokenMachineObserver, Int32)
+  field readonly NxGraph.Graphs.Graph Graph
+  method NxGraph.Tokens.TokenMachineSnapshot Suspend()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] Reset(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] StepAsync(System.Threading.CancellationToken)
+  method Void Resume(NxGraph.Tokens.TokenMachineSnapshot)
+  method Void SetBlackboard(NxGraph.Blackboards.Blackboard)
+  method Void SetRestartPolicy(NxGraph.Fsm.RestartPolicy)
+  property Int32 LiveTokenCount { get; }
+  property NxGraph.Fsm.ExecutionStatus Status { get; }
+class NxGraph.Tokens.AsyncTokenMachine`1 : NxGraph.Tokens.AsyncTokenMachine, IAgentSettable`1, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Tokens.IAsyncTokenMachineObserver, Int32)
+  method Void SetAgent(TAgent)
+sealed class NxGraph.Tokens.ForkState : NxGraph.Fsm.IAsyncDirector, NxGraph.Fsm.IDirector, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ILogic
+  ctor Void .ctor(NxGraph.Graphs.NodeId[])
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId] Branches { get; }
+interface NxGraph.Tokens.IAsyncTokenMachineObserver
+  method System.Threading.Tasks.ValueTask OnJoinFired(NxGraph.Graphs.NodeId, Int32, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnLogReport(Int32, NxGraph.Graphs.NodeId, System.String, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateEntered(Int32, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateExited(Int32, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateFailed(Int32, NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenMachineCancelled(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenMachineReset(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenMachineStarted(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenRetired(Int32, NxGraph.Graphs.NodeId, NxGraph.Tokens.TokenRetireReason, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenSpawned(Int32, Int32, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTransition(Int32, NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask TokenMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus, System.Threading.CancellationToken)
+interface NxGraph.Tokens.ITokenMachineObserver
+  method Void OnJoinFired(NxGraph.Graphs.NodeId, Int32)
+  method Void OnLogReport(Int32, NxGraph.Graphs.NodeId, System.String)
+  method Void OnStateEntered(Int32, NxGraph.Graphs.NodeId)
+  method Void OnStateExited(Int32, NxGraph.Graphs.NodeId)
+  method Void OnStateFailed(Int32, NxGraph.Graphs.NodeId, System.Exception)
+  method Void OnTokenMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result)
+  method Void OnTokenMachineReset(NxGraph.Graphs.NodeId)
+  method Void OnTokenMachineStarted(NxGraph.Graphs.NodeId)
+  method Void OnTokenRetired(Int32, NxGraph.Graphs.NodeId, NxGraph.Tokens.TokenRetireReason)
+  method Void OnTokenSpawned(Int32, Int32, NxGraph.Graphs.NodeId)
+  method Void OnTransition(Int32, NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method Void TokenMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus)
+enum NxGraph.Tokens.JoinKind : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  All = 0
+  Any = 1
+  Quorum = 2
+struct NxGraph.Tokens.JoinPolicy
+  method NxGraph.Tokens.JoinPolicy All(Int32)
+  method NxGraph.Tokens.JoinPolicy Quorum(Int32)
+  method System.String ToString()
+  property Int32 Count { get; }
+  property Int32 RequiredCount { get; }
+  property NxGraph.Tokens.JoinKind Kind { get; }
+  property NxGraph.Tokens.JoinPolicy Any { get; }
+sealed class NxGraph.Tokens.JoinState : NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ILogic
+  ctor Void .ctor(NxGraph.Tokens.JoinPolicy)
+  property NxGraph.Tokens.JoinPolicy Policy { get; }
+class NxGraph.Tokens.TokenMachine : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Tokens.ITokenMachineObserver, Int32)
+  field readonly NxGraph.Graphs.Graph Graph
+  field static System.Int32 DefaultMaxTokens
+  method NxGraph.Result OnRun()
+  method NxGraph.Result Reset()
+  method NxGraph.Tokens.TokenMachineSnapshot Suspend()
+  method Void OnEnter()
+  method Void OnExit()
+  method Void Resume(NxGraph.Tokens.TokenMachineSnapshot)
+  method Void SetBlackboard(NxGraph.Blackboards.Blackboard)
+  method Void SetRestartPolicy(NxGraph.Fsm.RestartPolicy)
+  method Void SetStepMode(NxGraph.Fsm.ParallelStepMode)
+  property Int32 LiveTokenCount { get; }
+  property NxGraph.Fsm.ExecutionStatus Status { get; }
+  property NxGraph.Fsm.ParallelStepMode StepMode { get; }
+sealed class NxGraph.Tokens.TokenMachineSnapshot : System.IEquatable`1[[NxGraph.Tokens.TokenMachineSnapshot, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+  ctor Void .ctor(NxGraph.Fsm.ExecutionStatus, Boolean, Int32, NxGraph.Tokens.TokenRecord[], Int32[])
+  method Boolean Equals(NxGraph.Tokens.TokenMachineSnapshot)
+  method Boolean Equals(System.Object)
+  method Int32 GetHashCode()
+  method NxGraph.Tokens.TokenMachineSnapshot <Clone>$()
+  method System.String ToString()
+  method Void Deconstruct(NxGraph.Fsm.ExecutionStatus ByRef, Boolean ByRef, Int32 ByRef, NxGraph.Tokens.TokenRecord[] ByRef, Int32[] ByRef)
+  operator Boolean op_Equality(NxGraph.Tokens.TokenMachineSnapshot, NxGraph.Tokens.TokenMachineSnapshot)
+  operator Boolean op_Inequality(NxGraph.Tokens.TokenMachineSnapshot, NxGraph.Tokens.TokenMachineSnapshot)
+  property Boolean AnyTokenDied { get; set; }
+  property Boolean MidRun { get; set; }
+  property Boolean[] JoinsFired { get; set; }
+  property Int32 NextTokenId { get; set; }
+  property Int32[] JoinArrivals { get; set; }
+  property NxGraph.Fsm.ExecutionStatus Status { get; set; }
+  property NxGraph.Tokens.TokenRecord[] Tokens { get; set; }
+class NxGraph.Tokens.TokenMachine`1 : NxGraph.Tokens.TokenMachine, IAgentSettable`1, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Tokens.ITokenMachineObserver, Int32)
+  method Void SetAgent(TAgent)
+enum NxGraph.Tokens.TokenPhase : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Parked = 1
+  Runnable = 0
+sealed class NxGraph.Tokens.TokenRecord : System.IEquatable`1[[NxGraph.Tokens.TokenRecord, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+  ctor Void .ctor(Int32, Int32, Int32, Boolean, NxGraph.Tokens.TokenPhase)
+  method Boolean Equals(NxGraph.Tokens.TokenRecord)
+  method Boolean Equals(System.Object)
+  method Int32 GetHashCode()
+  method NxGraph.Tokens.TokenRecord <Clone>$()
+  method System.String ToString()
+  method Void Deconstruct(Int32 ByRef, Int32 ByRef, Int32 ByRef, Boolean ByRef, NxGraph.Tokens.TokenPhase ByRef)
+  operator Boolean op_Equality(NxGraph.Tokens.TokenRecord, NxGraph.Tokens.TokenRecord)
+  operator Boolean op_Inequality(NxGraph.Tokens.TokenRecord, NxGraph.Tokens.TokenRecord)
+  property Boolean NodeEntered { get; set; }
+  property Int32 Attempts { get; set; }
+  property Int32 Id { get; set; }
+  property Int32 NodeIndex { get; set; }
+  property NxGraph.Tokens.TokenPhase Phase { get; set; }
+enum NxGraph.Tokens.TokenRetireReason : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Absorbed = 4
+  Completed = 0
+  Failed = 1
+  Joined = 2
+  Starved = 3

--- a/NxGraph.Tests/Tokens/AsyncTokenMachineTests.cs
+++ b/NxGraph.Tests/Tokens/AsyncTokenMachineTests.cs
@@ -1,0 +1,284 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Tests.Tokens;
+
+/// <summary>
+/// Async twin of <see cref="TokenMachineTests"/> (runtime parity): same fork/join/quorum,
+/// per-token failure, and starvation semantics, plus the async-specific mechanics —
+/// <c>StepAsync</c> round stepping, cancellation, retry backoff, and the node-level
+/// <see cref="Result.InProgress"/> rejection.
+/// </summary>
+[TestFixture]
+public class AsyncTokenMachineTests
+{
+    private static Func<CancellationToken, ValueTask<Result>> Log(List<string> log, string message) => _ =>
+    {
+        log.Add(message);
+        return ResultHelpers.Success;
+    };
+
+    /// <summary>load → fork(a, b) → join(All 2) → finish.</summary>
+    private static Graph Diamond(List<string> log)
+    {
+        JoinState join = new(JoinPolicy.All(2));
+        return GraphBuilder.StartWithAsync(Log(log, "load"))
+            .ForkTo(
+                b => b.ToAsync(Log(log, "a")).To(join).ToAsync(Log(log, "finish")),
+                b => b.ToAsync(Log(log, "b")).To(join))
+            .Build();
+    }
+
+    [Test]
+    public async Task fork_join_all_runs_both_branches_and_joins()
+    {
+        List<string> log = [];
+        AsyncTokenMachine machine = Diamond(log).ToAsyncTokenMachine();
+
+        Result result = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b", "finish" }),
+                "Same interleaving as the sync twin: one node per token per round.");
+        });
+    }
+
+    [Test]
+    public async Task step_async_advances_one_round_per_call()
+    {
+        List<string> log = [];
+        AsyncTokenMachine machine = Diamond(log).ToAsyncTokenMachine();
+
+        Result first = await machine.StepAsync();
+        Result second = await machine.StepAsync();
+        Result third = await machine.StepAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo(Result.InProgress), "Round 1: load runs.");
+            Assert.That(second, Is.EqualTo(Result.InProgress), "Round 2: branches run, join fires.");
+            Assert.That(third, Is.EqualTo(Result.Success), "Round 3: finish runs; run drains.");
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b", "finish" }));
+        });
+    }
+
+    [Test]
+    public async Task any_join_is_a_merge_point_every_token_passes()
+    {
+        List<string> log = [];
+        JoinState merge = new(JoinPolicy.Any);
+        Graph graph = GraphBuilder.StartWithAsync(Log(log, "load"))
+            .ForkTo(
+                b => b.ToAsync(Log(log, "a")).To(merge).ToAsync(Log(log, "after")),
+                b => b.ToAsync(Log(log, "b")).To(merge))
+            .Build();
+
+        Result result = await graph.ToAsyncTokenMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log.Count(entry => entry == "after"), Is.EqualTo(2),
+                "Any-join merges: both tokens rejoin the shared tail mid-graph.");
+        });
+    }
+
+    [Test]
+    public async Task quorum_join_fires_at_m_and_absorbs_leftovers()
+    {
+        List<string> log = [];
+        List<TokenRetireReason> reasons = [];
+        JoinState quorum = new(JoinPolicy.Quorum(2));
+        Graph graph = GraphBuilder.StartWithAsync(Log(log, "load"))
+            .ForkTo(
+                b => b.ToAsync(Log(log, "fast1")).To(quorum).ToAsync(Log(log, "after")),
+                b => b.ToAsync(Log(log, "fast2")).To(quorum),
+                b => b.ToAsync(Log(log, "slow1")).ToAsync(Log(log, "slow2")).To(quorum))
+            .Build();
+
+        Result result = await graph.ToAsyncTokenMachine(new RetireRecorder(reasons)).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log.Count(entry => entry == "after"), Is.EqualTo(1));
+            Assert.That(reasons.Count(r => r == TokenRetireReason.Absorbed), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task all_join_starves_when_a_supplier_dies()
+    {
+        List<TokenRetireReason> reasons = [];
+        JoinState join = new(JoinPolicy.All(2));
+        Graph graph = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success)
+            .ForkTo(
+                b => b.ToAsync(_ => ResultHelpers.Success).To(join).ToAsync(_ => ResultHelpers.Success),
+                b => b.ToAsync(_ => new ValueTask<Result>(Result.Failure)))
+            .Build();
+
+        Result result = await graph.ToAsyncTokenMachine(new RetireRecorder(reasons)).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(reasons.Count(r => r == TokenRetireReason.Failed), Is.EqualTo(1));
+            Assert.That(reasons.Count(r => r == TokenRetireReason.Starved), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task per_token_retry_honors_backoff_and_succeeds()
+    {
+        int attempts = 0;
+        JoinState join = new(JoinPolicy.All(2));
+        Graph graph = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success)
+            .ForkTo(
+                b => b.ToAsync(_ => new ValueTask<Result>(++attempts < 3 ? Result.Failure : Result.Success))
+                    .Retry(3, TimeSpan.FromMilliseconds(1))
+                    .To(join),
+                b => b.ToAsync(_ => ResultHelpers.Success).To(join))
+            .Build();
+
+        Result result = await graph.ToAsyncTokenMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(attempts, Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public async Task failure_edge_reroutes_and_rejoins()
+    {
+        List<string> log = [];
+        JoinState join = new(JoinPolicy.All(2));
+        Fsm.Async.AsyncRelayState recovered = new(Log(log, "recovered"));
+        Graph graph = GraphBuilder.StartWithAsync(Log(log, "load"))
+            .ForkTo(
+                b =>
+                {
+                    StateToken broken = b.ToAsync(_ =>
+                    {
+                        log.Add("broken");
+                        return new ValueTask<Result>(Result.Failure);
+                    });
+                    broken.OnErrorAsync(recovered);
+                    NodeId handlerId = broken.Builder.AddNode(recovered);
+                    return broken.Builder.TokenFor(handlerId).To(join);
+                },
+                b => b.ToAsync(Log(log, "steady")).To(join).ToAsync(Log(log, "finish")))
+            .Build();
+
+        Result result = await graph.ToAsyncTokenMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "load", "broken", "steady", "recovered", "finish" }));
+        });
+    }
+
+    [Test]
+    public void node_level_in_progress_is_rejected()
+    {
+        Graph graph = GraphBuilder.StartWithAsync(_ => new ValueTask<Result>(Result.InProgress)).Build();
+        AsyncTokenMachine machine = graph.ToAsyncTokenMachine();
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await machine.ExecuteAsync(),
+            "Async node logic must never return InProgress — same contract as the async FSM.");
+    }
+
+    [Test]
+    public void cancellation_flows_out_and_cancels_the_machine()
+    {
+        using CancellationTokenSource cts = new();
+        Graph graph = GraphBuilder.StartWithAsync(async ct =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                return Result.Success;
+            })
+            .Build();
+
+        AsyncTokenMachine machine = graph.ToAsyncTokenMachine();
+        machine.SetRestartPolicy(RestartPolicy.Manual);
+
+        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
+        Assert.CatchAsync<OperationCanceledException>(async () => await machine.ExecuteAsync(cts.Token));
+        Assert.That(machine.Status, Is.EqualTo(ExecutionStatus.Cancelled));
+    }
+
+    [Test]
+    public async Task snapshots_are_interchangeable_between_token_runtimes()
+    {
+        // Drive the sync machine two rounds in (one token parked at the join, one mid-branch),
+        // suspend, and finish the flow on a fresh async machine — and vice versa.
+        List<string> log = [];
+        JoinState join = new(JoinPolicy.All(2));
+
+        Graph BuildGraph() => GraphBuilder.StartWith(() =>
+            {
+                log.Add("load");
+                return Result.Success;
+            })
+            .ForkTo(
+                b => b.To(() =>
+                {
+                    log.Add("a");
+                    return Result.Success;
+                }).To(join).To(() =>
+                {
+                    log.Add("finish");
+                    return Result.Success;
+                }),
+                b => b.To(() =>
+                {
+                    log.Add("b1");
+                    return Result.Success;
+                }).To(() =>
+                {
+                    log.Add("b2");
+                    return Result.Success;
+                }).To(join))
+            .Build();
+
+        TokenMachine sync = BuildGraph().ToTokenMachine();
+        Assert.That(sync.Execute(), Is.EqualTo(Result.InProgress)); // round 1: load
+        Assert.That(sync.Execute(), Is.EqualTo(Result.InProgress)); // round 2: a parks, b1 runs
+
+        TokenMachineSnapshot snapshot = sync.Suspend();
+        Assert.That(snapshot.MidRun, Is.True);
+        Assert.That(snapshot.Tokens, Has.Length.EqualTo(2));
+
+        AsyncTokenMachine resumed = BuildGraph().ToAsyncTokenMachine();
+        resumed.Resume(snapshot);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await resumed.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b1", "b2", "finish" }),
+                "The resumed machine continues exactly where the suspended one stopped.");
+        });
+    }
+
+    private sealed class RetireRecorder(List<TokenRetireReason> sink) : IAsyncTokenMachineObserver
+    {
+        public ValueTask OnTokenRetired(int tokenId, NodeId at, TokenRetireReason reason,
+            CancellationToken ct = default)
+        {
+            sink.Add(reason);
+            return default;
+        }
+    }
+}

--- a/NxGraph.Tests/Tokens/TokenMachineTests.cs
+++ b/NxGraph.Tests/Tokens/TokenMachineTests.cs
@@ -1,0 +1,418 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Tests.Tokens;
+
+/// <summary>
+/// Behavior spec for the sync <see cref="TokenMachine"/> (spec 007): fork fan-out, join
+/// merge/quorum semantics, per-token failure/retry, starvation rules, stepping modes, and
+/// the fail-loud contract of fork/join nodes under the FSM runtimes.
+/// </summary>
+[TestFixture]
+public class TokenMachineTests
+{
+    private static Func<Result> Log(List<string> log, string message) => () =>
+    {
+        log.Add(message);
+        return Result.Success;
+    };
+
+    /// <summary>load → fork(a, b) → join(All 2) → finish.</summary>
+    private static Graph Diamond(List<string> log)
+    {
+        JoinState join = new(JoinPolicy.All(2));
+        return GraphBuilder.StartWith(Log(log, "load"))
+            .ForkTo(
+                b => b.To(Log(log, "a")).To(join).To(Log(log, "finish")),
+                b => b.To(Log(log, "b")).To(join))
+            .Build();
+    }
+
+    [Test]
+    public void fork_join_all_runs_both_branches_and_joins()
+    {
+        List<string> log = [];
+        TokenMachine machine = Diamond(log).ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b", "finish" }),
+                "Round scheduling: both branches advance one node per round; the join fires when both arrive.");
+        });
+    }
+
+    [Test]
+    public void round_per_tick_returns_in_progress_between_rounds()
+    {
+        List<string> log = [];
+        TokenMachine machine = Diamond(log).ToTokenMachine();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(machine.Execute(), Is.EqualTo(Result.InProgress), "Round 1: load runs.");
+            Assert.That(machine.Execute(), Is.EqualTo(Result.InProgress), "Round 2: branches run, join fires.");
+            Assert.That(machine.Execute(), Is.EqualTo(Result.Success), "Round 3: finish runs; run drains.");
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b", "finish" }));
+        });
+    }
+
+    [Test]
+    public void any_join_is_a_merge_point_every_token_passes()
+    {
+        List<string> log = [];
+        JoinState merge = new(JoinPolicy.Any);
+        Graph graph = GraphBuilder.StartWith(Log(log, "load"))
+            .ForkTo(
+                b => b.To(Log(log, "a")).To(merge).To(Log(log, "after")),
+                b => b.To(Log(log, "b")).To(merge))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log.Count(entry => entry == "after"), Is.EqualTo(2),
+                "Any-join merges: both tokens pass through and re-enter the shared tail mid-graph.");
+        });
+    }
+
+    [Test]
+    public void quorum_join_fires_at_m_and_absorbs_leftovers()
+    {
+        List<string> log = [];
+        List<(int Token, TokenRetireReason Reason)> retired = [];
+        JoinState quorum = new(JoinPolicy.Quorum(2));
+        Graph graph = GraphBuilder.StartWith(Log(log, "load"))
+            .ForkTo(
+                b => b.To(Log(log, "fast1")).To(quorum).To(Log(log, "after")),
+                b => b.To(Log(log, "fast2")).To(quorum),
+                b => b.To(Log(log, "slow1")).To(Log(log, "slow2")).To(quorum))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine(new RetireRecorder(retired));
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success),
+                "The 2-of-3 quorum fires on the two fast branches; the slow leftover absorbs benignly.");
+            Assert.That(log.Count(entry => entry == "after"), Is.EqualTo(1), "The quorum fires exactly once.");
+            Assert.That(retired.Count(r => r.Reason == TokenRetireReason.Absorbed), Is.EqualTo(1),
+                "The late third token retires as a benign quorum leftover.");
+        });
+    }
+
+    [Test]
+    public void all_join_starves_when_a_supplier_dies()
+    {
+        List<(int Token, TokenRetireReason Reason)> retired = [];
+        JoinState join = new(JoinPolicy.All(2));
+        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success).To(join).To(() => Result.Success),
+                b => b.To(() => Result.Failure))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine(new RetireRecorder(retired));
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure), "A dead supplier starves the All-join.");
+            Assert.That(retired.Count(r => r.Reason == TokenRetireReason.Failed), Is.EqualTo(1));
+            Assert.That(retired.Count(r => r.Reason == TokenRetireReason.Starved), Is.EqualTo(1),
+                "The waiting token starves at the join that never fired.");
+        });
+    }
+
+    [Test]
+    public void machine_fails_when_any_token_dies_but_others_run_to_completion()
+    {
+        List<string> log = [];
+        Graph graph = GraphBuilder.StartWith(Log(log, "load"))
+            .ForkTo(
+                b => b.To(Log(log, "ok1")).To(Log(log, "ok2")),
+                b => b.To(() => Result.Failure))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure), "A token died unjoined.");
+            Assert.That(log, Is.EqualTo(new[] { "load", "ok1", "ok2" }),
+                "The surviving branch runs to its natural end before the machine reports failure.");
+        });
+    }
+
+    [Test]
+    public void per_token_retry_consumes_attempts_in_place()
+    {
+        int attempts = 0;
+        JoinState join = new(JoinPolicy.All(2));
+        StateToken flakyChain = default;
+        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b =>
+                {
+                    flakyChain = b.To(() => ++attempts < 3 ? Result.Failure : Result.Success);
+                    flakyChain.Retry(3);
+                    return flakyChain.To(join);
+                },
+                b => b.To(() => Result.Success).To(join))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success), "The flaky node succeeds within its retry budget.");
+            Assert.That(attempts, Is.EqualTo(3), "Two in-place retries after the first failure.");
+        });
+    }
+
+    [Test]
+    public void failure_edge_reroutes_the_failing_token_only()
+    {
+        List<string> log = [];
+        JoinState join = new(JoinPolicy.All(2));
+        Graph graph = GraphBuilder.StartWith(Log(log, "load"))
+            .ForkTo(
+                b => b.To(() =>
+                    {
+                        log.Add("broken");
+                        return Result.Failure;
+                    })
+                    .OnError(new RelayState(Log(log, "recovered")))
+                    .To(join),
+                b => b.To(Log(log, "steady")).To(join).To(Log(log, "finish")))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure),
+                "The recovered handler is terminal (not wired onward), so its token completes there — " +
+                "but the steady token starves at the All-join, failing the run.");
+            Assert.That(log, Does.Contain("recovered"), "The failing token rerouted to its failure handler.");
+        });
+    }
+
+    [Test]
+    public void failure_edge_rejoining_the_flow_keeps_the_run_green()
+    {
+        List<string> log = [];
+        JoinState join = new(JoinPolicy.All(2));
+        RelayState recovered = new(Log(log, "recovered"));
+        GraphBuilder? builderCapture = null;
+        Graph graph = GraphBuilder.StartWith(Log(log, "load"))
+            .ForkTo(
+                b =>
+                {
+                    StateToken broken = b.To(() =>
+                    {
+                        log.Add("broken");
+                        return Result.Failure;
+                    });
+                    builderCapture = broken.Builder;
+                    broken.OnError(recovered);
+                    // Wire the handler onward into the join so the rerouted token reconverges.
+                    NodeId handlerId = builderCapture.AddNode(recovered);
+                    return builderCapture.TokenFor(handlerId).To(join);
+                },
+                b => b.To(Log(log, "steady")).To(join).To(Log(log, "finish")))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success),
+                "The rerouted token reaches the join; both tokens join and the run completes.");
+            Assert.That(log, Is.EqualTo(new[] { "load", "broken", "steady", "recovered", "finish" }));
+        });
+    }
+
+    [Test]
+    public void token_multiplicity_same_node_active_for_each_token()
+    {
+        int sharedRuns = 0;
+        JoinState merge = new(JoinPolicy.Any);
+        RelayState shared = new(() =>
+        {
+            sharedRuns++;
+            return Result.Success;
+        });
+
+        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(shared).To(merge),
+                // Same head instance dedupes to the same node — the chain past it is already
+                // wired by the first branch.
+                b => b.To(shared))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(sharedRuns, Is.EqualTo(2),
+                "Both fork branches dedupe to the same node; two tokens each execute it once.");
+        });
+    }
+
+    [Test]
+    public void fsm_runtimes_throw_loud_on_fork_nodes()
+    {
+        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success),
+                b => b.To(() => Result.Success))
+            .Build();
+
+        StateMachine syncFsm = graph.ToStateMachine();
+        AsyncStateMachine asyncFsm = graph.ToAsyncStateMachine();
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                Result r = Result.InProgress;
+                while (r == Result.InProgress)
+                {
+                    r = syncFsm.Execute();
+                }
+            }, "The sync FSM cannot express multiple active nodes — fork must fail loud.");
+            Assert.ThrowsAsync<NotSupportedException>(async () => await asyncFsm.ExecuteAsync(),
+                "The async FSM must fail loud on fork nodes too.");
+        });
+    }
+
+    [Test]
+    public void pool_exhaustion_throws_and_fails_the_machine()
+    {
+        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success),
+                b => b.To(() => Result.Success),
+                b => b.To(() => Result.Success))
+            .Build();
+
+        TokenMachine machine = graph.ToTokenMachine(maxTokens: 2);
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+        machine.SetRestartPolicy(RestartPolicy.Manual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<InvalidOperationException>(() => machine.Execute());
+            Assert.That(machine.Status, Is.EqualTo(ExecutionStatus.Failed));
+        });
+    }
+
+    [Test]
+    public void auto_restart_policy_allows_back_to_back_runs()
+    {
+        List<string> log = [];
+        TokenMachine machine = Diamond(log).ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result first = machine.Execute();
+        Result second = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first, Is.EqualTo(Result.Success));
+            Assert.That(second, Is.EqualTo(Result.Success));
+            Assert.That(log.Count(entry => entry == "finish"), Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void token_machine_nests_as_a_node_of_a_sync_fsm()
+    {
+        List<string> log = [];
+        TokenMachine child = Diamond(log).ToTokenMachine();
+        child.SetStepMode(ParallelStepMode.RunToJoin);
+        child.SetRestartPolicy(RestartPolicy.Manual);
+
+        Graph parent = GraphBuilder.StartWith(Log(log, "before"))
+            .To(child)
+            .To(Log(log, "after"))
+            .Build();
+
+        StateMachine fsm = parent.ToStateMachine();
+        fsm.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = fsm.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "before", "load", "a", "b", "finish", "after" }),
+                "The token subnet runs as one node of the parent FSM (RunToJoin).");
+        });
+    }
+
+    [Test]
+    public void ctor_fails_fast_on_async_only_nodes()
+    {
+        Graph graph = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+
+        Assert.Throws<ArgumentException>(() => graph.ToTokenMachine(),
+            "The sync token machine mirrors StateMachine's fail-fast on async-only logic.");
+    }
+
+    [Test]
+    public void manual_restart_policy_requires_reset()
+    {
+        List<string> log = [];
+        TokenMachine machine = Diamond(log).ToTokenMachine();
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+        machine.SetRestartPolicy(RestartPolicy.Manual);
+
+        Assert.That(machine.Execute(), Is.EqualTo(Result.Success));
+        Assert.Throws<InvalidOperationException>(() => machine.Execute());
+        machine.Reset();
+        Assert.That(machine.Execute(), Is.EqualTo(Result.Success));
+    }
+
+    private sealed class RetireRecorder(List<(int Token, TokenRetireReason Reason)> sink) : ITokenMachineObserver
+    {
+        public void OnTokenRetired(int tokenId, NodeId at, TokenRetireReason reason)
+        {
+            sink.Add((tokenId, reason));
+        }
+    }
+}

--- a/NxGraph.Tests/Tokens/TokenObserverTests.cs
+++ b/NxGraph.Tests/Tokens/TokenObserverTests.cs
@@ -1,0 +1,194 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Tests.Tokens;
+
+/// <summary>
+/// Codifies the token observers' event ordering around fork passage and join firing — this
+/// fixture is the behavior spec for the event schema, like <see cref="AsyncObserverTests"/>
+/// is for the FSM runtimes.
+/// </summary>
+[TestFixture]
+public class TokenObserverTests
+{
+    /// <summary>load → fork(a, b) → join(All 2) → finish, with named nodes.</summary>
+    private static Graph Diamond(out JoinState join)
+    {
+        JoinState j = new(JoinPolicy.All(2));
+        join = j;
+        StateToken start = GraphBuilder.StartWith(() => Result.Success);
+        start.Builder.SetName(start.Id, "load");
+        ForkToken fork = start.ForkTo(
+            b =>
+            {
+                StateToken a = b.To(() => Result.Success);
+                a.Builder.SetName(a.Id, "a");
+                StateToken joined = a.To(j);
+                joined.Builder.SetName(joined.Id, "join");
+                StateToken finish = joined.To(() => Result.Success);
+                finish.Builder.SetName(finish.Id, "finish");
+                return finish;
+            },
+            b =>
+            {
+                StateToken bNode = b.To(() => Result.Success);
+                bNode.Builder.SetName(bNode.Id, "b");
+                return bNode.To(j);
+            });
+        return fork.SetName("fork").Build();
+    }
+
+    private static readonly string[] ExpectedDiamondTrace =
+    [
+        "spawned t0 parent -1 at load",
+        "entered t0 load",
+        // round 1: load succeeds, token passes through the fork
+        "exited t0 load",
+        "transition t0 load->fork",
+        "entered t0 fork",
+        "exited t0 fork",
+        "transition t0 fork->a",
+        "entered t0 a",
+        "spawned t1 parent 0 at fork",
+        "transition t1 fork->b",
+        "entered t1 b",
+        // round 2: a parks at the join; b arrives and fires it
+        "exited t0 a",
+        "transition t0 a->join",
+        "entered t0 join",
+        "exited t1 b",
+        "transition t1 b->join",
+        "entered t1 join",
+        "retired t0 at join Joined",
+        "join fired join survivor t1",
+        "exited t1 join",
+        "transition t1 join->finish",
+        "entered t1 finish",
+        // round 3: finish completes the surviving token
+        "exited t1 finish",
+        "retired t1 at finish Completed",
+    ];
+
+    [Test]
+    public void sync_diamond_emits_the_canonical_event_order()
+    {
+        List<string> trace = [];
+        Graph graph = Diamond(out _);
+        TokenMachine machine = graph.ToTokenMachine(new SyncRecorder(trace));
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(ExpectedDiamondTrace));
+        });
+    }
+
+    [Test]
+    public async Task async_diamond_emits_the_same_event_order()
+    {
+        List<string> trace = [];
+        Graph graph = Diamond(out _);
+        AsyncTokenMachine machine = graph.ToAsyncTokenMachine(new AsyncRecorder(trace));
+
+        Result result = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(ExpectedDiamondTrace),
+                "Runtime parity: the async machine's token events match the sync machine's exactly.");
+        });
+    }
+
+    [Test]
+    public void machine_lifecycle_events_fire_once_per_run()
+    {
+        List<string> lifecycle = [];
+        Graph graph = Diamond(out _);
+        TokenMachine machine = graph.ToTokenMachine(new SyncLifecycleRecorder(lifecycle));
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        machine.Execute();
+
+        Assert.That(lifecycle, Is.EqualTo(new[]
+        {
+            "started",
+            "completed Success",
+            "reset", // RestartPolicy.Auto resets to Ready after completion
+        }));
+    }
+
+    private sealed class SyncRecorder(List<string> trace) : ITokenMachineObserver
+    {
+        public void OnTokenSpawned(int tokenId, int parentTokenId, NodeId at) =>
+            trace.Add($"spawned t{tokenId} parent {parentTokenId} at {at.Name}");
+
+        public void OnTokenRetired(int tokenId, NodeId at, TokenRetireReason reason) =>
+            trace.Add($"retired t{tokenId} at {at.Name} {reason}");
+
+        public void OnJoinFired(NodeId joinNode, int survivingTokenId) =>
+            trace.Add($"join fired {joinNode.Name} survivor t{survivingTokenId}");
+
+        public void OnStateEntered(int tokenId, NodeId id) => trace.Add($"entered t{tokenId} {id.Name}");
+
+        public void OnStateExited(int tokenId, NodeId id) => trace.Add($"exited t{tokenId} {id.Name}");
+
+        public void OnTransition(int tokenId, NodeId from, NodeId to) =>
+            trace.Add($"transition t{tokenId} {from.Name}->{to.Name}");
+    }
+
+    private sealed class AsyncRecorder(List<string> trace) : IAsyncTokenMachineObserver
+    {
+        public ValueTask OnTokenSpawned(int tokenId, int parentTokenId, NodeId at, CancellationToken ct = default)
+        {
+            trace.Add($"spawned t{tokenId} parent {parentTokenId} at {at.Name}");
+            return default;
+        }
+
+        public ValueTask OnTokenRetired(int tokenId, NodeId at, TokenRetireReason reason,
+            CancellationToken ct = default)
+        {
+            trace.Add($"retired t{tokenId} at {at.Name} {reason}");
+            return default;
+        }
+
+        public ValueTask OnJoinFired(NodeId joinNode, int survivingTokenId, CancellationToken ct = default)
+        {
+            trace.Add($"join fired {joinNode.Name} survivor t{survivingTokenId}");
+            return default;
+        }
+
+        public ValueTask OnStateEntered(int tokenId, NodeId id, CancellationToken ct = default)
+        {
+            trace.Add($"entered t{tokenId} {id.Name}");
+            return default;
+        }
+
+        public ValueTask OnStateExited(int tokenId, NodeId id, CancellationToken ct = default)
+        {
+            trace.Add($"exited t{tokenId} {id.Name}");
+            return default;
+        }
+
+        public ValueTask OnTransition(int tokenId, NodeId from, NodeId to, CancellationToken ct = default)
+        {
+            trace.Add($"transition t{tokenId} {from.Name}->{to.Name}");
+            return default;
+        }
+    }
+
+    private sealed class SyncLifecycleRecorder(List<string> lifecycle) : ITokenMachineObserver
+    {
+        public void OnTokenMachineStarted(NodeId graphId) => lifecycle.Add("started");
+
+        public void OnTokenMachineCompleted(NodeId graphId, Result result) =>
+            lifecycle.Add($"completed {result}");
+
+        public void OnTokenMachineReset(NodeId graphId) => lifecycle.Add("reset");
+    }
+}

--- a/NxGraph.Tests/Tokens/TokenSnapshotTests.cs
+++ b/NxGraph.Tests/Tokens/TokenSnapshotTests.cs
@@ -1,0 +1,235 @@
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Tests.Tokens;
+
+/// <summary>
+/// Suspend/resume spec for the token runtimes: the multiset snapshot round-trips mid-run on
+/// both machines (and across them — see
+/// <see cref="AsyncTokenMachineTests.snapshots_are_interchangeable_between_token_runtimes"/>),
+/// Node-scope scratch resumes as defaults, and structural mismatches fail loud.
+/// </summary>
+[TestFixture]
+public class TokenSnapshotTests
+{
+    private static Graph Diamond(List<string> log)
+    {
+        JoinState join = new(JoinPolicy.All(2));
+        return GraphBuilder.StartWith(() =>
+            {
+                log.Add("load");
+                return Result.Success;
+            })
+            .ForkTo(
+                b => b.To(() =>
+                {
+                    log.Add("a");
+                    return Result.Success;
+                }).To(join).To(() =>
+                {
+                    log.Add("finish");
+                    return Result.Success;
+                }),
+                b => b.To(() =>
+                {
+                    log.Add("b1");
+                    return Result.Success;
+                }).To(() =>
+                {
+                    log.Add("b2");
+                    return Result.Success;
+                }).To(join))
+            .Build();
+    }
+
+    [Test]
+    public void sync_mid_run_suspend_resume_continues_to_the_same_outcome()
+    {
+        List<string> log = [];
+        TokenMachine first = Diamond(log).ToTokenMachine();
+        first.Execute(); // round 1: load
+        first.Execute(); // round 2: a parks at the join, b1 runs
+
+        TokenMachineSnapshot snapshot = first.Suspend();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.MidRun, Is.True);
+            Assert.That(snapshot.Tokens, Has.Length.EqualTo(2));
+            Assert.That(snapshot.Tokens.Count(t => t.Phase == TokenPhase.Parked), Is.EqualTo(1),
+                "One token waits at the All-join.");
+            Assert.That(snapshot.JoinArrivals.Sum(), Is.EqualTo(1), "One arrival is banked at the join.");
+        });
+
+        TokenMachine second = Diamond(log).ToTokenMachine();
+        second.Resume(snapshot);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = second.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b1", "b2", "finish" }),
+                "No node re-runs after the resume.");
+        });
+    }
+
+    [Test]
+    public async Task async_mid_run_suspend_resume_continues_to_the_same_outcome()
+    {
+        List<string> log = [];
+        AsyncTokenMachine first = Diamond(log).ToAsyncTokenMachine();
+        await first.StepAsync();
+        await first.StepAsync();
+
+        TokenMachineSnapshot snapshot = first.Suspend();
+        Assert.That(snapshot.MidRun, Is.True);
+
+        AsyncTokenMachine second = Diamond(log).ToAsyncTokenMachine();
+        second.Resume(snapshot);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await second.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "load", "a", "b1", "b2", "finish" }));
+        });
+    }
+
+    [Test]
+    public void any_token_died_survives_the_round_trip()
+    {
+        // One branch dies immediately; the other is long enough that the run is still going
+        // when we suspend. The resumed machine must remember the death and end in Failure.
+        List<string> log = [];
+        Graph BuildGraph() => GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Failure),
+                b => b.To(() =>
+                {
+                    log.Add("s1");
+                    return Result.Success;
+                }).To(() =>
+                {
+                    log.Add("s2");
+                    return Result.Success;
+                }))
+            .Build();
+
+        TokenMachine first = BuildGraph().ToTokenMachine();
+        first.Execute(); // round 1: root passes the fork
+        first.Execute(); // round 2: one token dies, the other runs s1
+
+        TokenMachineSnapshot snapshot = first.Suspend();
+        Assert.That(snapshot.AnyTokenDied, Is.True);
+
+        TokenMachine second = BuildGraph().ToTokenMachine();
+        second.Resume(snapshot);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = second.Execute();
+        }
+
+        Assert.That(result, Is.EqualTo(Result.Failure),
+            "The resumed run still reports the pre-suspend token death.");
+    }
+
+    [Test]
+    public void node_scope_scratch_resumes_as_defaults()
+    {
+        BlackboardSchema nodeSchema = new("scratch", BlackboardScope.Node);
+        BlackboardKey<int> counter = nodeSchema.Register("counter", 0);
+
+        List<int> observed = [];
+        Graph BuildGraph() => GraphBuilder
+            .StartWith(bb =>
+            {
+                // Multi-visit accumulation would need Graph scope; Node scratch is per visit
+                // and per token — after a resume it must read the registered default again.
+                observed.Add(bb.Get(counter));
+                bb.Set(counter, 41);
+                return Result.Success;
+            })
+            .To(_ => Result.Success)
+            .Builder.WithSchema(nodeSchema).Build();
+
+        TokenMachine first = BuildGraph().ToTokenMachine();
+        first.Execute(); // round 1: start node writes 41 into its scratch
+
+        TokenMachineSnapshot snapshot = first.Suspend();
+        TokenMachine second = BuildGraph().ToTokenMachine();
+        second.Resume(snapshot);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = second.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(observed, Is.EqualTo(new[] { 0 }),
+                "The start node ran once and saw the default — scratch never leaks across machines.");
+        });
+    }
+
+    [Test]
+    public void resume_rejects_a_pool_too_small_for_the_snapshot()
+    {
+        List<string> log = [];
+        TokenMachine first = Diamond(log).ToTokenMachine();
+        first.Execute();
+        first.Execute();
+        TokenMachineSnapshot snapshot = first.Suspend();
+
+        TokenMachine tiny = Diamond(log).ToTokenMachine(maxTokens: 1);
+
+        Assert.Throws<InvalidOperationException>(() => tiny.Resume(snapshot));
+    }
+
+    [Test]
+    public void resume_rejects_join_bookkeeping_from_a_different_graph()
+    {
+        List<string> log = [];
+        TokenMachine first = Diamond(log).ToTokenMachine();
+        first.Execute();
+        first.Execute();
+        TokenMachineSnapshot snapshot = first.Suspend();
+
+        Graph joinless = GraphBuilder.StartWith(() => Result.Success).Build();
+        TokenMachine other = joinless.ToTokenMachine();
+
+        Assert.Throws<InvalidOperationException>(() => other.Resume(snapshot));
+    }
+
+    [Test]
+    public void suspend_from_inside_node_logic_is_rejected()
+    {
+        TokenMachine? machineRef = null;
+        Graph graph = GraphBuilder.StartWith(() =>
+        {
+            Assert.Throws<InvalidOperationException>(() => machineRef!.Suspend());
+            return Result.Success;
+        }).Build();
+
+        machineRef = graph.ToTokenMachine();
+        machineRef.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Assert.That(machineRef.Execute(), Is.EqualTo(Result.Success));
+    }
+}

--- a/NxGraph.Tests/Tokens/TokenValidationTests.cs
+++ b/NxGraph.Tests/Tokens/TokenValidationTests.cs
@@ -1,0 +1,198 @@
+using NxGraph.Authoring;
+using NxGraph.Diagnostics.Export;
+using NxGraph.Diagnostics.Validations;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Tests.Tokens;
+
+/// <summary>
+/// Validator lints and tooling visibility for token fork/join nodes (spec 007).
+/// </summary>
+[TestFixture]
+public class TokenValidationTests
+{
+    private static Graph Diamond()
+    {
+        JoinState join = new(JoinPolicy.All(2));
+        return GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success).To(join).To(() => Result.Success),
+                b => b.To(() => Result.Success).To(join))
+            .Build();
+    }
+
+    [Test]
+    public void token_graph_gets_the_token_runtime_info()
+    {
+        GraphValidationResult result = Diamond().Validate();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.HasErrors, Is.False);
+            Assert.That(result.Diagnostics.Any(d =>
+                    d.Severity == Severity.Info && d.Message.Contains("TokenMachine")),
+                Is.True, "Fork/join presence is surfaced as an Info pointing at the token machines.");
+        });
+    }
+
+    [Test]
+    public void fork_with_a_wired_success_edge_is_an_error()
+    {
+        ForkToken fork = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success),
+                b => b.To(() => Result.Success));
+
+        // The DSL never wires an edge from a fork; force one through the raw builder API.
+        NodeId stray = fork.Builder.AddNode(new RelayState(() => Result.Success));
+        fork.Builder.AddTransition(fork.Id, stray);
+        Graph graph = fork.Builder.Build(throwOnError: false);
+
+        GraphValidationResult result = graph.Validate();
+
+        Assert.That(result.Diagnostics.Any(d =>
+                d.Severity == Severity.Error && d.Message.Contains("Fork node has a wired")),
+            Is.True);
+    }
+
+    [Test]
+    public void unsatisfiable_quorum_is_a_warning()
+    {
+        // Only two static inbound edges reach the join, but the quorum wants three.
+        JoinState join = new(JoinPolicy.Quorum(3));
+        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success).To(join).To(() => Result.Success),
+                b => b.To(() => Result.Success).To(join))
+            .Build();
+
+        GraphValidationResult result = graph.Validate();
+
+        Assert.That(result.Diagnostics.Any(d =>
+                d.Severity == Severity.Warning && d.Message.Contains("can never fire")),
+            Is.True);
+    }
+
+    [Test]
+    public void satisfiable_quorum_stays_clean()
+    {
+        JoinState join = new(JoinPolicy.Quorum(2));
+        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success).To(join).To(() => Result.Success),
+                b => b.To(() => Result.Success).To(join),
+                b => b.To(() => Result.Success).To(join))
+            .Build();
+
+        GraphValidationResult result = graph.Validate();
+
+        Assert.That(result.Diagnostics.Any(d => d.Severity == Severity.Warning &&
+                d.Message.Contains("can never fire")),
+            Is.False, "Three static inbound edges satisfy a 2-of-N quorum.");
+    }
+
+    [Test]
+    public void fork_branches_are_reachable_via_static_targets()
+    {
+        JoinState join = new(JoinPolicy.All(2));
+        ForkToken fork = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success).To(join).To(() => Result.Success),
+                b => b.To(() => Result.Success).To(join));
+        Graph graph = fork.Build();
+
+        GraphValidationResult result = graph.Validate(new GraphValidationOptions
+        {
+            AllNodes = fork.Builder.GetAllNodeIds(),
+        });
+
+        Assert.That(result.Diagnostics.Any(d =>
+                d.Severity == Severity.Warning && d.Message.Contains("unreachable")),
+            Is.False,
+            "Fork branches surface through EnumerateStaticTargets, so branch nodes are reachable.");
+    }
+
+    [Test]
+    public void mermaid_export_renders_fork_and_join_first_class()
+    {
+        // Diamond node indices: load=0, a=1, join=2, finish=3, b=4, fork=5 (branch heads are
+        // created before the fork).
+        string mermaid = Diamond().ToMermaid();
+
+        Assert.Multiple(() =>
+        {
+            // Fork: subroutine-bar shape, solid labeled AND-split edges, and no terminal
+            // edge (its empty transition slot is structure, not a terminal exit).
+            Assert.That(mermaid, Does.Contain("n5[[\""), "Fork renders as a bar, not a decision rhombus.");
+            Assert.That(mermaid, Does.Contain("n5 -- fork --> n1"), "Fork → branch a (solid, labeled).");
+            Assert.That(mermaid, Does.Contain("n5 -- fork --> n4"), "Fork → branch b (solid, labeled).");
+            Assert.That(mermaid, Does.Not.Contain("n5 --> End"), "A fork never ends a token.");
+            Assert.That(mermaid, Does.Not.Contain("n5 -.-> "), "Fork branches are not dashed director edges.");
+
+            // Join: bar shape with the firing policy in the label, ordinary edges otherwise.
+            Assert.That(mermaid, Does.Contain(": All(2)\"]]"), "Join label carries its policy.");
+            Assert.That(mermaid, Does.Contain("n1 --> n2"), "Branch a converges on the join.");
+            Assert.That(mermaid, Does.Contain("n4 --> n2"), "Branch b converges on the join.");
+            Assert.That(mermaid, Does.Contain("n2 --> n3"), "The join's success edge is an ordinary edge.");
+        });
+    }
+
+    [Test]
+    public void mermaid_export_labels_each_join_policy()
+    {
+        JoinState any = new(JoinPolicy.Any);
+        JoinState quorum = new(JoinPolicy.Quorum(2));
+        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+            .ForkTo(
+                b => b.To(() => Result.Success).To(any).To(() => Result.Success).To(quorum),
+                b => b.To(() => Result.Success).To(any),
+                b => b.To(() => Result.Success).To(quorum))
+            .Build();
+
+        string mermaid = graph.ToMermaid();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mermaid, Does.Contain(": Any\"]]"));
+            Assert.That(mermaid, Does.Contain(": Quorum(2)\"]]"));
+        });
+    }
+
+    [Test]
+    public void fork_ctor_rejects_empty_and_default_branches()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentException>(() => _ = new ForkState());
+            Assert.Throws<ArgumentException>(() => _ = new ForkState(NodeId.Default));
+        });
+    }
+
+    [Test]
+    public void join_ctor_rejects_uninitialized_policy()
+    {
+        Assert.Throws<ArgumentException>(() => _ = new JoinState(default));
+    }
+
+    [Test]
+    public void join_policy_factories_validate_counts()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = JoinPolicy.All(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = JoinPolicy.Quorum(0));
+            Assert.That(JoinPolicy.Any.RequiredCount, Is.EqualTo(1));
+            Assert.That(JoinPolicy.All(3).RequiredCount, Is.EqualTo(3));
+            Assert.That(JoinPolicy.Quorum(2).RequiredCount, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void fork_branch_lambda_must_add_a_state()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            GraphBuilder.StartWith(() => Result.Success).ForkTo(b => default));
+    }
+}

--- a/NxGraph/Authoring/Dsl.Tokens.cs
+++ b/NxGraph/Authoring/Dsl.Tokens.cs
@@ -1,0 +1,207 @@
+using NxGraph.Compatibility;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Authoring;
+
+/// <summary>
+/// Seed handed to each branch lambda of <see cref="TokenDsl.ForkTo(StateToken, Func{ForkBranch, StateToken}[])"/>.
+/// The first <c>To</c>/<c>ToAsync</c> call creates the branch's head node (the fork target);
+/// it returns an ordinary <see cref="StateToken"/> for continued chaining.
+/// </summary>
+public sealed class ForkBranch
+{
+    private readonly GraphBuilder _builder;
+    private NodeId _head = NodeId.Default;
+    private bool _hasHead;
+
+    internal ForkBranch(GraphBuilder builder)
+    {
+        _builder = builder;
+    }
+
+    internal NodeId Head => _hasHead
+        ? _head
+        : throw new InvalidOperationException(
+            "A fork branch must add at least one state — call To(...)/ToAsync(...) inside the branch lambda.");
+
+    private StateToken Record(NodeId head)
+    {
+        if (_hasHead)
+        {
+            throw new InvalidOperationException(
+                "A fork branch declares its head once — continue the chain on the returned StateToken.");
+        }
+
+        _head = head;
+        _hasHead = true;
+        return new StateToken(head, _builder);
+    }
+
+    /// <summary>Creates the branch head from sync logic. Routing several branches to the same instance (e.g. one shared <see cref="JoinState"/>) converges them on one node.</summary>
+    public StateToken To(ILogic syncLogic)
+    {
+        Guard.NotNull(syncLogic, nameof(syncLogic));
+        return Record(_builder.AddNode(syncLogic));
+    }
+
+    /// <summary>Creates the branch head from async logic.</summary>
+    public StateToken ToAsync(IAsyncLogic asyncLogic)
+    {
+        Guard.NotNull(asyncLogic, nameof(asyncLogic));
+        return Record(_builder.AddNode(asyncLogic));
+    }
+
+    /// <summary>Creates the branch head from a sync function.</summary>
+    public StateToken To(Func<Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return To(new RelayState(run));
+    }
+
+    /// <summary>Creates the branch head from an async function.</summary>
+    public StateToken ToAsync(Func<CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return ToAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>Creates the branch head from a sync function receiving the machine-bound routed blackboard context.</summary>
+    public StateToken To(Func<Blackboards.BlackboardContext, Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return To(new RelayState(run));
+    }
+
+    /// <summary>Creates the branch head from an async function receiving the machine-bound routed blackboard context.</summary>
+    public StateToken ToAsync(Func<Blackboards.BlackboardContext, CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return ToAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>Points the branch at an already-added node (e.g. a shared handler or join).</summary>
+    public StateToken To(StateToken existing)
+    {
+        return Record(existing.Id);
+    }
+}
+
+/// <summary>
+/// Returned by <c>ForkTo(...)</c>. The fork's chain is closed — branches continue inside
+/// their lambdas — so the only remaining operations are graph-level.
+/// </summary>
+public readonly struct ForkToken
+{
+    internal ForkToken(NodeId id, GraphBuilder builder)
+    {
+        Id = id;
+        Builder = builder;
+    }
+
+    public GraphBuilder Builder { get; }
+
+    /// <summary>The fork node's id (useful with <see cref="GraphBuilder.TokenFor"/>-style helpers).</summary>
+    public NodeId Id { get; }
+
+    /// <summary>Sets the fork node's display name.</summary>
+    public ForkToken SetName(string name)
+    {
+        Builder.SetName(Id, name);
+        return this;
+    }
+
+    /// <summary>Finishes the DSL and produces an immutable <see cref="Graph"/>.</summary>
+    public Graph Build()
+    {
+        return Builder.Build();
+    }
+}
+
+/// <summary>
+/// Authoring surface for the token runtime (spec 007): fork fan-out and graph→machine
+/// factories. Join convergence needs no dedicated DSL — construct one <see cref="JoinState"/>
+/// and route any number of chains to it with <c>.To(join)</c> (nodes dedupe by logic
+/// reference).
+/// </summary>
+public static class TokenDsl
+{
+    private static ForkToken BuildFork(GraphBuilder builder, NodeId? from, bool isStart,
+        Func<ForkBranch, StateToken>[] branches)
+    {
+        Guard.NotNull(branches, nameof(branches));
+        if (branches.Length < 1)
+        {
+            throw new ArgumentException("A fork needs at least one branch.", nameof(branches));
+        }
+
+        // Branch heads are created first so the fork can be constructed immutably.
+        NodeId[] heads = new NodeId[branches.Length];
+        for (int i = 0; i < branches.Length; i++)
+        {
+            Guard.NotNull(branches[i], nameof(branches));
+            ForkBranch seed = new(builder);
+            branches[i](seed);
+            heads[i] = seed.Head;
+        }
+
+        ForkState fork = new(heads);
+        NodeId forkId = builder.AddNode((IAsyncLogic)fork, isStart);
+        if (from is { } fromId)
+        {
+            builder.AddTransition(fromId, forkId);
+        }
+
+        return new ForkToken(forkId, builder);
+    }
+
+    /// <summary>
+    /// Wires this state to a <see cref="ForkState"/>: when a token completes this state, it
+    /// continues into the first branch and one new token spawns per remaining branch. Each
+    /// lambda builds one branch chain; converge branches by routing them to the same
+    /// <see cref="JoinState"/> instance. Token machines only — the FSM runtimes throw on
+    /// fork nodes.
+    /// </summary>
+    public static ForkToken ForkTo(this StateToken prev, params Func<ForkBranch, StateToken>[] branches)
+    {
+        return BuildFork(prev.Builder, prev.Id, isStart: false, branches);
+    }
+
+    /// <summary>Starts the graph with a fork: the root token fans out immediately at run start.</summary>
+    public static ForkToken ForkTo(this StartToken root, params Func<ForkBranch, StateToken>[] branches)
+    {
+        return BuildFork(root.Builder, from: null, isStart: true, branches);
+    }
+
+    // ── Graph → machine factories (mirroring To{Async,}StateMachine) ────
+
+    /// <summary>Creates a sync <see cref="TokenMachine"/> over the graph.</summary>
+    public static TokenMachine ToTokenMachine(this Graph graph, ITokenMachineObserver? observer = null,
+        int maxTokens = TokenMachine.DefaultMaxTokens)
+    {
+        return new TokenMachine(graph, observer, maxTokens);
+    }
+
+    /// <summary>Creates a typed sync <see cref="TokenMachine{TAgent}"/> over the graph.</summary>
+    public static TokenMachine<TAgent> ToTokenMachine<TAgent>(this Graph graph,
+        ITokenMachineObserver? observer = null, int maxTokens = TokenMachine.DefaultMaxTokens)
+    {
+        return new TokenMachine<TAgent>(graph, observer, maxTokens);
+    }
+
+    /// <summary>Creates an <see cref="AsyncTokenMachine"/> over the graph.</summary>
+    public static AsyncTokenMachine ToAsyncTokenMachine(this Graph graph,
+        IAsyncTokenMachineObserver? observer = null, int maxTokens = TokenMachine.DefaultMaxTokens)
+    {
+        return new AsyncTokenMachine(graph, observer, maxTokens);
+    }
+
+    /// <summary>Creates a typed <see cref="AsyncTokenMachine{TAgent}"/> over the graph.</summary>
+    public static AsyncTokenMachine<TAgent> ToAsyncTokenMachine<TAgent>(this Graph graph,
+        IAsyncTokenMachineObserver? observer = null, int maxTokens = TokenMachine.DefaultMaxTokens)
+    {
+        return new AsyncTokenMachine<TAgent>(graph, observer, maxTokens);
+    }
+}

--- a/NxGraph/Authoring/GraphBuilder.cs
+++ b/NxGraph/Authoring/GraphBuilder.cs
@@ -25,6 +25,7 @@ public sealed partial class GraphBuilder
     private readonly Dictionary<int, Action> _exitActions = new(); // sparse; attached to LogicNodes at Build()
     private readonly Dictionary<int, int> _outcomeCodes = new(); // sparse; materialized at Build()
     private readonly Dictionary<int, string> _outcomeNames = new(); // code -> display name
+    private readonly Dictionary<int, Guid> _uids = new(); // sparse; materialized at Build()
     private BlackboardSchema? _graphSchema; // Graph-scoped declaration, baked into the Graph at Build()
     private BlackboardSchema? _globalSchema; // required Global-scoped schema, baked into the Graph at Build()
     private BlackboardSchema? _nodeSchema; // transient Node-scoped schema, baked into the Graph at Build()
@@ -358,12 +359,27 @@ public sealed partial class GraphBuilder
             }
         }
 
+        Guid[]? uids = null;
+        if (_uids.Count > 0)
+        {
+            uids = new Guid[length];
+            foreach ((int idx, Guid uid) in _uids)
+            {
+                if ((uint)idx >= (uint)uids.Length)
+                {
+                    throw new InvalidOperationException($"Uid node index {idx} is out of bounds.");
+                }
+
+                uids[idx] = uid;
+            }
+        }
+
         IReadOnlyDictionary<int, string>? outcomeNames =
             _outcomeNames.Count > 0 ? new Dictionary<int, string>(_outcomeNames) : null;
 
         NodeId graphId = _next.Next();
         return new Graph(graphId, nodes, edges, logic: null, retries, outcomes, outcomeNames,
-            _graphSchema, _globalSchema, _nodeSchema);
+            _graphSchema, _globalSchema, _nodeSchema, uids);
     }
 
 
@@ -507,6 +523,25 @@ public sealed partial class GraphBuilder
             _outcomeNames[code] = name;
         }
 
+        return this;
+    }
+
+    /// <summary>
+    /// Assigns a stable UID to a node. UIDs are identity metadata for external tooling
+    /// (editors persisting layouts, breakpoints, references across rebuilds) — runtime
+    /// identity stays the index. <see cref="Guid.Empty"/> is reserved for "no uid";
+    /// duplicate UIDs across nodes are a validator Error. Uniqueness scope is per-graph;
+    /// nested subgraphs may reuse uids. Repeat calls for the same node overwrite.
+    /// </summary>
+    public GraphBuilder SetUid(NodeId id, Guid uid)
+    {
+        if (uid == Guid.Empty)
+        {
+            throw new ArgumentException("Node UID cannot be Guid.Empty (reserved for 'no uid').", nameof(uid));
+        }
+
+        RequireExistingNode(id);
+        _uids[id.Index] = uid;
         return this;
     }
 

--- a/NxGraph/Authoring/StateToken.cs
+++ b/NxGraph/Authoring/StateToken.cs
@@ -53,6 +53,17 @@ public readonly struct StateToken
     }
 
     /// <summary>
+    /// Assigns a stable UID to this state for external tooling (editors persisting layouts,
+    /// breakpoints, references across rebuilds). Runtime identity stays the index;
+    /// <see cref="Guid.Empty"/> is rejected and duplicate UIDs are a validator Error.
+    /// </summary>
+    public StateToken WithUid(Guid uid)
+    {
+        Builder.SetUid(Id, uid);
+        return this;
+    }
+
+    /// <summary>
     /// Attaches an action fired when the machine enters this state — once per visit,
     /// before its first execution (retries do not re-fire it).
     /// </summary>

--- a/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
+++ b/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
@@ -2,12 +2,17 @@
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
+using NxGraph.Tokens;
 
 namespace NxGraph.Diagnostics.Export;
 
 /// <summary>
 /// Exports a <see cref="Graph"/> (single static transition per node) to Mermaid flowchart syntax.
-/// Dynamic branches chosen at runtime by <c>IDirector</c> are not emitted (no static edges).
+/// Dynamic branches chosen at runtime by <c>IDirector</c> are not emitted (no static edges),
+/// but statically-known director targets appear as dashed edges. Token fork/join nodes render
+/// first-class: subroutine-bar shapes, solid <c>fork</c>-labeled branch edges (every branch
+/// runs — an AND-split, not a choice), the join's <see cref="JoinPolicy"/> in its label, and
+/// no terminal edge from forks (a fork never ends a token).
 /// </summary>
 public sealed class MermaidGraphExporter : IGraphExporter
 {
@@ -46,24 +51,46 @@ public sealed class MermaidGraphExporter : IGraphExporter
             // async IAsyncDirector — get a rhombus, others are rectangles. Previously only
             // the sync IDirector path was checked, so async If/Switch nodes silently
             // rendered as plain rectangles.
-            if (node is LogicNode ln && (ln.AsyncLogic is IDirector || ln.Logic is IDirector
-                                         || ln.AsyncLogic is IAsyncDirector || ln.Logic is IAsyncDirector))
+            if (node is LogicNode ln)
             {
-                label = $"{{\"{EscapeLabel( label)}\"}}";
-                sb.Append("  ").Append(nodeId).Append(label).AppendLine();
-                continue;
+                // Token fork/join first: ForkState implements IDirector purely so its branches
+                // reach reachability/exports — rendering it as a decision rhombus would read
+                // as "choose one" when every branch runs. Both get the subroutine-bar shape;
+                // the join carries its firing policy so All/Any/Quorum are distinguishable.
+                if (ForkOf(ln) is not null)
+                {
+                    sb.Append("  ").Append(nodeId).Append("[[\"").Append(label).AppendLine("\"]]");
+                    continue;
+                }
+
+                if (JoinOf(ln) is { } join)
+                {
+                    sb.Append("  ").Append(nodeId).Append("[[\"").Append(label)
+                        .Append(" : ").Append(join.Policy).AppendLine("\"]]");
+                    continue;
+                }
+
+                if (ln.AsyncLogic is IDirector || ln.Logic is IDirector
+                    || ln.AsyncLogic is IAsyncDirector || ln.Logic is IAsyncDirector)
+                {
+                    label = $"{{\"{EscapeLabel(label)}\"}}";
+                    sb.Append("  ").Append(nodeId).Append(label).AppendLine();
+                    continue;
+                }
             }
 
             string shape = (i == NodeId.Start.Index) ? $"([\"{label}\"])" : $"[\"{label}\"]";
             sb.Append("  ").Append(nodeId).Append(shape).AppendLine();
         }
 
-        // Optional global terminal node (only emitted if needed)
+        // Optional global terminal node (only emitted if needed). A fork's transition slot is
+        // always empty by design (branches replace the success edge), but a fork never ends a
+        // token — it must not count as terminal.
         bool needsTerminal = false;
         for (int i = 0; i < graph.TransitionCount; i++)
         {
             Transition edge = graph.GetTransitionByIndex(i);
-            if (!edge.IsEmpty)
+            if (!edge.IsEmpty || IsFork(graph, i))
             {
                 continue;
             }
@@ -86,12 +113,13 @@ public sealed class MermaidGraphExporter : IGraphExporter
 
             if (edge.IsEmpty)
             {
-                if (opts.AddTerminalNode)
+                if (opts.AddTerminalNode && !IsFork(graph, i))
                 {
                     sb.Append("  ").Append(from).Append(" --> ").Append(TerminalVar).AppendLine();
                 }
 
-                // else: omit terminal arrow; the node appears unconnected (terminal)
+                // else: omit terminal arrow; the node appears unconnected (terminal).
+                // Forks are skipped either way — their fan-out renders below.
                 continue;
             }
 
@@ -132,10 +160,26 @@ public sealed class MermaidGraphExporter : IGraphExporter
         // Director edges: directors don't carry a static transition (the runtime calls
         // SelectNext at execution time), so they're missed by the static-edge loop above.
         // Emit dashed edges to every statically-known target so the rendered diagram
-        // reflects the actual reachability.
+        // reflects the actual reachability. Fork branches are the exception: they are
+        // static AND-splits (every branch runs), so they render as solid labeled edges
+        // instead of the dashed "chosen at runtime" style.
         for (int i = 0; i < graph.NodeCount; i++)
         {
             if (graph.GetNodeByIndex(i) is not LogicNode dn) continue;
+
+            if (ForkOf(dn) is { } fork)
+            {
+                string forkVar = NodeVar(i);
+                foreach (NodeId branch in fork.Branches)
+                {
+                    int branchIdx = branch.Index;
+                    if ((uint)branchIdx >= (uint)graph.NodeCount) continue;
+                    sb.Append("  ").Append(forkVar).Append(" -- fork --> ").Append(NodeVar(branchIdx))
+                        .AppendLine();
+                }
+
+                continue;
+            }
 
             IEnumerable<NodeId>? targets =
                 (dn.AsyncLogic as IDirector)?.EnumerateStaticTargets()
@@ -161,6 +205,15 @@ public sealed class MermaidGraphExporter : IGraphExporter
 
     private static string NodeVar(int index) => $"n{index}";
     private const string TerminalVar = "End";
+
+    private static ForkState? ForkOf(LogicNode node) =>
+        node.Logic as ForkState ?? node.AsyncLogic as ForkState;
+
+    private static JoinState? JoinOf(LogicNode node) =>
+        node.Logic as JoinState ?? node.AsyncLogic as JoinState;
+
+    private static bool IsFork(Graph graph, int index) =>
+        graph.GetNodeByIndex(index) is LogicNode ln && ForkOf(ln) is not null;
 
     private static string BuildNodeLabel(NodeId id, int index, MermaidExportOptions opts)
     {

--- a/NxGraph/Diagnostics/Validations/GraphValidator.cs
+++ b/NxGraph/Diagnostics/Validations/GraphValidator.cs
@@ -3,6 +3,7 @@ using NxGraph.Compatibility;
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
+using NxGraph.Tokens;
 namespace NxGraph.Diagnostics.Validations;
 
 public static class GraphValidator
@@ -208,6 +209,15 @@ public static class GraphValidator
             }
         }
 
+        // 4c) Token-runtime structural lints (fork/join nodes — spec 007). Always on: the
+        // nodes are unambiguous, and a graph carrying them can only run under the token
+        // machines, which is worth an Info even when everything else is clean.
+        ValidateTokenNodes(graph, result);
+
+        // 4d) Duplicate node UIDs — an Error, because a UID is a stable identity key for
+        // external tooling and two nodes claiming it makes lookups ambiguous.
+        ValidateUids(graph, result);
+
         // 5) If AllNodes are supplied, check for unreachable nodes and duplicate names
         if (options.AllNodes is { Count: > 0 } all)
         {
@@ -251,6 +261,129 @@ public static class GraphValidator
         ValidateBlackboardDeclarations(graph, result);
 
         return result;
+    }
+
+    private static void ValidateUids(Graph graph, GraphValidationResult result)
+    {
+        if (graph.Uids is not { } uids)
+        {
+            return;
+        }
+
+        Dictionary<Guid, List<int>> byUid = new();
+        for (int i = 0; i < uids.Length; i++)
+        {
+            if (uids[i] == Guid.Empty) continue;
+            if (!byUid.TryGetValue(uids[i], out List<int>? list))
+                byUid[uids[i]] = list = new List<int>(2);
+            list.Add(i);
+        }
+
+        foreach (KeyValuePair<Guid, List<int>> kvp in byUid)
+        {
+            if (kvp.Value.Count <= 1)
+            {
+                continue;
+            }
+
+            foreach (int dup in kvp.Value)
+                result.Add(Severity.Error, $"Duplicate node UID '{kvp.Key:D}'.", graph.GetNodeByIndex(dup).Id);
+        }
+    }
+
+    private static void ValidateTokenNodes(Graph graph, GraphValidationResult result)
+    {
+        bool anyTokenNode = false;
+        for (int i = 0; i < graph.NodeCount; i++)
+        {
+            if (!graph.TryGetNodeByIndex(i, out INode? node) || node is not LogicNode logicNode)
+            {
+                continue;
+            }
+
+            ForkState? fork = logicNode.Logic as ForkState ?? logicNode.AsyncLogic as ForkState;
+            if (fork is not null)
+            {
+                anyTokenNode = true;
+                if (graph.TryGetTransition(node.Id, out Transition edge) &&
+                    (!edge.IsEmpty || edge.HasFailureDestination))
+                {
+                    result.Add(Severity.Error,
+                        "Fork node has a wired success/failure edge — a fork's branches replace its success " +
+                        "edge, and forks carry no logic that could fail. Remove the edge.", node.Id);
+                }
+            }
+
+            JoinState? join = logicNode.Logic as JoinState ?? logicNode.AsyncLogic as JoinState;
+            if (join is not null)
+            {
+                anyTokenNode = true;
+                int required = join.Policy.RequiredCount;
+                int inbound = CountStaticInbound(graph, i);
+                if (required > inbound)
+                {
+                    result.Add(Severity.Warning,
+                        $"Join requires {required} arrivals per firing but only {inbound} statically-known " +
+                        "inbound edges reach it — unless tokens arrive via dynamic directors or loops, the " +
+                        "join can never fire and its tokens will starve.", node.Id);
+                }
+            }
+        }
+
+        if (anyTokenNode)
+        {
+            result.Add(Severity.Info,
+                "Graph contains token fork/join nodes — run it with TokenMachine/AsyncTokenMachine " +
+                "(NxGraph.Tokens); the FSM runtimes throw on these nodes.", graph.Id);
+        }
+    }
+
+    /// <summary>
+    /// Counts statically-known edges into <paramref name="target"/>: success and failure
+    /// destinations plus director/fork static targets. Dynamic director selections are
+    /// invisible here, which is why the unsatisfiable-join lint is a Warning, not an Error.
+    /// </summary>
+    private static int CountStaticInbound(Graph graph, int target)
+    {
+        int count = 0;
+        for (int j = 0; j < graph.NodeCount; j++)
+        {
+            Transition edge = graph.GetTransitionByIndex(j);
+            if (!edge.IsEmpty && edge.Destination.Index == target)
+            {
+                count++;
+            }
+
+            if (edge.HasFailureDestination && edge.FailureDestination.Index == target)
+            {
+                count++;
+            }
+
+            if (!graph.TryGetNodeByIndex(j, out INode? node) || node is not LogicNode logicNode)
+            {
+                continue;
+            }
+
+            IEnumerable<NodeId>? targets =
+                (logicNode.AsyncLogic as IDirector)?.EnumerateStaticTargets()
+                ?? (logicNode.Logic as IDirector)?.EnumerateStaticTargets()
+                ?? (logicNode.AsyncLogic as IAsyncDirector)?.EnumerateStaticTargets()
+                ?? (logicNode.Logic as IAsyncDirector)?.EnumerateStaticTargets();
+            if (targets is null)
+            {
+                continue;
+            }
+
+            foreach (NodeId t in targets)
+            {
+                if (t.Index == target)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
     }
 
     private static void ValidateBlackboardDeclarations(Graph graph, GraphValidationResult result)

--- a/NxGraph/Fsm/Async/AsyncCompositeState.cs
+++ b/NxGraph/Fsm/Async/AsyncCompositeState.cs
@@ -14,6 +14,13 @@ public class AsyncCompositeState(IAsyncLogic child) : AsyncState, ISubGraphProvi
     IEnumerable<Graph> ISubGraphProvider.SubGraphs =>
         child is ISubGraphProvider provider ? provider.SubGraphs : [];
 
+    /// <summary>
+    /// The wrapped child logic. Exposed to subclasses so a user container codec can read
+    /// back what the primary constructor captured (e.g. to serialize a wrapped machine's
+    /// graph or a logic-codec key for a non-graph child).
+    /// </summary>
+    protected IAsyncLogic Child => child;
+
     void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
     {
         if (child is IBlackboardSettable settable)

--- a/NxGraph/Fsm/Async/AsyncDynamicParallelState.cs
+++ b/NxGraph/Fsm/Async/AsyncDynamicParallelState.cs
@@ -37,6 +37,13 @@ public sealed class AsyncDynamicParallelState : IAsyncLogic, ISubGraphProvider, 
     /// <summary>The region machines (selected or not).</summary>
     public IReadOnlyList<AsyncStateMachine> Regions => _regions;
 
+    /// <summary>
+    /// The region selector this composite was constructed with. Exposed (like
+    /// <see cref="Regions"/> and the ctor arguments) so serializers can map the delegate
+    /// back to a registered key — delegates themselves cannot ride a wire payload.
+    /// </summary>
+    public Func<BlackboardContext, RegionMask> Selector => _selector;
+
     IEnumerable<Graph> ISubGraphProvider.SubGraphs
     {
         get

--- a/NxGraph/Fsm/DynamicParallelState.cs
+++ b/NxGraph/Fsm/DynamicParallelState.cs
@@ -41,6 +41,13 @@ public sealed class DynamicParallelState : ILogic, ISubGraphProvider, IBlackboar
     /// <summary>How region rounds map onto <see cref="Execute"/> calls.</summary>
     public ParallelStepMode Mode => _mode;
 
+    /// <summary>
+    /// The region selector this composite was constructed with. Exposed (like
+    /// <see cref="Regions"/> and <see cref="Mode"/>) so serializers can map the delegate
+    /// back to a registered key — delegates themselves cannot ride a wire payload.
+    /// </summary>
+    public Func<BlackboardContext, RegionMask> Selector => _selector;
+
     IEnumerable<Graph> ISubGraphProvider.SubGraphs
     {
         get

--- a/NxGraph/Graphs/Graph.cs
+++ b/NxGraph/Graphs/Graph.cs
@@ -15,6 +15,8 @@ public sealed class Graph : INode, IGraph
     private readonly Transition[] _edges; // index = from.Index
     private readonly RetryPolicy[]? _retryPolicies; // index = NodeId.Index; null when no node has a policy
     private readonly int[]? _outcomeCodes; // index = NodeId.Index; null when no node declares an outcome
+    private readonly Guid[]? _uids; // index = NodeId.Index; Guid.Empty = no uid; null when no node has one
+    private readonly Dictionary<Guid, int>? _uidIndex; // built once at construction; never touched by run loops
 
     /// <summary>
     /// The unique identifier for this graph. 
@@ -54,12 +56,13 @@ public sealed class Graph : INode, IGraph
     /// <param name="nodes">The array of nodes in the graph. Must be non-empty and start with the start node at index 0.</param>
     /// <param name="edges">The array of transitions (edges) in the graph. Must be non-empty and have the same length as the nodes array.</param>
     /// <param name="logic">The logic associated with the graph. If null, an empty logic is used.</param>
+    /// <param name="uids">Optional per-node stable UIDs indexed by <see cref="NodeId.Index"/> (<see cref="Guid.Empty"/> = unassigned). Must match the nodes array length when provided.</param>
     /// <exception cref="ArgumentException">Thrown when the nodes or edges arrays are empty, have unequal lengths, or the first node is not the start node.</exception>
     public Graph(NodeId id, INode[] nodes, Transition[] edges, IAsyncLogic? logic = null,
         RetryPolicy[]? retryPolicies = null, int[]? outcomeCodes = null,
         IReadOnlyDictionary<int, string>? outcomeNames = null,
         BlackboardSchema? schema = null, BlackboardSchema? globalSchema = null,
-        BlackboardSchema? nodeSchema = null)
+        BlackboardSchema? nodeSchema = null, Guid[]? uids = null)
     {
         if (schema is not null && schema.Scope != BlackboardScope.Graph)
         {
@@ -103,12 +106,34 @@ public sealed class Graph : INode, IGraph
                 nameof(outcomeCodes));
         }
 
+        if (uids is not null && uids.Length != nodes.Length)
+        {
+            throw new ArgumentException("Uid array must match the nodes array length.", nameof(uids));
+        }
+
         Id = id;
         StartNode = nodes[0];
         _nodes = nodes;
         _edges = edges;
         _retryPolicies = retryPolicies;
         _outcomeCodes = outcomeCodes;
+        _uids = uids;
+        if (uids is not null)
+        {
+            // First occurrence wins on duplicates: the graph must stay constructible so
+            // Validate() can report every duplicate as an Error instead of throwing here.
+            Dictionary<Guid, int> uidIndex = new();
+            for (int i = 0; i < uids.Length; i++)
+            {
+                if (uids[i] != Guid.Empty)
+                {
+                    uidIndex.TryAdd(uids[i], i);
+                }
+            }
+
+            _uidIndex = uidIndex;
+        }
+
         OutcomeNames = outcomeNames;
         Schema = schema;
         GlobalSchema = globalSchema;
@@ -148,6 +173,15 @@ public sealed class Graph : INode, IGraph
     /// node's code (default 0) as <c>LastOutcome</c>.
     /// </summary>
     public int[]? OutcomeCodes => _outcomeCodes;
+
+    /// <summary>
+    /// Per-node stable UIDs indexed by <see cref="NodeId.Index"/>, or <c>null</c> when no
+    /// node has one; <see cref="Guid.Empty"/> marks an unassigned slot. UIDs are identity
+    /// metadata for external tooling (editors persisting layouts, breakpoints, references
+    /// across rebuilds) — runtime identity stays the index and no run loop reads them.
+    /// Uniqueness scope is this graph only; nested subgraphs may reuse uids.
+    /// </summary>
+    public Guid[]? Uids => _uids;
 
     /// <summary>
     /// Optional display names for outcome codes, resolved lazily for reporting —
@@ -192,6 +226,26 @@ public sealed class Graph : INode, IGraph
 
         node = _nodes[id.Index];
         return true;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve a node by its stable UID (assigned at authoring time via
+    /// <c>WithUid</c>/<c>SetUid</c>). O(1) via a lookup built once at construction —
+    /// intended for editor tooling; the run loops never touch UIDs.
+    /// </summary>
+    /// <param name="uid">The stable UID to look up. <see cref="Guid.Empty"/> never matches.</param>
+    /// <param name="node">The node carrying the UID, if found; otherwise <see cref="LogicNode.Empty"/>.</param>
+    /// <returns><c>true</c> if a node carries the UID; otherwise, <c>false</c>.</returns>
+    public bool TryGetNodeByUid(Guid uid, out INode node)
+    {
+        if (_uidIndex is not null && _uidIndex.TryGetValue(uid, out int index))
+        {
+            node = _nodes[index];
+            return true;
+        }
+
+        node = LogicNode.Empty;
+        return false;
     }
 
     /// <summary>

--- a/NxGraph/Graphs/LogicNode.cs
+++ b/NxGraph/Graphs/LogicNode.cs
@@ -85,6 +85,34 @@ public class LogicNode : INode
     /// (wire marker string "SyncParallelState", payload version 4).
     /// </summary>
     public static readonly LogicNode SyncParallelStateMarker = new(NodeId.SyncParallelStateMarker, new EmptyAsyncLogic());
+
+    /// <summary>
+    /// Sentinel for token fork owner nodes during (de)serialization (wire marker string
+    /// "ForkState", payload version 6). One marker for both runtimes: fork nodes never
+    /// execute and populate both logic slots, so no sync twin is needed.
+    /// </summary>
+    public static readonly LogicNode ForkStateMarker = new(NodeId.ForkStateMarker, new EmptyAsyncLogic());
+
+    /// <summary>
+    /// Sentinel for token join owner nodes during (de)serialization (wire marker string
+    /// "JoinState", payload version 6). One marker for both runtimes — see
+    /// <see cref="ForkStateMarker"/>.
+    /// </summary>
+    public static readonly LogicNode JoinStateMarker = new(NodeId.JoinStateMarker, new EmptyAsyncLogic());
+
+    /// <summary>
+    /// Sentinel for async dynamic-parallel composite owner nodes during (de)serialization
+    /// (wire marker string "DynamicParallelState", payload version 6).
+    /// </summary>
+    public static readonly LogicNode DynamicParallelStateMarker =
+        new(NodeId.DynamicParallelStateMarker, new EmptyAsyncLogic());
+
+    /// <summary>
+    /// Sentinel for <b>sync</b> dynamic-parallel composite owner nodes during
+    /// (de)serialization (wire marker string "SyncDynamicParallelState", payload version 6).
+    /// </summary>
+    public static readonly LogicNode SyncDynamicParallelStateMarker =
+        new(NodeId.SyncDynamicParallelStateMarker, new EmptyAsyncLogic());
 }
 
 /// <summary>

--- a/NxGraph/Graphs/NodeId.cs
+++ b/NxGraph/Graphs/NodeId.cs
@@ -63,6 +63,10 @@ public struct NodeId(int index) : IEquatable<NodeId>
     public static NodeId SyncHistoryStateMarker => new(-5) { Name = "SyncHistoryState" };
     public static NodeId ParallelStateMarker => new(-6) { Name = "ParallelState" };
     public static NodeId SyncParallelStateMarker => new(-7) { Name = "SyncParallelState" };
+    public static NodeId ForkStateMarker => new(-8) { Name = "ForkState" };
+    public static NodeId JoinStateMarker => new(-9) { Name = "JoinState" };
+    public static NodeId DynamicParallelStateMarker => new(-10) { Name = "DynamicParallelState" };
+    public static NodeId SyncDynamicParallelStateMarker => new(-11) { Name = "SyncDynamicParallelState" };
 
     /// <summary>
     /// Represents the start NodeId with an index of 0 and a name of "Start".

--- a/NxGraph/Tokens/AsyncTokenMachine.cs
+++ b/NxGraph/Tokens/AsyncTokenMachine.cs
@@ -1,0 +1,1220 @@
+using System.Diagnostics;
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
+using NxGraph.Diagnostics.Replay;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tokens;
+
+/// <summary>
+/// An async token machine with an agent, mirroring <see cref="AsyncTokenMachine"/> the way
+/// <see cref="AsyncStateMachine{TAgent}"/> mirrors <see cref="AsyncStateMachine"/>.
+/// </summary>
+public class AsyncTokenMachine<TAgent>(Graph graph, IAsyncTokenMachineObserver? observer = null,
+        int maxTokens = TokenMachine.DefaultMaxTokens)
+    : AsyncTokenMachine(graph, observer, maxTokens), IAgentSettable<TAgent>
+{
+    private TAgent? _agent;
+    private bool _hasAgent;
+
+    /// <summary>
+    /// Binds the agent (typed context) to this machine. It is applied to the graph's nodes
+    /// immediately and re-applied at the start of every execution, so several machines can
+    /// share one <see cref="Graph"/> with distinct contexts as long as their executions do
+    /// not overlap.
+    /// </summary>
+    public void SetAgent(TAgent agent)
+    {
+        _agent = agent;
+        _hasAgent = true;
+        Graph.SetAgent(agent);
+    }
+
+    private protected override void ApplyExecutionContext()
+    {
+        base.ApplyExecutionContext(); // blackboards first, then the agent
+        if (_hasAgent)
+        {
+            Graph.SetAgent(_agent!);
+        }
+    }
+}
+
+/// <summary>
+/// The asynchronous token runtime — the <see cref="TokenMachine"/> twin with the async FSM's
+/// mechanics: <c>ValueTask&lt;Result&gt;</c>, cancellation awareness, atomic status
+/// transitions, and retry backoff honored via <see cref="Task.Delay(TimeSpan, CancellationToken)"/>
+/// (awaited inline during the failing token's turn). N pooled tokens flow through one flat
+/// graph via cooperative round scheduling; <see cref="ForkState"/>/<see cref="JoinState"/>
+/// nodes are interpreted structurally, and ordinary nodes keep their FSM semantics per token.
+/// <para>
+/// <c>ExecuteAsync</c> runs the whole flow; <c>StepAsync</c> advances exactly one scheduling
+/// round and returns <see cref="Result.InProgress"/> while tokens remain, mirroring the sync
+/// machine's <see cref="ParallelStepMode.RoundPerTick"/> granularity. Semantics (run
+/// lifecycle, join firing, starvation, outcome aggregation) are identical to the sync twin;
+/// only the mechanics differ, per the runtime-parity convention.
+/// </para>
+/// </summary>
+public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBindable, IBlackboardSettable
+{
+    private const int MaxCascadeDepth = 64;
+
+    public readonly Graph Graph;
+    private readonly IAsyncTokenMachineObserver? _observer;
+    private BlackboardContext _blackboards;
+
+    private int _statusInt = (int)ExecutionStatus.Created; // atomic state
+    private RestartPolicy _restartPolicy = RestartPolicy.Auto;
+    private Result _terminalResult = Result.Success;
+    private int _executeGate;
+    private bool _stepping; // a StepAsync-driven run is in flight
+
+    private readonly RetryPolicy[]? _retryPolicies;
+    private readonly ForkState?[] _forks;
+    private readonly JoinState?[] _joins;
+    private readonly IBlackboardSettable?[] _settables;
+    private readonly ILogReporter?[] _reporters;
+    private readonly Func<string, CancellationToken, ValueTask> _cachedLogReportCallback;
+    private readonly bool _hasNodeSchema;
+
+    // ── Token pool ──────────────────────────────────────────────────────
+    private readonly Token[] _pool;
+    private readonly int[] _freeStack;
+    private int _freeCount;
+    private int _runnable;
+    private int _parked;
+    private bool _anyDied;
+    private int _round;
+    private int _nextTokenId;
+    private readonly int[]? _joinArrivals;
+    private readonly bool[]? _joinFired; // "fired at least once this run" per join node
+
+    private int _steppingTokenId = -1;
+    private NodeId _steppingNodeId = NodeId.Default;
+
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Graph];
+
+    /// <summary>Public execution status (volatile for visibility).</summary>
+    public ExecutionStatus Status => (ExecutionStatus)Volatile.Read(ref _statusInt);
+
+    /// <summary>Live tokens (runnable + parked). 0 outside a run.</summary>
+    public int LiveTokenCount => _runnable + _parked;
+
+    public AsyncTokenMachine(Graph graph, IAsyncTokenMachineObserver? observer = null,
+        int maxTokens = TokenMachine.DefaultMaxTokens)
+    {
+        Guard.NotNull(graph, nameof(graph));
+        if (maxTokens < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxTokens), "A token machine needs at least one token.");
+        }
+
+        Graph = graph;
+        _observer = observer;
+        _retryPolicies = graph.RetryPolicies;
+        _cachedLogReportCallback = LogReportCallback;
+
+        _forks = new ForkState?[graph.NodeCount];
+        _joins = new JoinState?[graph.NodeCount];
+        _settables = new IBlackboardSettable?[graph.NodeCount];
+        _reporters = new ILogReporter?[graph.NodeCount];
+        bool anyJoin = false;
+        for (int i = 0; i < graph.NodeCount; i++)
+        {
+            if (!graph.TryGetNodeByIndex(i, out INode? node) || node is not LogicNode logicNode)
+            {
+                continue;
+            }
+
+            _forks[i] = logicNode.Logic as ForkState ?? logicNode.AsyncLogic as ForkState;
+            _joins[i] = logicNode.Logic as JoinState ?? logicNode.AsyncLogic as JoinState;
+            anyJoin |= _joins[i] is not null;
+            _settables[i] = logicNode.AsyncLogic as IBlackboardSettable ?? logicNode.Logic as IBlackboardSettable;
+            _reporters[i] = logicNode.AsyncLogic as ILogReporter ?? logicNode.Logic as ILogReporter;
+        }
+
+        _joinArrivals = anyJoin ? new int[graph.NodeCount] : null;
+        _joinFired = anyJoin ? new bool[graph.NodeCount] : null;
+
+        BlackboardSchema? nodeSchema = graph.NodeSchema;
+        _hasNodeSchema = nodeSchema is not null;
+        _pool = new Token[maxTokens];
+        _freeStack = new int[maxTokens];
+        for (int i = 0; i < maxTokens; i++)
+        {
+            _pool[i] = new Token
+            {
+                SlotIndex = i,
+                NodeBoard = nodeSchema is null ? null : new Blackboard(nodeSchema),
+            };
+            _freeStack[i] = maxTokens - 1 - i;
+        }
+
+        _freeCount = maxTokens;
+    }
+
+    // ── Context binding (mirrors the FSM machines) ─────────────────────
+
+    /// <summary>
+    /// Hook for derived machines to (re)apply per-machine execution context (e.g. the typed
+    /// agent) to the graph's nodes. Runs under the execute gate, right before Starting.
+    /// The base implementation re-stamps the bound blackboard context.
+    /// </summary>
+    private protected virtual void ApplyExecutionContext()
+    {
+        // Unconditional re-stamp, empty context included — same rationale as the FSM machines.
+        // The machine-level context carries no Node slot; per-token scratch is stamped per
+        // node execution instead.
+        Graph.SetBlackboards(in _blackboards);
+    }
+
+    /// <summary>
+    /// Binds a blackboard into the scope slot its schema declares (replace semantics).
+    /// Node-scoped boards are per-token and machine-owned — binding one throws.
+    /// </summary>
+    public void SetBlackboard(Blackboard blackboard)
+    {
+        Guard.NotNull(blackboard, nameof(blackboard));
+        if (blackboard.Schema.Scope == BlackboardScope.Node)
+        {
+            throw new InvalidOperationException(
+                "Node-scoped boards are per-token transient scratch owned by the token machine and cannot be " +
+                "bound — declare the schema on the graph via WithSchema(...); the machine creates one board per " +
+                "pooled token.");
+        }
+
+        ValidateBoardAgainstDeclarations(blackboard);
+        _blackboards = _blackboards.With(blackboard);
+        Graph.SetBlackboards(in _blackboards);
+    }
+
+    /// <summary>
+    /// Receives the whole context from a parent machine's stamping walk. The parent's Node
+    /// slot is dropped — Node boards are per-token scratch owned by this machine.
+    /// </summary>
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        if (context.Graph is { } graphBoard)
+        {
+            ValidateBoardAgainstDeclarations(graphBoard);
+        }
+
+        if (context.Global is { } globalBoard)
+        {
+            ValidateBoardAgainstDeclarations(globalBoard);
+        }
+
+        BlackboardContext own = context.WithoutNode();
+        _blackboards = own;
+        Graph.SetBlackboards(in own);
+    }
+
+    private void ValidateBoardAgainstDeclarations(Blackboard blackboard)
+    {
+        BlackboardSchema? declared = blackboard.Schema.Scope == BlackboardScope.Global
+            ? Graph.GlobalSchema
+            : Graph.Schema;
+
+        if (declared is not null && !ReferenceEquals(declared, blackboard.Schema))
+        {
+            throw new InvalidOperationException(
+                $"Blackboard schema '{blackboard.Schema.Name ?? "<unnamed>"}' does not match the " +
+                $"{blackboard.Schema.Scope} schema '{declared.Name ?? "<unnamed>"}' declared on graph '{Graph.Id}'.");
+        }
+    }
+
+    /// <summary>
+    /// Controls how the machine behaves after reaching a terminal status
+    /// (same contract as the FSM machines).
+    /// </summary>
+    public void SetRestartPolicy(RestartPolicy policy) => _restartPolicy = policy;
+
+    // ── Reset ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Reset to the initial single-token state. Disallowed while Running/Transitioning.
+    /// Status moves: (any non-running) → Resetting → Ready.
+    /// </summary>
+    public async ValueTask<Result> Reset(CancellationToken ct = default)
+    {
+        if (Interlocked.Exchange(ref _executeGate, 1) == 1)
+        {
+            throw new InvalidOperationException(
+                "Cannot reset while the machine is executing. Await completion before calling Reset.");
+        }
+
+        try
+        {
+            return await ResetCore(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            Volatile.Write(ref _executeGate, 0);
+        }
+    }
+
+    private async ValueTask<Result> ResetCore(CancellationToken ct)
+    {
+        _ = ct;
+        while (true)
+        {
+            ExecutionStatus status = Status;
+            switch (status)
+            {
+                case ExecutionStatus.Running:
+                case ExecutionStatus.Transitioning:
+                case ExecutionStatus.Starting:
+                    throw new InvalidOperationException("Cannot reset while starting, running, or transitioning.");
+                case ExecutionStatus.Created:
+                case ExecutionStatus.Ready:
+                case ExecutionStatus.Resetting:
+                    return Result.Success;
+                case ExecutionStatus.Completed:
+                case ExecutionStatus.Failed:
+                case ExecutionStatus.Cancelled:
+                    break;
+                default:
+                    throw new IndexOutOfRangeException(nameof(status));
+            }
+
+            if (!TryTransition(status, ExecutionStatus.Resetting, out ExecutionStatus previous))
+            {
+                continue;
+            }
+
+            await NotifyMachineStatusChangeAsync(previous, ExecutionStatus.Resetting).ConfigureAwait(false);
+            break;
+        }
+
+        ClearRunState();
+        await TransitionTo(ExecutionStatus.Ready).ConfigureAwait(false);
+        return Result.Success;
+    }
+
+    private void ClearRunState()
+    {
+        for (int i = 0; i < _pool.Length; i++)
+        {
+            _pool[i].Phase = TokenSlotPhase.Free;
+            _freeStack[i] = _pool.Length - 1 - i;
+        }
+
+        _freeCount = _pool.Length;
+        _runnable = 0;
+        _parked = 0;
+        _anyDied = false;
+        _round = 0;
+        _nextTokenId = 0;
+        if (_joinArrivals is not null)
+        {
+            Array.Clear(_joinArrivals, 0, _joinArrivals.Length);
+            Array.Clear(_joinFired!, 0, _joinFired!.Length);
+        }
+    }
+
+    // ── Suspend / resume ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Captures the machine's runtime state into a serializable snapshot. Legal only at a
+    /// round boundary: between <see cref="StepAsync"/> calls of a stepped run, or on a machine
+    /// that is not currently executing.
+    /// </summary>
+    public TokenMachineSnapshot Suspend()
+    {
+        if (Interlocked.Exchange(ref _executeGate, 1) == 1)
+        {
+            throw new InvalidOperationException(
+                "Cannot suspend while the machine is executing. Suspend between StepAsync calls.");
+        }
+
+        try
+        {
+            ExecutionStatus status = Status;
+            if (status is ExecutionStatus.Starting or ExecutionStatus.Transitioning or ExecutionStatus.Resetting)
+            {
+                throw new InvalidOperationException($"Cannot suspend in transient status '{status}'.");
+            }
+
+            int live = _runnable + _parked;
+            TokenRecord[] records = live == 0 ? Array.Empty<TokenRecord>() : new TokenRecord[live];
+            int w = 0;
+            for (int i = 0; i < _pool.Length; i++)
+            {
+                Token t = _pool[i];
+                if (t.Phase == TokenSlotPhase.Free)
+                {
+                    continue;
+                }
+
+                records[w++] = new TokenRecord(t.Id, t.NodeIndex, t.Attempts, t.NodeEntered,
+                    t.Phase == TokenSlotPhase.Parked ? TokenPhase.Parked : TokenPhase.Runnable);
+            }
+
+            int[] arrivals = _joinArrivals is null ? Array.Empty<int>() : (int[])_joinArrivals.Clone();
+            bool[] fired = _joinFired is null ? Array.Empty<bool>() : (bool[])_joinFired.Clone();
+            return new TokenMachineSnapshot(status, _stepping, _nextTokenId, records, arrivals)
+            {
+                AnyTokenDied = _anyDied,
+                JoinsFired = fired,
+            };
+        }
+        finally
+        {
+            Volatile.Write(ref _executeGate, 0);
+        }
+    }
+
+    /// <summary>
+    /// Restores a snapshot produced by <c>Suspend()</c> (from either token runtime) onto this
+    /// machine. The graph must be structurally equivalent (same node indices) and the pool
+    /// large enough for the snapshot's live tokens. A mid-run snapshot is continued with
+    /// <see cref="StepAsync"/> until it returns a terminal result. Node-scope scratch is
+    /// transient and comes back as defaults.
+    /// </summary>
+    public void Resume(TokenMachineSnapshot snapshot)
+    {
+        Guard.NotNull(snapshot, nameof(snapshot));
+
+        if (Interlocked.Exchange(ref _executeGate, 1) == 1)
+        {
+            throw new InvalidOperationException("Cannot resume while the machine is executing.");
+        }
+
+        try
+        {
+            if (snapshot.Status is ExecutionStatus.Starting or ExecutionStatus.Transitioning
+                or ExecutionStatus.Resetting)
+            {
+                throw new InvalidOperationException(
+                    $"Snapshot captured in transient status '{snapshot.Status}' cannot be resumed.");
+            }
+
+            RestoreSnapshotCore(snapshot);
+            _stepping = snapshot.MidRun;
+            ApplyExecutionContext();
+            _terminalResult = snapshot.Status is ExecutionStatus.Failed or ExecutionStatus.Cancelled
+                ? Result.Failure
+                : Result.Success;
+            Volatile.Write(ref _statusInt, (int)snapshot.Status);
+        }
+        finally
+        {
+            Volatile.Write(ref _executeGate, 0);
+        }
+    }
+
+    private void RestoreSnapshotCore(TokenMachineSnapshot snapshot)
+    {
+        TokenRecord[] tokens = snapshot.Tokens ?? Array.Empty<TokenRecord>();
+        if (tokens.Length > _pool.Length)
+        {
+            throw new InvalidOperationException(
+                $"Snapshot holds {tokens.Length} live tokens but this machine's pool caps at {_pool.Length} " +
+                "(maxTokens). Construct the machine with a larger pool to resume it.");
+        }
+
+        if (snapshot.JoinArrivals is { Length: > 0 } arrivals)
+        {
+            if (_joinArrivals is null || arrivals.Length != _joinArrivals.Length)
+            {
+                throw new InvalidOperationException(
+                    "Snapshot join-arrival counts do not match this graph (join nodes or node count differ).");
+            }
+        }
+
+        ClearRunState();
+
+        for (int i = 0; i < tokens.Length; i++)
+        {
+            TokenRecord record = tokens[i];
+            if ((uint)record.NodeIndex >= (uint)Graph.NodeCount)
+            {
+                throw new InvalidOperationException(
+                    $"Snapshot token #{record.Id} node index {record.NodeIndex} is out of range for this graph " +
+                    $"(0..{Graph.NodeCount - 1}).");
+            }
+
+            Token t = _pool[i];
+            t.Id = record.Id;
+            t.NodeIndex = record.NodeIndex;
+            t.Attempts = record.Attempts;
+            t.NodeEntered = record.NodeEntered;
+            t.SpawnRound = -1;
+            t.NodeBoard?.ResetToDefaults();
+            if (record.Phase == TokenPhase.Parked)
+            {
+                t.Phase = TokenSlotPhase.Parked;
+                _parked++;
+            }
+            else
+            {
+                t.Phase = TokenSlotPhase.Runnable;
+                _runnable++;
+            }
+        }
+
+        _freeCount = _pool.Length - tokens.Length;
+        for (int i = 0; i < _freeCount; i++)
+        {
+            _freeStack[i] = _pool.Length - 1 - i;
+        }
+
+        _nextTokenId = snapshot.NextTokenId;
+        _anyDied = snapshot.AnyTokenDied;
+        if (snapshot.JoinArrivals is { Length: > 0 } restoredArrivals)
+        {
+            Array.Copy(restoredArrivals, _joinArrivals!, restoredArrivals.Length);
+        }
+
+        if (snapshot.JoinsFired is { Length: > 0 } restoredFired)
+        {
+            if (_joinFired is null || restoredFired.Length != _joinFired.Length)
+            {
+                throw new InvalidOperationException(
+                    "Snapshot join-fired flags do not match this graph (join nodes or node count differ).");
+            }
+
+            Array.Copy(restoredFired, _joinFired, restoredFired.Length);
+        }
+    }
+
+    // ── AsyncState overrides — full-run lifecycle ───────────────────────
+
+    protected override async ValueTask<Result> OnEnterAsync(CancellationToken ct)
+    {
+        if (Interlocked.Exchange(ref _executeGate, 1) == 1)
+        {
+            throw new InvalidOperationException("AsyncTokenMachine is already executing.");
+        }
+
+        try
+        {
+            if (_stepping)
+            {
+                throw new InvalidOperationException(
+                    "A stepped run is in progress. Finish it with StepAsync or Reset() before calling ExecuteAsync.");
+            }
+
+            ExecutionStatus status = Status;
+            if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+            {
+                switch (_restartPolicy)
+                {
+                    case RestartPolicy.Ignore:
+                        // Gate stays held; OnRunAsync returns the cached terminal result and
+                        // OnExitAsync releases the gate — mirrors AsyncStateMachine.
+                        return Result.InProgress;
+                    case RestartPolicy.Manual:
+                        throw new InvalidOperationException(
+                            $"AsyncTokenMachine is in terminal state '{status}'. Call Reset() before executing again.");
+                    default:
+                        await ResetCore(ct).ConfigureAwait(false);
+                        break;
+                }
+            }
+
+            ApplyExecutionContext();
+
+            await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
+            ClearRunState();
+            await SpawnRootTokenAsync(ct).ConfigureAwait(false);
+            await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
+
+            return Result.InProgress;
+        }
+        catch
+        {
+            RepairTransientStatus();
+            Volatile.Write(ref _executeGate, 0);
+            throw;
+        }
+    }
+
+    private async ValueTask SpawnRootTokenAsync(CancellationToken ct)
+    {
+        Token root = Alloc();
+        if (_observer is not null)
+        {
+            await _observer.OnTokenSpawned(root.Id, -1, Graph.StartNode.Id, ct).ConfigureAwait(false);
+        }
+
+        await ArriveAtAsync(root, Graph.StartNode.Id.Index, 0, ct).ConfigureAwait(false);
+    }
+
+    private void RepairTransientStatus()
+    {
+        ExecutionStatus status = Status;
+        if (status is ExecutionStatus.Starting or ExecutionStatus.Resetting or ExecutionStatus.Transitioning)
+        {
+            Volatile.Write(ref _statusInt, (int)ExecutionStatus.Ready);
+        }
+    }
+
+    private bool IsTerminal => Status is ExecutionStatus.Completed or ExecutionStatus.Failed
+        or ExecutionStatus.Cancelled;
+
+    protected override async ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        ExecutionStatus status = Status;
+        if (_restartPolicy == RestartPolicy.Ignore &&
+            status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+        {
+            return _terminalResult;
+        }
+
+        try
+        {
+            Result result;
+            do
+            {
+                result = await RunRoundAsync(ct).ConfigureAwait(false);
+            } while (!result.IsCompleted);
+
+            _terminalResult = result;
+
+            await TransitionTo(result == Result.Success ? ExecutionStatus.Completed : ExecutionStatus.Failed)
+                .ConfigureAwait(false);
+
+            if (_restartPolicy == RestartPolicy.Auto)
+            {
+                await ResetCore(ct).ConfigureAwait(false);
+            }
+
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            if (!IsTerminal)
+            {
+                await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
+                _terminalResult = Result.Failure;
+                if (_restartPolicy == RestartPolicy.Auto)
+                {
+                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (!IsTerminal)
+            {
+                if (_observer is not null)
+                {
+                    await _observer.OnStateFailed(_steppingTokenId, _steppingNodeId, ex, ct).ConfigureAwait(false);
+                }
+
+                await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
+                _terminalResult = Result.Failure;
+                if (_restartPolicy == RestartPolicy.Auto)
+                {
+                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+
+            throw;
+        }
+    }
+
+    protected override ValueTask<Result> OnExitAsync(CancellationToken ct)
+    {
+        Volatile.Write(ref _executeGate, 0);
+        return ResultHelpers.Success;
+    }
+
+    // ── Stepped execution ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Advances the machine by exactly one scheduling round, mirroring the sync machine's
+    /// frame-stepped <c>Execute()</c>. Returns <see cref="Result.InProgress"/> while tokens
+    /// remain and the terminal result when the run finishes. The first call begins a run
+    /// (applying the restart policy exactly like <c>ExecuteAsync</c>); between rounds the
+    /// machine stays <see cref="ExecutionStatus.Running"/>.
+    /// </summary>
+    public async ValueTask<Result> StepAsync(CancellationToken ct = default)
+    {
+        if (Interlocked.Exchange(ref _executeGate, 1) == 1)
+        {
+            throw new InvalidOperationException("AsyncTokenMachine is already executing.");
+        }
+
+        try
+        {
+            if (!_stepping)
+            {
+                try
+                {
+                    ExecutionStatus status = Status;
+                    if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+                    {
+                        switch (_restartPolicy)
+                        {
+                            case RestartPolicy.Ignore:
+                                return _terminalResult;
+                            case RestartPolicy.Manual:
+                                throw new InvalidOperationException(
+                                    $"AsyncTokenMachine is in terminal state '{status}'. Call Reset() before stepping again.");
+                            default:
+                                await ResetCore(ct).ConfigureAwait(false);
+                                break;
+                        }
+                    }
+
+                    ApplyExecutionContext();
+
+                    await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
+                    ClearRunState();
+                    await SpawnRootTokenAsync(ct).ConfigureAwait(false);
+                    await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
+                    _stepping = true;
+                }
+                catch
+                {
+                    RepairTransientStatus();
+                    throw;
+                }
+            }
+
+            Result result;
+            try
+            {
+                result = await RunRoundAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                _stepping = false;
+                if (!IsTerminal)
+                {
+                    await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
+                    _terminalResult = Result.Failure;
+                    if (_restartPolicy == RestartPolicy.Auto)
+                    {
+                        await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                    }
+                }
+
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _stepping = false;
+                if (!IsTerminal)
+                {
+                    if (_observer is not null)
+                    {
+                        await _observer.OnStateFailed(_steppingTokenId, _steppingNodeId, ex, ct)
+                            .ConfigureAwait(false);
+                    }
+
+                    await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
+                    _terminalResult = Result.Failure;
+                    if (_restartPolicy == RestartPolicy.Auto)
+                    {
+                        await ResetCore(CancellationToken.None).ConfigureAwait(false);
+                    }
+                }
+
+                throw;
+            }
+
+            if (!result.IsCompleted)
+            {
+                return Result.InProgress;
+            }
+
+            _stepping = false;
+            _terminalResult = result;
+            await TransitionTo(result == Result.Success ? ExecutionStatus.Completed : ExecutionStatus.Failed)
+                .ConfigureAwait(false);
+
+            if (_restartPolicy == RestartPolicy.Auto)
+            {
+                await ResetCore(ct).ConfigureAwait(false);
+            }
+
+            return result;
+        }
+        finally
+        {
+            Volatile.Write(ref _executeGate, 0);
+        }
+    }
+
+    // ── The round scheduler (the hot path) ─────────────────────────────
+
+    private async ValueTask<Result> RunRoundAsync(CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        _round++;
+        for (int i = 0; i < _pool.Length; i++)
+        {
+            Token t = _pool[i];
+            if (t.Phase != TokenSlotPhase.Runnable || t.SpawnRound == _round)
+            {
+                continue;
+            }
+
+            await StepTokenAsync(t, ct).ConfigureAwait(false);
+        }
+
+        if (_runnable > 0)
+        {
+            return Result.InProgress;
+        }
+
+        if (_parked > 0)
+        {
+            // Tokens parked at a join that already fired this run are benign quorum leftovers
+            // and absorb quietly; tokens parked at a join that never fired are starved — their
+            // suppliers died or completed elsewhere — and fail the machine.
+            bool anyStarved = false;
+            for (int i = 0; i < _pool.Length; i++)
+            {
+                Token t = _pool[i];
+                if (t.Phase != TokenSlotPhase.Parked)
+                {
+                    continue;
+                }
+
+                if (_joinFired![t.NodeIndex])
+                {
+                    await RetireTokenAsync(t, IdOf(t.NodeIndex), TokenRetireReason.Absorbed, ct)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    anyStarved = true;
+                    await RetireTokenAsync(t, IdOf(t.NodeIndex), TokenRetireReason.Starved, ct)
+                        .ConfigureAwait(false);
+                }
+            }
+
+            if (anyStarved)
+            {
+                return Result.Failure;
+            }
+        }
+
+        return _anyDied ? Result.Failure : Result.Success;
+    }
+
+    private async ValueTask StepTokenAsync(Token t, CancellationToken ct)
+    {
+        int idx = t.NodeIndex;
+        if (!Graph.TryGetNodeByIndex(idx, out INode? node) || node is not LogicNode logicNode)
+        {
+            throw new InvalidOperationException($"Node #{idx} not found.");
+        }
+
+        _steppingTokenId = t.Id;
+        _steppingNodeId = logicNode.Id;
+
+        // Per-token Node-scope scratch: stamped onto this node only, right before it executes.
+        if (_hasNodeSchema && _settables[idx] is { } settable)
+        {
+            settable.SetBlackboards(_blackboards.With(t.NodeBoard!));
+        }
+
+        ILogReporter? reporter = _reporters[idx];
+        if (reporter is not null)
+        {
+            reporter.LogReport = _cachedLogReportCallback;
+        }
+
+        if (!t.NodeEntered)
+        {
+            t.NodeEntered = true;
+            logicNode.EnterAction?.Invoke();
+        }
+
+        Result result = await logicNode.AsyncLogic.ExecuteAsync(ct).ConfigureAwait(false);
+        t.Attempts++;
+        switch (result.Code)
+        {
+            case Result.StatusCode.Success:
+            {
+                t.NodeEntered = false;
+                logicNode.ExitAction?.Invoke();
+                if (_observer is not null)
+                {
+                    await _observer.OnStateExited(t.Id, logicNode.Id, ct).ConfigureAwait(false);
+                }
+
+                NodeId next;
+                if (logicNode.AsyncLogic is IAsyncDirector director)
+                {
+                    next = await director.SelectNextAsync(ct).ConfigureAwait(false);
+                    if (next.Equals(NodeId.Default))
+                    {
+                        await RetireTokenAsync(t, logicNode.Id, TokenRetireReason.Completed, ct)
+                            .ConfigureAwait(false);
+                        return;
+                    }
+                }
+                else if (logicNode.Logic is IDirector syncDirector)
+                {
+                    next = syncDirector.SelectNext();
+                    if (next.Equals(NodeId.Default))
+                    {
+                        await RetireTokenAsync(t, logicNode.Id, TokenRetireReason.Completed, ct)
+                            .ConfigureAwait(false);
+                        return;
+                    }
+                }
+                else
+                {
+                    if (!Graph.TryGetTransition(logicNode.Id, out Transition edge))
+                    {
+                        if (_observer is not null)
+                        {
+                            await _observer.OnStateFailed(t.Id, logicNode.Id,
+                                    new InvalidOperationException($"No transition found for state '{logicNode.Id}'."),
+                                    ct)
+                                .ConfigureAwait(false);
+                        }
+
+                        _anyDied = true;
+                        await RetireTokenAsync(t, logicNode.Id, TokenRetireReason.Failed, ct).ConfigureAwait(false);
+                        return;
+                    }
+
+                    if (edge.IsEmpty)
+                    {
+                        await RetireTokenAsync(t, logicNode.Id, TokenRetireReason.Completed, ct)
+                            .ConfigureAwait(false);
+                        return;
+                    }
+
+                    next = edge.Destination;
+                }
+
+                if (_observer is not null)
+                {
+                    await _observer.OnTransition(t.Id, logicNode.Id, next, ct).ConfigureAwait(false);
+                }
+
+                t.Attempts = 0;
+                t.NodeBoard?.ResetToDefaults();
+                await ArriveAtAsync(t, next.Index, 0, ct).ConfigureAwait(false);
+                return;
+            }
+            case Result.StatusCode.Failure:
+            {
+                if (_retryPolicies is not null)
+                {
+                    RetryPolicy retry = _retryPolicies[idx];
+                    if (t.Attempts < retry.MaxAttempts)
+                    {
+                        TimeSpan delay = retry.DelayForAttempt(t.Attempts);
+                        if (delay > TimeSpan.Zero)
+                        {
+                            // Awaited inline during this token's turn — the round resumes
+                            // with the next token afterwards; the retry itself happens on
+                            // this token's next round.
+                            await Task.Delay(delay, ct).ConfigureAwait(false);
+                        }
+
+                        return;
+                    }
+                }
+
+                t.NodeEntered = false;
+                logicNode.ExitAction?.Invoke();
+
+                if (Graph.TryGetTransition(logicNode.Id, out Transition failEdge) &&
+                    failEdge.HasFailureDestination)
+                {
+                    if (_observer is not null)
+                    {
+                        await _observer.OnStateFailed(t.Id, logicNode.Id, null, ct).ConfigureAwait(false);
+                    }
+
+                    NodeId handler = failEdge.FailureDestination;
+                    if (_observer is not null)
+                    {
+                        await _observer.OnTransition(t.Id, logicNode.Id, handler, ct).ConfigureAwait(false);
+                    }
+
+                    t.Attempts = 0;
+                    t.NodeBoard?.ResetToDefaults();
+                    await ArriveAtAsync(t, handler.Index, 0, ct).ConfigureAwait(false);
+                    return;
+                }
+
+                if (_observer is not null)
+                {
+                    await _observer.OnStateFailed(t.Id, logicNode.Id, null, ct).ConfigureAwait(false);
+                }
+
+                _anyDied = true;
+                await RetireTokenAsync(t, logicNode.Id, TokenRetireReason.Failed, ct).ConfigureAwait(false);
+                return;
+            }
+            case Result.StatusCode.InProgress:
+                throw new InvalidOperationException(
+                    $"Node '{logicNode.Id}' returned Result.InProgress, which is reserved for the " +
+                    "stepped-execution runtime. Node logic must return Success or Failure.");
+            default:
+                throw new InvalidOperationException("Unknown node result.");
+        }
+    }
+
+    /// <summary>
+    /// Lands <paramref name="t"/> on node <paramref name="idx"/>, resolving fork/join structure
+    /// at arrival — same semantics as the sync twin.
+    /// </summary>
+    private async ValueTask ArriveAtAsync(Token t, int idx, int depth, CancellationToken ct)
+    {
+        if (depth > MaxCascadeDepth)
+        {
+            throw new InvalidOperationException(
+                $"Fork/join arrival cascade exceeds {MaxCascadeDepth} levels — check for a cycle of fork nodes.");
+        }
+
+        if ((uint)idx >= (uint)_forks.Length)
+        {
+            throw new InvalidOperationException($"Transition points to non-existent node #{idx}.");
+        }
+
+        ForkState? fork = _forks[idx];
+        if (fork is not null)
+        {
+            await PassThroughForkAsync(t, idx, fork, depth, ct).ConfigureAwait(false);
+            return;
+        }
+
+        JoinState? join = _joins[idx];
+        if (join is not null)
+        {
+            await ArriveAtJoinAsync(t, idx, join, depth, ct).ConfigureAwait(false);
+            return;
+        }
+
+        t.NodeIndex = idx;
+        t.NodeEntered = false;
+        if (_observer is not null)
+        {
+            await _observer.OnStateEntered(t.Id, IdOf(idx), ct).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask PassThroughForkAsync(Token t, int idx, ForkState fork, int depth, CancellationToken ct)
+    {
+        LogicNode forkNode = (LogicNode)Graph.GetNodeByIndex(idx);
+        NodeId forkId = forkNode.Id;
+        if (_observer is not null)
+        {
+            await _observer.OnStateEntered(t.Id, forkId, ct).ConfigureAwait(false);
+        }
+
+        forkNode.EnterAction?.Invoke();
+        forkNode.ExitAction?.Invoke();
+        if (_observer is not null)
+        {
+            await _observer.OnStateExited(t.Id, forkId, ct).ConfigureAwait(false);
+        }
+
+        // Branch 0 continues the arriving token; every other branch spawns a new one.
+        // Branch ids are resolved through the graph so observers see the applied display
+        // names (the fork stores pre-Build ids, whose names are empty).
+        int firstIndex = fork.BranchAt(0).Index;
+        if (_observer is not null)
+        {
+            await _observer.OnTransition(t.Id, forkId, IdOf(firstIndex), ct).ConfigureAwait(false);
+        }
+
+        await ArriveAtAsync(t, firstIndex, depth + 1, ct).ConfigureAwait(false);
+
+        for (int b = 1; b < fork.BranchCount; b++)
+        {
+            Token child = Alloc();
+            int branchIndex = fork.BranchAt(b).Index;
+            if (_observer is not null)
+            {
+                await _observer.OnTokenSpawned(child.Id, t.Id, forkId, ct).ConfigureAwait(false);
+                await _observer.OnTransition(child.Id, forkId, IdOf(branchIndex), ct).ConfigureAwait(false);
+            }
+
+            await ArriveAtAsync(child, branchIndex, depth + 1, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask ArriveAtJoinAsync(Token t, int idx, JoinState join, int depth, CancellationToken ct)
+    {
+        LogicNode joinNode = (LogicNode)Graph.GetNodeByIndex(idx);
+        NodeId joinId = joinNode.Id;
+        if (_observer is not null)
+        {
+            await _observer.OnStateEntered(t.Id, joinId, ct).ConfigureAwait(false);
+        }
+
+        joinNode.EnterAction?.Invoke();
+
+        int arrivals = ++_joinArrivals![idx];
+        int required = join.Policy.RequiredCount;
+        if (arrivals < required)
+        {
+            t.NodeIndex = idx;
+            t.NodeEntered = false;
+            t.Phase = TokenSlotPhase.Parked;
+            _runnable--;
+            _parked++;
+            return;
+        }
+
+        // Fire: consume the requirement — this token plus (required - 1) parked ones.
+        _joinArrivals[idx] = arrivals - required;
+        _joinFired![idx] = true;
+        int toConsume = required - 1;
+        for (int i = 0; i < _pool.Length && toConsume > 0; i++)
+        {
+            Token parked = _pool[i];
+            if (parked.Phase == TokenSlotPhase.Parked && parked.NodeIndex == idx)
+            {
+                await RetireTokenAsync(parked, joinId, TokenRetireReason.Joined, ct).ConfigureAwait(false);
+                toConsume--;
+            }
+        }
+
+        if (_observer is not null)
+        {
+            await _observer.OnJoinFired(joinId, t.Id, ct).ConfigureAwait(false);
+        }
+
+        joinNode.ExitAction?.Invoke();
+        if (_observer is not null)
+        {
+            await _observer.OnStateExited(t.Id, joinId, ct).ConfigureAwait(false);
+        }
+
+        t.Attempts = 0;
+        t.NodeBoard?.ResetToDefaults();
+
+        if (!Graph.TryGetTransition(joinId, out Transition edge) || edge.IsEmpty)
+        {
+            await RetireTokenAsync(t, joinId, TokenRetireReason.Completed, ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (_observer is not null)
+        {
+            await _observer.OnTransition(t.Id, joinId, edge.Destination, ct).ConfigureAwait(false);
+        }
+
+        await ArriveAtAsync(t, edge.Destination.Index, depth + 1, ct).ConfigureAwait(false);
+    }
+
+    // ── Pool operations ─────────────────────────────────────────────────
+
+    private Token Alloc()
+    {
+        if (_freeCount == 0)
+        {
+            throw new InvalidOperationException(
+                $"Token pool exhausted ({_pool.Length} tokens live). Raise the machine's maxTokens " +
+                "constructor argument to fit this graph's fan-out.");
+        }
+
+        int slot = _freeStack[--_freeCount];
+        Token t = _pool[slot];
+        t.Id = _nextTokenId++;
+        t.NodeIndex = 0;
+        t.Attempts = 0;
+        t.NodeEntered = false;
+        t.Phase = TokenSlotPhase.Runnable;
+        t.SpawnRound = _round;
+        t.NodeBoard?.ResetToDefaults();
+        _runnable++;
+        return t;
+    }
+
+    private async ValueTask RetireTokenAsync(Token t, NodeId at, TokenRetireReason reason, CancellationToken ct)
+    {
+        if (t.Phase == TokenSlotPhase.Runnable)
+        {
+            _runnable--;
+        }
+        else if (t.Phase == TokenSlotPhase.Parked)
+        {
+            _parked--;
+        }
+
+        t.Phase = TokenSlotPhase.Free;
+        _freeStack[_freeCount++] = t.SlotIndex;
+        if (_observer is not null)
+        {
+            await _observer.OnTokenRetired(t.Id, at, reason, ct).ConfigureAwait(false);
+        }
+    }
+
+    private NodeId IdOf(int index) => Graph.GetNodeByIndex(index).Id;
+
+    private async ValueTask LogReportCallback(string message, CancellationToken ct)
+    {
+        if (_observer is not null)
+        {
+            await _observer.OnLogReport(_steppingTokenId, _steppingNodeId, message, ct).ConfigureAwait(false);
+        }
+    }
+
+    // ── Status plumbing (mirrors AsyncStateMachine) ─────────────────────
+
+    private bool TryTransition(ExecutionStatus from, ExecutionStatus to, out ExecutionStatus prev)
+    {
+        int f = (int)from, t = (int)to;
+        int seen = Interlocked.CompareExchange(ref _statusInt, t, f);
+        prev = (ExecutionStatus)seen;
+
+        return seen == f;
+    }
+
+    private async ValueTask TransitionTo(ExecutionStatus next)
+    {
+        ExecutionStatus prev = (ExecutionStatus)Interlocked.Exchange(ref _statusInt, (int)next);
+        Debug.Assert(prev != next, $"Redundant status transition: {prev} -> {next}");
+        if (prev != next && _observer is not null)
+        {
+            await NotifyMachineStatusChangeAsync(prev, next).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask NotifyMachineStatusChangeAsync(ExecutionStatus prev, ExecutionStatus next)
+    {
+        if (_observer is null)
+        {
+            return;
+        }
+
+        NodeId graphId = Graph.Id;
+        await _observer.TokenMachineStatusChanged(graphId, prev, next).ConfigureAwait(false);
+        switch (next)
+        {
+            case ExecutionStatus.Starting:
+                await _observer.OnTokenMachineStarted(graphId).ConfigureAwait(false);
+                break;
+            case ExecutionStatus.Completed:
+                await _observer.OnTokenMachineCompleted(graphId, Result.Success).ConfigureAwait(false);
+                break;
+            case ExecutionStatus.Failed:
+                await _observer.OnTokenMachineCompleted(graphId, Result.Failure).ConfigureAwait(false);
+                break;
+            case ExecutionStatus.Cancelled:
+                await _observer.OnTokenMachineCancelled(graphId).ConfigureAwait(false);
+                break;
+            case ExecutionStatus.Resetting:
+                await _observer.OnTokenMachineReset(graphId).ConfigureAwait(false);
+                break;
+            case ExecutionStatus.Ready:
+            case ExecutionStatus.Created:
+            case ExecutionStatus.Running:
+            case ExecutionStatus.Transitioning:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(next), next, null);
+        }
+    }
+}

--- a/NxGraph/Tokens/ForkState.cs
+++ b/NxGraph/Tokens/ForkState.cs
@@ -1,0 +1,72 @@
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tokens;
+
+/// <summary>
+/// Structural fan-out node for the token runtimes: a token passing through a fork continues
+/// to <see cref="Branches"/>[0] and one new token is spawned per remaining branch. Forks carry
+/// no user logic and their <see cref="Transition"/> slot must stay empty — the branches replace
+/// the success edge (the DSL enforces this; the validator lints it).
+/// <para>
+/// Fork nodes are interpreted <b>only</b> by <see cref="TokenMachine"/> /
+/// <see cref="AsyncTokenMachine"/>. The FSM runtimes cannot express multiple active nodes, so
+/// executing a fork under them throws instead of silently misrouting. The
+/// <see cref="IDirector"/>/<see cref="IAsyncDirector"/> implementations exist solely to surface
+/// the branches to reachability validation and Mermaid export via
+/// <c>EnumerateStaticTargets()</c> — selection likewise throws.
+/// </para>
+/// </summary>
+public sealed class ForkState : ILogic, IAsyncLogic, IDirector, IAsyncDirector
+{
+    private readonly NodeId[] _branches;
+
+    public ForkState(params NodeId[] branches)
+    {
+        if (branches is null || branches.Length == 0)
+        {
+            throw new ArgumentException("A fork must declare at least one branch.", nameof(branches));
+        }
+
+        foreach (NodeId branch in branches)
+        {
+            if (branch == NodeId.Default)
+            {
+                throw new ArgumentException("Fork branches cannot be NodeId.Default.", nameof(branches));
+            }
+        }
+
+        _branches = (NodeId[])branches.Clone();
+    }
+
+    /// <summary>The branch heads, in declaration order. Branch 0 continues the arriving token.</summary>
+    public IReadOnlyList<NodeId> Branches => _branches;
+
+    internal int BranchCount => _branches.Length;
+
+    internal NodeId BranchAt(int index) => _branches[index];
+
+    Result ILogic.Execute() => throw TokenNodeMisuse.ForFork();
+
+    ValueTask<Result> IAsyncLogic.ExecuteAsync(CancellationToken ct) => throw TokenNodeMisuse.ForFork();
+
+    NodeId IDirector.SelectNext() => throw TokenNodeMisuse.ForFork();
+
+    ValueTask<NodeId> IAsyncDirector.SelectNextAsync(CancellationToken ct) => throw TokenNodeMisuse.ForFork();
+
+    IEnumerable<NodeId> IDirector.EnumerateStaticTargets() => _branches;
+
+    IEnumerable<NodeId> IAsyncDirector.EnumerateStaticTargets() => _branches;
+}
+
+/// <summary>Shared throw helpers for token-only structural nodes run under the wrong runtime.</summary>
+internal static class TokenNodeMisuse
+{
+    internal static NotSupportedException ForFork() => new(
+        "ForkState is a token-runtime structural node and cannot be executed by the FSM runtimes. " +
+        "Run this graph with TokenMachine or AsyncTokenMachine (NxGraph.Tokens).");
+
+    internal static NotSupportedException ForJoin() => new(
+        "JoinState is a token-runtime structural node and cannot be executed by the FSM runtimes. " +
+        "Run this graph with TokenMachine or AsyncTokenMachine (NxGraph.Tokens).");
+}

--- a/NxGraph/Tokens/IAsyncTokenMachineObserver.cs
+++ b/NxGraph/Tokens/IAsyncTokenMachineObserver.cs
@@ -1,0 +1,88 @@
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tokens;
+
+/// <summary>
+/// Asynchronous observer for <see cref="AsyncTokenMachine"/> — the <c>ValueTask</c> twin of
+/// <see cref="ITokenMachineObserver"/>. Every node-level event names the token it happened to.
+/// All methods have default no-op implementations. Observer exceptions bubble by design.
+/// </summary>
+public interface IAsyncTokenMachineObserver
+{
+    /// <summary>A new token entered the run. The root token reports <paramref name="parentTokenId"/> -1.</summary>
+    ValueTask OnTokenSpawned(int tokenId, int parentTokenId, NodeId at, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    /// <summary>A token left the run (terminal success/failure, join consumption, or starvation).</summary>
+    ValueTask OnTokenRetired(int tokenId, NodeId at, TokenRetireReason reason, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    /// <summary>A join's policy was met; <paramref name="survivingTokenId"/> continues past it.</summary>
+    ValueTask OnJoinFired(NodeId joinNode, int survivingTokenId, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    ValueTask OnStateEntered(int tokenId, NodeId id, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    ValueTask OnStateExited(int tokenId, NodeId id, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    ValueTask OnTransition(int tokenId, NodeId from, NodeId to, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    /// <summary>
+    /// A node failed for the given token. <paramref name="ex"/> is <c>null</c> when the node
+    /// returned <see cref="Result.Failure"/> without throwing (a result-based failure).
+    /// </summary>
+    ValueTask OnStateFailed(int tokenId, NodeId id, Exception? ex, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    /// <summary>A log report emitted by node logic, attributed to the token being stepped.</summary>
+    ValueTask OnLogReport(int tokenId, NodeId nodeId, string message, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    //--- Machine lifecycle events (same shapes as the FSM observers) ---
+
+    ValueTask OnTokenMachineReset(NodeId graphId, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    ValueTask OnTokenMachineStarted(NodeId graphId, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    ValueTask OnTokenMachineCompleted(NodeId graphId, Result result, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    ValueTask OnTokenMachineCancelled(NodeId graphId, CancellationToken ct = default)
+    {
+        return default;
+    }
+
+    ValueTask TokenMachineStatusChanged(NodeId graphId, ExecutionStatus prev, ExecutionStatus next,
+        CancellationToken ct = default)
+    {
+        return default;
+    }
+}

--- a/NxGraph/Tokens/ITokenMachineObserver.cs
+++ b/NxGraph/Tokens/ITokenMachineObserver.cs
@@ -1,0 +1,47 @@
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tokens;
+
+/// <summary>
+/// Synchronous observer for <see cref="TokenMachine"/>. The FSM observer surface gains a token
+/// identity dimension: every node-level event names the token it happened to. All methods have
+/// default no-op implementations so consumers only override what they need; callbacks are
+/// <c>void</c> — no allocations, no async machinery. Observer exceptions bubble by design.
+/// </summary>
+public interface ITokenMachineObserver
+{
+    /// <summary>A new token entered the run. The root token reports <paramref name="parentTokenId"/> -1.</summary>
+    void OnTokenSpawned(int tokenId, int parentTokenId, NodeId at) { }
+
+    /// <summary>A token left the run (terminal success/failure, join consumption, or starvation).</summary>
+    void OnTokenRetired(int tokenId, NodeId at, TokenRetireReason reason) { }
+
+    /// <summary>A join's policy was met; <paramref name="survivingTokenId"/> continues past it.</summary>
+    void OnJoinFired(NodeId joinNode, int survivingTokenId) { }
+
+    void OnStateEntered(int tokenId, NodeId id) { }
+
+    void OnStateExited(int tokenId, NodeId id) { }
+
+    void OnTransition(int tokenId, NodeId from, NodeId to) { }
+
+    /// <summary>
+    /// A node failed for the given token. <paramref name="ex"/> is <c>null</c> when the node
+    /// returned <see cref="Result.Failure"/> without throwing (a result-based failure).
+    /// </summary>
+    void OnStateFailed(int tokenId, NodeId id, Exception? ex) { }
+
+    /// <summary>A log report emitted by node logic, attributed to the token being stepped.</summary>
+    void OnLogReport(int tokenId, NodeId nodeId, string message) { }
+
+    //--- Machine lifecycle events (same shapes as the FSM observers) ---
+
+    void OnTokenMachineReset(NodeId graphId) { }
+
+    void OnTokenMachineStarted(NodeId graphId) { }
+
+    void OnTokenMachineCompleted(NodeId graphId, Result result) { }
+
+    void TokenMachineStatusChanged(NodeId graphId, ExecutionStatus prev, ExecutionStatus next) { }
+}

--- a/NxGraph/Tokens/JoinPolicy.cs
+++ b/NxGraph/Tokens/JoinPolicy.cs
@@ -1,0 +1,75 @@
+namespace NxGraph.Tokens;
+
+/// <summary>
+/// Discriminates how a <see cref="JoinState"/> decides it has enough arrived tokens to fire.
+/// </summary>
+public enum JoinKind : byte
+{
+    /// <summary>Fire when all <c>n</c> expected tokens have arrived (classic AND-join).</summary>
+    All = 0,
+
+    /// <summary>Fire on every arrival — the join is a mid-graph merge point.</summary>
+    Any = 1,
+
+    /// <summary>Fire when <c>m</c> of the expected tokens have arrived (M-of-N quorum).</summary>
+    Quorum = 2,
+}
+
+/// <summary>
+/// The firing rule of a <see cref="JoinState"/>. A join accumulates arriving tokens and
+/// <b>fires</b> whenever the accumulated count reaches <see cref="RequiredCount"/>: the
+/// requirement is consumed, one token continues along the join's success edge, and the other
+/// consumed tokens retire. Joins re-arm — they can fire many times per run, which is what
+/// makes <see cref="Any"/> a merge point and lets stream-style token flows pass through.
+/// </summary>
+public readonly struct JoinPolicy
+{
+    private JoinPolicy(JoinKind kind, int count)
+    {
+        Kind = kind;
+        Count = count;
+    }
+
+    /// <summary>The firing rule discriminator.</summary>
+    public JoinKind Kind { get; }
+
+    /// <summary>The declared count (<c>n</c> for All, <c>m</c> for Quorum, 1 for Any).</summary>
+    public int Count { get; }
+
+    /// <summary>Arrivals consumed per firing. A default-constructed policy is invalid (0).</summary>
+    public int RequiredCount => Count;
+
+    /// <summary>Fire when <paramref name="expectedTokens"/> tokens have arrived.</summary>
+    public static JoinPolicy All(int expectedTokens)
+    {
+        if (expectedTokens < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expectedTokens),
+                "An All-join must expect at least one token.");
+        }
+
+        return new JoinPolicy(JoinKind.All, expectedTokens);
+    }
+
+    /// <summary>Fire on every arrival (mid-graph merge).</summary>
+    public static JoinPolicy Any => new(JoinKind.Any, 1);
+
+    /// <summary>Fire when <paramref name="requiredTokens"/> of the incoming tokens have arrived.</summary>
+    public static JoinPolicy Quorum(int requiredTokens)
+    {
+        if (requiredTokens < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(requiredTokens),
+                "A quorum join must require at least one token.");
+        }
+
+        return new JoinPolicy(JoinKind.Quorum, requiredTokens);
+    }
+
+    public override string ToString() => Kind switch
+    {
+        JoinKind.Any => "Any",
+        JoinKind.Quorum => $"Quorum({Count})",
+        _ => $"All({Count})",
+    };
+}

--- a/NxGraph/Tokens/JoinState.cs
+++ b/NxGraph/Tokens/JoinState.cs
@@ -1,0 +1,37 @@
+using NxGraph.Graphs;
+
+namespace NxGraph.Tokens;
+
+/// <summary>
+/// Structural merge node for the token runtimes: arriving tokens are parked until the
+/// <see cref="Policy"/>'s requirement is met, then the join <b>fires</b> — the firing token
+/// continues along the join's ordinary success edge, the other consumed tokens retire, and the
+/// join re-arms for the next batch. <see cref="JoinPolicy.Any"/> makes the join a mid-graph
+/// merge point (every arrival passes straight through).
+/// <para>
+/// Join nodes are interpreted <b>only</b> by <see cref="TokenMachine"/> /
+/// <see cref="AsyncTokenMachine"/>; executing one under the FSM runtimes throws. Convergence
+/// is authored by routing several chains to the <i>same</i> <see cref="JoinState"/> instance
+/// (<c>.To(join)</c> dedupes by reference into one node).
+/// </para>
+/// </summary>
+public sealed class JoinState : ILogic, IAsyncLogic
+{
+    public JoinState(JoinPolicy policy)
+    {
+        if (policy.RequiredCount < 1)
+        {
+            throw new ArgumentException(
+                "Join policy is uninitialized — construct it via JoinPolicy.All/Any/Quorum.", nameof(policy));
+        }
+
+        Policy = policy;
+    }
+
+    /// <summary>The firing rule of this join.</summary>
+    public JoinPolicy Policy { get; }
+
+    Result ILogic.Execute() => throw TokenNodeMisuse.ForJoin();
+
+    ValueTask<Result> IAsyncLogic.ExecuteAsync(CancellationToken ct) => throw TokenNodeMisuse.ForJoin();
+}

--- a/NxGraph/Tokens/Token.cs
+++ b/NxGraph/Tokens/Token.cs
@@ -1,0 +1,52 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Tokens;
+
+/// <summary>
+/// Pool-slot lifecycle of a token. <see cref="Free"/> slots are available for spawning;
+/// only <see cref="Runnable"/>/<see cref="Parked"/> tokens exist logically.
+/// </summary>
+internal enum TokenSlotPhase : byte
+{
+    Free = 0,
+    Runnable = 1,
+    Parked = 2,
+}
+
+/// <summary>
+/// A unit of execution state in the token runtimes: its position, per-visit attempt counter,
+/// lifecycle phase, and (when the graph declares a Node-scope schema) its own transient
+/// scratch board. Tokens are pooled — every slot (board included) is preallocated at machine
+/// construction so spawning and retiring are free-list index operations at 0 B.
+/// </summary>
+internal sealed class Token
+{
+    /// <summary>The pool slot this token permanently occupies (set once at pool creation).</summary>
+    public int SlotIndex;
+
+    /// <summary>Stable identity within a run (dense, ascending from 0).</summary>
+    public int Id;
+
+    /// <summary>Index of the node this token currently occupies (or is parked at).</summary>
+    public int NodeIndex;
+
+    /// <summary>Executions of the current node by this token in this visit.</summary>
+    public int Attempts;
+
+    /// <summary>Whether the current node's EnterAction has fired for this token's visit.</summary>
+    public bool NodeEntered;
+
+    public TokenSlotPhase Phase;
+
+    /// <summary>
+    /// The scheduling round this token was spawned in. A token never runs in its spawn round —
+    /// it first executes in the following round, keeping interleaving deterministic.
+    /// </summary>
+    public int SpawnRound;
+
+    /// <summary>
+    /// Per-token Node-scope scratch, created from the graph's declared Node schema; null when
+    /// none is declared. Resets exactly when this token's attempt counter resets.
+    /// </summary>
+    public Blackboard? NodeBoard;
+}

--- a/NxGraph/Tokens/TokenMachine.cs
+++ b/NxGraph/Tokens/TokenMachine.cs
@@ -1,0 +1,1000 @@
+using System.Runtime.CompilerServices;
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tokens;
+
+/// <summary>
+/// A synchronous token machine with an agent, mirroring <see cref="TokenMachine"/> the way
+/// <see cref="StateMachine{TAgent}"/> mirrors <see cref="StateMachine"/>.
+/// </summary>
+public class TokenMachine<TAgent>(Graph graph, ITokenMachineObserver? observer = null, int maxTokens = TokenMachine.DefaultMaxTokens)
+    : TokenMachine(graph, observer, maxTokens), IAgentSettable<TAgent>
+{
+    private TAgent? _agent;
+    private bool _hasAgent;
+
+    /// <summary>
+    /// Binds the agent (typed context) to this machine. It is applied to the graph's nodes
+    /// immediately and re-applied at the start of every run, so several machines can share
+    /// one <see cref="Graph"/> with distinct contexts as long as their runs do not interleave.
+    /// </summary>
+    public void SetAgent(TAgent agent)
+    {
+        _agent = agent;
+        _hasAgent = true;
+        Graph.SetAgent(agent);
+    }
+
+    private protected override void ApplyExecutionContext()
+    {
+        base.ApplyExecutionContext(); // blackboards first, then the agent
+        if (_hasAgent)
+        {
+            Graph.SetAgent(_agent!);
+        }
+    }
+}
+
+/// <summary>
+/// The synchronous token runtime: N pooled tokens flow through <b>one flat graph</b>
+/// concurrently via cooperative round scheduling — each round advances every runnable token
+/// by one node. <see cref="ForkState"/> nodes fan tokens out, <see cref="JoinState"/> nodes
+/// merge them (all / any / M-of-N), and every ordinary node keeps its FSM semantics
+/// (retry policy, failure edge, enter/exit hooks) applied <i>per token</i>.
+/// <para>
+/// This is the third runtime beside the sync/async FSMs — the single-active-node FSM
+/// machines are untouched, and a graph without fork/join nodes runs identically under
+/// either family. Like the sync <see cref="StateMachine"/>, the machine inherits
+/// <see cref="State"/> so it can be nested as a node inside a parent graph, steps one
+/// scheduling round per <see cref="State.Execute"/> call by default
+/// (<see cref="ParallelStepMode.RoundPerTick"/>), and drains to the terminal result in one
+/// call under <see cref="ParallelStepMode.RunToJoin"/>. Scheduling is deliberately not
+/// thread-concurrent, preserving the 0 B hot-path guarantee.
+/// </para>
+/// <para>
+/// A run starts with one token at the start node and ends when no runnable token remains:
+/// if tokens are still parked at joins the machine fails (join starvation); otherwise it
+/// succeeds only when no token died (failed terminally). Machine status stays
+/// <see cref="ExecutionStatus.Running"/> between rounds — the FSM's per-edge
+/// <see cref="ExecutionStatus.Transitioning"/> status is a single-active-node concept and is
+/// not reported by the token machines.
+/// </para>
+/// </summary>
+public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlackboardSettable
+{
+    public const int DefaultMaxTokens = 64;
+
+    /// <summary>
+    /// Cap on fork/join arrival cascades resolved within a single token step. Fork→fork or
+    /// join→fork chains are resolved recursively at arrival time; a cycle of forks would
+    /// otherwise recurse forever while spawning tokens.
+    /// </summary>
+    private const int MaxCascadeDepth = 64;
+
+    public readonly Graph Graph;
+    private readonly ITokenMachineObserver? _observer;
+    private BlackboardContext _blackboards;
+
+    private ExecutionStatus _status = ExecutionStatus.Created;
+    private RestartPolicy _restartPolicy = RestartPolicy.Auto;
+    private Result _terminalResult = Result.Success;
+    private bool _executeGate;
+    private bool _reentranceGuard;
+
+    private readonly RetryPolicy[]? _retryPolicies;
+    private readonly ForkState?[] _forks; // index = NodeId.Index; null for non-fork nodes
+    private readonly JoinState?[] _joins; // index = NodeId.Index; null for non-join nodes
+    private readonly IBlackboardSettable?[] _settables; // per-node, for per-token scratch stamping
+    private readonly State?[] _logReportStates; // indexed by NodeId.Index, resolved once
+    private readonly Action<string> _cachedLogReportCallback;
+    private readonly bool _hasNodeSchema;
+
+    // ── Token pool ──────────────────────────────────────────────────────
+    private readonly Token[] _pool;
+    private readonly int[] _freeStack; // slot indices; top = _freeCount - 1
+    private int _freeCount;
+    private int _runnable;
+    private int _parked;
+    private bool _anyDied;
+    private int _round;
+    private int _nextTokenId;
+    private readonly int[]? _joinArrivals; // index = NodeId.Index; null when the graph has no joins
+    private readonly bool[]? _joinFired; // "fired at least once this run" per join node
+
+    // Attribution for log reports and exception observers while a token is being stepped.
+    private int _steppingTokenId = -1;
+    private NodeId _steppingNodeId = NodeId.Default;
+
+    IEnumerable<Graph> ISubGraphProvider.SubGraphs => [Graph];
+
+    /// <summary>Public execution status.</summary>
+    public ExecutionStatus Status
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _status;
+    }
+
+    /// <summary>Live tokens (runnable + parked). 0 outside a run.</summary>
+    public int LiveTokenCount => _runnable + _parked;
+
+    public TokenMachine(Graph graph, ITokenMachineObserver? observer = null, int maxTokens = DefaultMaxTokens)
+    {
+        Guard.NotNull(graph, nameof(graph));
+        if (maxTokens < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxTokens), "A token machine needs at least one token.");
+        }
+
+        // Fail fast on graphs the sync runtime cannot execute (fork/join nodes implement
+        // ILogic, so only genuinely async-only user logic trips this) — mirrors StateMachine.
+        for (int i = 0; i < graph.NodeCount; i++)
+        {
+            if (graph.TryGetNodeByIndex(i, out INode? node) && node!.Logic is null)
+            {
+                throw new ArgumentException(
+                    $"Node '{node.Id}' logic ({node.AsyncLogic.GetType().Name}) does not implement ILogic " +
+                    "and cannot be executed by the sync TokenMachine. Use AsyncTokenMachine for this graph, " +
+                    "or author the node with sync logic.", nameof(graph));
+            }
+        }
+
+        Graph = graph;
+        _observer = observer;
+        _retryPolicies = graph.RetryPolicies;
+        _cachedLogReportCallback = LogReportCallback;
+
+        _forks = new ForkState?[graph.NodeCount];
+        _joins = new JoinState?[graph.NodeCount];
+        _settables = new IBlackboardSettable?[graph.NodeCount];
+        _logReportStates = new State?[graph.NodeCount];
+        bool anyJoin = false;
+        for (int i = 0; i < graph.NodeCount; i++)
+        {
+            if (!graph.TryGetNodeByIndex(i, out INode? node) || node is not LogicNode logicNode)
+            {
+                continue;
+            }
+
+            _forks[i] = logicNode.Logic as ForkState ?? logicNode.AsyncLogic as ForkState;
+            _joins[i] = logicNode.Logic as JoinState ?? logicNode.AsyncLogic as JoinState;
+            anyJoin |= _joins[i] is not null;
+            _settables[i] = logicNode.AsyncLogic as IBlackboardSettable ?? logicNode.Logic as IBlackboardSettable;
+            _logReportStates[i] = logicNode.Logic as State;
+        }
+
+        _joinArrivals = anyJoin ? new int[graph.NodeCount] : null;
+        _joinFired = anyJoin ? new bool[graph.NodeCount] : null;
+
+        BlackboardSchema? nodeSchema = graph.NodeSchema;
+        _hasNodeSchema = nodeSchema is not null;
+        _pool = new Token[maxTokens];
+        _freeStack = new int[maxTokens];
+        for (int i = 0; i < maxTokens; i++)
+        {
+            _pool[i] = new Token
+            {
+                SlotIndex = i,
+                NodeBoard = nodeSchema is null ? null : new Blackboard(nodeSchema),
+            };
+            // Fill the stack so slot 0 is popped first (deterministic slot assignment).
+            _freeStack[i] = maxTokens - 1 - i;
+        }
+
+        _freeCount = maxTokens;
+    }
+
+    // ── Context binding (mirrors the FSM machines) ─────────────────────
+
+    /// <summary>
+    /// Hook for derived machines to (re)apply per-machine execution context (e.g. the typed
+    /// agent) to the graph's nodes. Runs under the execute gate, right before Starting.
+    /// The base implementation re-stamps the bound blackboard context.
+    /// </summary>
+    private protected virtual void ApplyExecutionContext()
+    {
+        // Unconditional re-stamp, empty context included — same rationale as the FSM machines:
+        // a board-less machine over a shared graph must hit the unbound-scope throw, not
+        // silently read a previous machine's boards. The context carries no Node slot at the
+        // machine level; per-token scratch is stamped per node execution instead.
+        Graph.SetBlackboards(in _blackboards);
+    }
+
+    /// <summary>
+    /// Binds a blackboard into the scope slot its schema declares (replace semantics).
+    /// Applied to the graph's nodes immediately and re-applied at the start of every run.
+    /// Node-scoped boards are per-token and machine-owned — binding one throws.
+    /// </summary>
+    public void SetBlackboard(Blackboard blackboard)
+    {
+        Guard.NotNull(blackboard, nameof(blackboard));
+        if (blackboard.Schema.Scope == BlackboardScope.Node)
+        {
+            throw new InvalidOperationException(
+                "Node-scoped boards are per-token transient scratch owned by the token machine and cannot be " +
+                "bound — declare the schema on the graph via WithSchema(...); the machine creates one board per " +
+                "pooled token.");
+        }
+
+        ValidateBoardAgainstDeclarations(blackboard);
+        _blackboards = _blackboards.With(blackboard);
+        Graph.SetBlackboards(in _blackboards);
+    }
+
+    /// <summary>
+    /// Receives the whole context from a parent machine's stamping walk (nested composite
+    /// path). The parent's Node slot is dropped — Node boards are per-token scratch owned by
+    /// this machine.
+    /// </summary>
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        if (context.Graph is { } graphBoard)
+        {
+            ValidateBoardAgainstDeclarations(graphBoard);
+        }
+
+        if (context.Global is { } globalBoard)
+        {
+            ValidateBoardAgainstDeclarations(globalBoard);
+        }
+
+        BlackboardContext own = context.WithoutNode();
+        _blackboards = own;
+        Graph.SetBlackboards(in own);
+    }
+
+    private void ValidateBoardAgainstDeclarations(Blackboard blackboard)
+    {
+        BlackboardSchema? declared = blackboard.Schema.Scope == BlackboardScope.Global
+            ? Graph.GlobalSchema
+            : Graph.Schema;
+
+        if (declared is not null && !ReferenceEquals(declared, blackboard.Schema))
+        {
+            throw new InvalidOperationException(
+                $"Blackboard schema '{blackboard.Schema.Name ?? "<unnamed>"}' does not match the " +
+                $"{blackboard.Schema.Scope} schema '{declared.Name ?? "<unnamed>"}' declared on graph '{Graph.Id}'.");
+        }
+    }
+
+    // ── Machine configuration ───────────────────────────────────────────
+
+    /// <summary>
+    /// Controls how the machine behaves after reaching a terminal status
+    /// (same contract as the FSM machines).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetRestartPolicy(RestartPolicy policy) => _restartPolicy = policy;
+
+    /// <summary>
+    /// How <see cref="State.Execute"/> maps scheduling rounds onto ticks:
+    /// <see cref="ParallelStepMode.RoundPerTick"/> (default) advances one round per call and
+    /// returns <see cref="Result.InProgress"/> while tokens remain;
+    /// <see cref="ParallelStepMode.RunToJoin"/> drains the run inside one call, which also
+    /// makes the machine executable as a node under the async runtime via the adapter.
+    /// </summary>
+    public ParallelStepMode StepMode { get; private set; } = ParallelStepMode.RoundPerTick;
+
+    /// <summary>Sets <see cref="StepMode"/>. Machine-level runtime configuration — not graph structure.</summary>
+    public void SetStepMode(ParallelStepMode mode) => StepMode = mode;
+
+    // ── Reset / suspend / resume ────────────────────────────────────────
+
+    /// <summary>
+    /// Reset to the initial single-token state. Disallowed while Running/Transitioning.
+    /// Status moves: (any non-running) → Resetting → Ready.
+    /// </summary>
+    public Result Reset()
+    {
+        ExecutionStatus status = _status;
+        switch (status)
+        {
+            case ExecutionStatus.Running:
+            case ExecutionStatus.Transitioning:
+            case ExecutionStatus.Starting:
+                throw new InvalidOperationException("Cannot reset while starting, running, or transitioning.");
+            case ExecutionStatus.Created:
+            case ExecutionStatus.Ready:
+                return Result.Success;
+            case ExecutionStatus.Completed:
+            case ExecutionStatus.Failed:
+            case ExecutionStatus.Cancelled:
+            case ExecutionStatus.Resetting:
+                break;
+            default:
+                throw new IndexOutOfRangeException(nameof(status));
+        }
+
+        TransitionTo(ExecutionStatus.Resetting);
+        ClearRunState();
+        TransitionTo(ExecutionStatus.Ready);
+        return Result.Success;
+    }
+
+    /// <summary>Returns every token slot to the pool and zeroes run bookkeeping. No observer events.</summary>
+    private void ClearRunState()
+    {
+        for (int i = 0; i < _pool.Length; i++)
+        {
+            _pool[i].Phase = TokenSlotPhase.Free;
+            _freeStack[i] = _pool.Length - 1 - i;
+        }
+
+        _freeCount = _pool.Length;
+        _runnable = 0;
+        _parked = 0;
+        _anyDied = false;
+        _round = 0;
+        _nextTokenId = 0;
+        if (_joinArrivals is not null)
+        {
+            Array.Clear(_joinArrivals, 0, _joinArrivals.Length);
+            Array.Clear(_joinFired!, 0, _joinFired!.Length);
+        }
+    }
+
+    /// <summary>
+    /// Captures the machine's runtime state into a serializable snapshot. The sync runtime is
+    /// frame-stepped, so any point between <see cref="State.Execute"/> calls is a legal round
+    /// boundary — including the middle of a run. Only calling from inside node logic is rejected.
+    /// </summary>
+    public TokenMachineSnapshot Suspend()
+    {
+        if (_reentranceGuard)
+        {
+            throw new InvalidOperationException(
+                "Cannot suspend from inside node logic. Suspend between Execute() calls.");
+        }
+
+        ExecutionStatus status = _status;
+        if (status is ExecutionStatus.Starting or ExecutionStatus.Transitioning or ExecutionStatus.Resetting)
+        {
+            throw new InvalidOperationException($"Cannot suspend in transient status '{status}'.");
+        }
+
+        return BuildSnapshot(status, midRun: _executeGate);
+    }
+
+    private TokenMachineSnapshot BuildSnapshot(ExecutionStatus status, bool midRun)
+    {
+        int live = _runnable + _parked;
+        TokenRecord[] records = live == 0 ? Array.Empty<TokenRecord>() : new TokenRecord[live];
+        int w = 0;
+        for (int i = 0; i < _pool.Length; i++)
+        {
+            Token t = _pool[i];
+            if (t.Phase == TokenSlotPhase.Free)
+            {
+                continue;
+            }
+
+            records[w++] = new TokenRecord(t.Id, t.NodeIndex, t.Attempts, t.NodeEntered,
+                t.Phase == TokenSlotPhase.Parked ? TokenPhase.Parked : TokenPhase.Runnable);
+        }
+
+        int[] arrivals = _joinArrivals is null ? Array.Empty<int>() : (int[])_joinArrivals.Clone();
+        bool[] fired = _joinFired is null ? Array.Empty<bool>() : (bool[])_joinFired.Clone();
+        return new TokenMachineSnapshot(status, midRun, _nextTokenId, records, arrivals)
+        {
+            AnyTokenDied = _anyDied,
+            JoinsFired = fired,
+        };
+    }
+
+    /// <summary>
+    /// Restores a snapshot produced by <see cref="Suspend"/> (from either token runtime) onto
+    /// this machine. The graph must be structurally equivalent (same node indices) and the
+    /// pool must be large enough for the snapshot's live tokens. A mid-run snapshot is
+    /// continued by calling <see cref="State.Execute"/> until it returns a terminal result.
+    /// Node-scope scratch is transient and comes back as defaults.
+    /// </summary>
+    public void Resume(TokenMachineSnapshot snapshot)
+    {
+        Guard.NotNull(snapshot, nameof(snapshot));
+        if (_reentranceGuard)
+        {
+            throw new InvalidOperationException("Cannot resume from inside node logic.");
+        }
+
+        if (snapshot.Status is ExecutionStatus.Starting or ExecutionStatus.Transitioning
+            or ExecutionStatus.Resetting)
+        {
+            throw new InvalidOperationException(
+                $"Snapshot captured in transient status '{snapshot.Status}' cannot be resumed.");
+        }
+
+        RestoreSnapshotCore(snapshot);
+        ApplyExecutionContext();
+        _terminalResult = snapshot.Status is ExecutionStatus.Failed or ExecutionStatus.Cancelled
+            ? Result.Failure
+            : Result.Success;
+        // Mid-run: the gate stays held between ticks and the State lifecycle must skip
+        // OnEnter (which would restart the run) on the next Execute() call.
+        _executeGate = snapshot.MidRun;
+        HasEntered = snapshot.MidRun;
+        _status = snapshot.Status;
+    }
+
+    private void RestoreSnapshotCore(TokenMachineSnapshot snapshot)
+    {
+        TokenRecord[] tokens = snapshot.Tokens ?? Array.Empty<TokenRecord>();
+        if (tokens.Length > _pool.Length)
+        {
+            throw new InvalidOperationException(
+                $"Snapshot holds {tokens.Length} live tokens but this machine's pool caps at {_pool.Length} " +
+                "(maxTokens). Construct the machine with a larger pool to resume it.");
+        }
+
+        if (snapshot.JoinArrivals is { Length: > 0 } arrivals)
+        {
+            if (_joinArrivals is null || arrivals.Length != _joinArrivals.Length)
+            {
+                throw new InvalidOperationException(
+                    "Snapshot join-arrival counts do not match this graph (join nodes or node count differ).");
+            }
+        }
+
+        ClearRunState();
+
+        for (int i = 0; i < tokens.Length; i++)
+        {
+            TokenRecord record = tokens[i];
+            if ((uint)record.NodeIndex >= (uint)Graph.NodeCount)
+            {
+                throw new InvalidOperationException(
+                    $"Snapshot token #{record.Id} node index {record.NodeIndex} is out of range for this graph " +
+                    $"(0..{Graph.NodeCount - 1}).");
+            }
+
+            Token t = _pool[i];
+            t.Id = record.Id;
+            t.NodeIndex = record.NodeIndex;
+            t.Attempts = record.Attempts;
+            t.NodeEntered = record.NodeEntered;
+            t.SpawnRound = -1; // every restored token runs in the next round
+            t.NodeBoard?.ResetToDefaults();
+            if (record.Phase == TokenPhase.Parked)
+            {
+                t.Phase = TokenSlotPhase.Parked;
+                _parked++;
+            }
+            else
+            {
+                t.Phase = TokenSlotPhase.Runnable;
+                _runnable++;
+            }
+        }
+
+        // Free stack now starts above the restored tokens.
+        _freeCount = _pool.Length - tokens.Length;
+        for (int i = 0; i < _freeCount; i++)
+        {
+            _freeStack[i] = _pool.Length - 1 - i;
+        }
+
+        _nextTokenId = snapshot.NextTokenId;
+        _anyDied = snapshot.AnyTokenDied;
+        if (snapshot.JoinArrivals is { Length: > 0 } restoredArrivals)
+        {
+            Array.Copy(restoredArrivals, _joinArrivals!, restoredArrivals.Length);
+        }
+
+        if (snapshot.JoinsFired is { Length: > 0 } restoredFired)
+        {
+            if (_joinFired is null || restoredFired.Length != _joinFired.Length)
+            {
+                throw new InvalidOperationException(
+                    "Snapshot join-fired flags do not match this graph (join nodes or node count differ).");
+            }
+
+            Array.Copy(restoredFired, _joinFired, restoredFired.Length);
+        }
+    }
+
+    // ── State overrides — Execute() is the stepped entry point ─────────
+
+    protected override void OnEnter()
+    {
+        ExecutionStatus status = _status;
+
+        if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+        {
+            if (_restartPolicy == RestartPolicy.Ignore)
+                return; // OnRun will return the cached result; no init needed
+            if (_restartPolicy == RestartPolicy.Manual)
+                throw new InvalidOperationException(
+                    $"TokenMachine is in terminal state '{status}'. Call Reset() before executing again.");
+            Reset(); // Auto
+        }
+
+        if (_executeGate)
+            throw new InvalidOperationException("TokenMachine is already executing.");
+
+        _executeGate = true;
+
+        // Re-stamp this machine's context onto the (potentially shared) graph before running.
+        ApplyExecutionContext();
+
+        TransitionTo(ExecutionStatus.Starting);
+        ClearRunState();
+        SpawnRootToken();
+        TransitionTo(ExecutionStatus.Running);
+    }
+
+    private void SpawnRootToken()
+    {
+        Token root = Alloc();
+        _observer?.OnTokenSpawned(root.Id, -1, Graph.StartNode.Id);
+        ArriveAt(root, Graph.StartNode.Id.Index, 0);
+    }
+
+    protected override Result OnRun()
+    {
+        ExecutionStatus status = _status;
+        if (_restartPolicy == RestartPolicy.Ignore &&
+            status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+        {
+            return _terminalResult;
+        }
+
+        if (_reentranceGuard)
+            throw new InvalidOperationException("TokenMachine is already executing.");
+
+        _reentranceGuard = true;
+        try
+        {
+            Result result = RunRound();
+            if (StepMode == ParallelStepMode.RunToJoin)
+            {
+                while (result == Result.InProgress)
+                {
+                    result = RunRound();
+                }
+            }
+
+            if (result == Result.InProgress)
+                return Result.InProgress;
+
+            Finalise(result);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _observer?.OnStateFailed(_steppingTokenId, _steppingNodeId, ex);
+            Finalise(Result.Failure);
+            throw;
+        }
+        finally
+        {
+            _reentranceGuard = false;
+        }
+    }
+
+    protected override void OnExit()
+    {
+        // Intentionally empty — Finalise() releases the gate on the terminal path, and the
+        // gate must stay held while Execute() returns InProgress between rounds.
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void Finalise(Result result)
+    {
+        try
+        {
+            ExecutionStatus current = _status;
+            if (current is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+            {
+                return;
+            }
+
+            _terminalResult = result;
+            TransitionTo(result.IsSuccess ? ExecutionStatus.Completed : ExecutionStatus.Failed);
+
+            if (_restartPolicy == RestartPolicy.Auto)
+            {
+                Reset();
+            }
+        }
+        finally
+        {
+            _executeGate = false;
+        }
+    }
+
+    // ── The round scheduler (the hot path) ─────────────────────────────
+
+    /// <summary>
+    /// Advances every runnable token by one node execution and returns
+    /// <see cref="Result.InProgress"/> while runnable tokens remain, or the terminal
+    /// aggregate when the run has drained.
+    /// </summary>
+    private Result RunRound()
+    {
+        _round++;
+        for (int i = 0; i < _pool.Length; i++)
+        {
+            Token t = _pool[i];
+            if (t.Phase != TokenSlotPhase.Runnable || t.SpawnRound == _round)
+            {
+                continue;
+            }
+
+            StepToken(t);
+        }
+
+        if (_runnable > 0)
+        {
+            return Result.InProgress;
+        }
+
+        if (_parked > 0)
+        {
+            // Tokens parked at a join that already fired this run are benign quorum leftovers
+            // (e.g. the late arrival of an M-of-N join) and absorb quietly. Tokens parked at a
+            // join that never fired are starved — their suppliers died or completed elsewhere —
+            // and fail the machine.
+            bool anyStarved = false;
+            for (int i = 0; i < _pool.Length; i++)
+            {
+                Token t = _pool[i];
+                if (t.Phase != TokenSlotPhase.Parked)
+                {
+                    continue;
+                }
+
+                if (_joinFired![t.NodeIndex])
+                {
+                    RetireToken(t, IdOf(t.NodeIndex), TokenRetireReason.Absorbed);
+                }
+                else
+                {
+                    anyStarved = true;
+                    RetireToken(t, IdOf(t.NodeIndex), TokenRetireReason.Starved);
+                }
+            }
+
+            if (anyStarved)
+            {
+                return Result.Failure;
+            }
+        }
+
+        return _anyDied ? Result.Failure : Result.Success;
+    }
+
+    /// <summary>Executes one node for one token and routes the result (per-token fault model).</summary>
+    private void StepToken(Token t)
+    {
+        int idx = t.NodeIndex;
+        if (!Graph.TryGetNodeByIndex(idx, out INode? node) || node is not LogicNode logicNode)
+        {
+            throw new InvalidOperationException($"Node #{idx} not found.");
+        }
+
+        _steppingTokenId = t.Id;
+        _steppingNodeId = logicNode.Id;
+
+        // Per-token Node-scope scratch: two tokens can occupy the same node instance, so the
+        // token's board is stamped onto this node only, right before it executes. Graphs with
+        // no Node schema skip this entirely.
+        if (_hasNodeSchema && _settables[idx] is { } settable)
+        {
+            settable.SetBlackboards(_blackboards.With(t.NodeBoard!));
+        }
+
+        State? stateForLog = _logReportStates[idx];
+        if (stateForLog is not null)
+        {
+            stateForLog.SyncLogReport = _cachedLogReportCallback;
+        }
+
+        ILogic syncLogic = logicNode.Logic!;
+        if (!t.NodeEntered)
+        {
+            t.NodeEntered = true;
+            logicNode.EnterAction?.Invoke();
+        }
+
+        Result result = syncLogic.Execute();
+        if (result.Code != Result.StatusCode.InProgress)
+        {
+            t.Attempts++;
+        }
+
+        switch (result.Code)
+        {
+            case Result.StatusCode.Success:
+            {
+                t.NodeEntered = false;
+                logicNode.ExitAction?.Invoke();
+                _observer?.OnStateExited(t.Id, logicNode.Id);
+
+                NodeId next;
+                if (logicNode.Logic is IDirector director)
+                {
+                    next = director.SelectNext();
+                    if (next.Equals(NodeId.Default))
+                    {
+                        RetireToken(t, logicNode.Id, TokenRetireReason.Completed);
+                        return;
+                    }
+                }
+                else
+                {
+                    if (!Graph.TryGetTransition(logicNode.Id, out Transition edge))
+                    {
+                        _observer?.OnStateFailed(t.Id, logicNode.Id,
+                            new InvalidOperationException($"No transition found for state '{logicNode.Id}'."));
+                        _anyDied = true;
+                        RetireToken(t, logicNode.Id, TokenRetireReason.Failed);
+                        return;
+                    }
+
+                    if (edge.IsEmpty)
+                    {
+                        RetireToken(t, logicNode.Id, TokenRetireReason.Completed);
+                        return;
+                    }
+
+                    next = edge.Destination;
+                }
+
+                _observer?.OnTransition(t.Id, logicNode.Id, next);
+                t.Attempts = 0;
+                t.NodeBoard?.ResetToDefaults();
+                ArriveAt(t, next.Index, 0);
+                return;
+            }
+            case Result.StatusCode.Failure:
+            {
+                if (_retryPolicies is not null)
+                {
+                    RetryPolicy retry = _retryPolicies[idx];
+                    if (t.Attempts < retry.MaxAttempts)
+                    {
+                        // Frame-stepped runtime: the retry happens next round; the configured
+                        // backoff is intentionally not honored (never block a frame).
+                        return;
+                    }
+                }
+
+                t.NodeEntered = false;
+                logicNode.ExitAction?.Invoke();
+
+                if (Graph.TryGetTransition(logicNode.Id, out Transition failEdge) &&
+                    failEdge.HasFailureDestination)
+                {
+                    _observer?.OnStateFailed(t.Id, logicNode.Id, null);
+                    NodeId handler = failEdge.FailureDestination;
+                    _observer?.OnTransition(t.Id, logicNode.Id, handler);
+                    t.Attempts = 0;
+                    t.NodeBoard?.ResetToDefaults();
+                    ArriveAt(t, handler.Index, 0);
+                    return;
+                }
+
+                _observer?.OnStateFailed(t.Id, logicNode.Id, null);
+                _anyDied = true;
+                RetireToken(t, logicNode.Id, TokenRetireReason.Failed);
+                return;
+            }
+            case Result.StatusCode.InProgress:
+                // Multi-tick sync node: the token stays; next round re-runs it.
+                return;
+            default:
+                throw new InvalidOperationException("Unknown node result.");
+        }
+    }
+
+    /// <summary>
+    /// Lands <paramref name="t"/> on node <paramref name="idx"/>, resolving fork/join structure
+    /// at arrival: forks fan out (branch 0 continues this token, the rest spawn), joins park or
+    /// fire per policy. Cascades recursively — a token never rests on a fork.
+    /// </summary>
+    private void ArriveAt(Token t, int idx, int depth)
+    {
+        if (depth > MaxCascadeDepth)
+        {
+            throw new InvalidOperationException(
+                $"Fork/join arrival cascade exceeds {MaxCascadeDepth} levels — check for a cycle of fork nodes.");
+        }
+
+        if ((uint)idx >= (uint)_forks.Length)
+        {
+            throw new InvalidOperationException($"Transition points to non-existent node #{idx}.");
+        }
+
+        ForkState? fork = _forks[idx];
+        if (fork is not null)
+        {
+            PassThroughFork(t, idx, fork, depth);
+            return;
+        }
+
+        JoinState? join = _joins[idx];
+        if (join is not null)
+        {
+            ArriveAtJoin(t, idx, join, depth);
+            return;
+        }
+
+        t.NodeIndex = idx;
+        t.NodeEntered = false;
+        _observer?.OnStateEntered(t.Id, IdOf(idx));
+    }
+
+    private void PassThroughFork(Token t, int idx, ForkState fork, int depth)
+    {
+        LogicNode forkNode = (LogicNode)Graph.GetNodeByIndex(idx);
+        NodeId forkId = forkNode.Id;
+        _observer?.OnStateEntered(t.Id, forkId);
+        forkNode.EnterAction?.Invoke();
+        forkNode.ExitAction?.Invoke();
+        _observer?.OnStateExited(t.Id, forkId);
+
+        // Branch 0 continues the arriving token; every other branch spawns a new one.
+        // Branch ids are resolved through the graph so observers see the applied display
+        // names (the fork stores pre-Build ids, whose names are empty).
+        int firstIndex = fork.BranchAt(0).Index;
+        _observer?.OnTransition(t.Id, forkId, IdOf(firstIndex));
+        ArriveAt(t, firstIndex, depth + 1);
+
+        for (int b = 1; b < fork.BranchCount; b++)
+        {
+            Token child = Alloc();
+            int branchIndex = fork.BranchAt(b).Index;
+            _observer?.OnTokenSpawned(child.Id, t.Id, forkId);
+            _observer?.OnTransition(child.Id, forkId, IdOf(branchIndex));
+            ArriveAt(child, branchIndex, depth + 1);
+        }
+    }
+
+    private void ArriveAtJoin(Token t, int idx, JoinState join, int depth)
+    {
+        LogicNode joinNode = (LogicNode)Graph.GetNodeByIndex(idx);
+        NodeId joinId = joinNode.Id;
+        _observer?.OnStateEntered(t.Id, joinId);
+        joinNode.EnterAction?.Invoke();
+
+        int arrivals = ++_joinArrivals![idx];
+        int required = join.Policy.RequiredCount;
+        if (arrivals < required)
+        {
+            t.NodeIndex = idx;
+            t.NodeEntered = false;
+            t.Phase = TokenSlotPhase.Parked;
+            _runnable--;
+            _parked++;
+            return;
+        }
+
+        // Fire: consume the requirement — this token plus (required - 1) parked ones.
+        _joinArrivals[idx] = arrivals - required;
+        _joinFired![idx] = true;
+        int toConsume = required - 1;
+        for (int i = 0; i < _pool.Length && toConsume > 0; i++)
+        {
+            Token parked = _pool[i];
+            if (parked.Phase == TokenSlotPhase.Parked && parked.NodeIndex == idx)
+            {
+                RetireToken(parked, joinId, TokenRetireReason.Joined);
+                toConsume--;
+            }
+        }
+
+        _observer?.OnJoinFired(joinId, t.Id);
+        joinNode.ExitAction?.Invoke();
+        _observer?.OnStateExited(t.Id, joinId);
+
+        t.Attempts = 0;
+        t.NodeBoard?.ResetToDefaults();
+
+        if (!Graph.TryGetTransition(joinId, out Transition edge) || edge.IsEmpty)
+        {
+            RetireToken(t, joinId, TokenRetireReason.Completed);
+            return;
+        }
+
+        _observer?.OnTransition(t.Id, joinId, edge.Destination);
+        ArriveAt(t, edge.Destination.Index, depth + 1);
+    }
+
+    // ── Pool operations ─────────────────────────────────────────────────
+
+    private Token Alloc()
+    {
+        if (_freeCount == 0)
+        {
+            throw new InvalidOperationException(
+                $"Token pool exhausted ({_pool.Length} tokens live). Raise the machine's maxTokens " +
+                "constructor argument to fit this graph's fan-out.");
+        }
+
+        int slot = _freeStack[--_freeCount];
+        Token t = _pool[slot];
+        t.Id = _nextTokenId++;
+        t.NodeIndex = 0;
+        t.Attempts = 0;
+        t.NodeEntered = false;
+        t.Phase = TokenSlotPhase.Runnable;
+        t.SpawnRound = _round;
+        t.NodeBoard?.ResetToDefaults();
+        _runnable++;
+        return t;
+    }
+
+    private void RetireToken(Token t, NodeId at, TokenRetireReason reason)
+    {
+        if (t.Phase == TokenSlotPhase.Runnable)
+        {
+            _runnable--;
+        }
+        else if (t.Phase == TokenSlotPhase.Parked)
+        {
+            _parked--;
+        }
+
+        t.Phase = TokenSlotPhase.Free;
+        _freeStack[_freeCount++] = t.SlotIndex;
+        _observer?.OnTokenRetired(t.Id, at, reason);
+    }
+
+    private NodeId IdOf(int index) => Graph.GetNodeByIndex(index).Id;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void LogReportCallback(string message)
+    {
+        // Attribution uses the token currently being stepped.
+        _observer?.OnLogReport(_steppingTokenId, _steppingNodeId, message);
+    }
+
+    // ── Status plumbing ─────────────────────────────────────────────────
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void TransitionTo(ExecutionStatus next)
+    {
+        ExecutionStatus prev = _status;
+        _status = next;
+        if (prev != next)
+        {
+            NotifyMachineStatusChange(prev, next);
+        }
+    }
+
+    private void NotifyMachineStatusChange(ExecutionStatus prev, ExecutionStatus next)
+    {
+        if (_observer is null)
+        {
+            return;
+        }
+
+        NodeId graphId = Graph.Id;
+        _observer.TokenMachineStatusChanged(graphId, prev, next);
+
+        switch (next)
+        {
+            case ExecutionStatus.Starting:
+                _observer.OnTokenMachineStarted(graphId);
+                break;
+            case ExecutionStatus.Completed:
+                _observer.OnTokenMachineCompleted(graphId, Result.Success);
+                break;
+            case ExecutionStatus.Failed:
+                _observer.OnTokenMachineCompleted(graphId, Result.Failure);
+                break;
+            case ExecutionStatus.Resetting:
+                _observer.OnTokenMachineReset(graphId);
+                break;
+            case ExecutionStatus.Cancelled:
+            case ExecutionStatus.Ready:
+            case ExecutionStatus.Created:
+            case ExecutionStatus.Running:
+            case ExecutionStatus.Transitioning:
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(next), next, null);
+        }
+    }
+}

--- a/NxGraph/Tokens/TokenMachineSnapshot.cs
+++ b/NxGraph/Tokens/TokenMachineSnapshot.cs
@@ -1,0 +1,80 @@
+using NxGraph.Fsm;
+
+namespace NxGraph.Tokens;
+
+/// <summary>Lifecycle phase of a live token inside a <see cref="TokenMachineSnapshot"/>.</summary>
+public enum TokenPhase : byte
+{
+    /// <summary>The token is advancing through the graph.</summary>
+    Runnable = 0,
+
+    /// <summary>The token is parked at a join, waiting for the join's policy to be met.</summary>
+    Parked = 1,
+}
+
+/// <summary>Why a token left the run. Reported via the observers' <c>OnTokenRetired</c>.</summary>
+public enum TokenRetireReason : byte
+{
+    /// <summary>The token reached a terminal node with Success.</summary>
+    Completed = 0,
+
+    /// <summary>The token failed terminally (retries and failure edge exhausted) — it died.</summary>
+    Failed = 1,
+
+    /// <summary>The token was consumed by a join firing.</summary>
+    Joined = 2,
+
+    /// <summary>
+    /// The run ended while the token was parked at a join that never fired (join starvation —
+    /// the machine fails).
+    /// </summary>
+    Starved = 3,
+
+    /// <summary>
+    /// The run ended while the token was parked at a join that had already fired — a benign
+    /// quorum leftover (e.g. the late arrival of an M-of-N join). Does not fail the machine.
+    /// </summary>
+    Absorbed = 4,
+}
+
+/// <summary>A serialization-friendly capture of one live token inside a snapshot.</summary>
+public sealed record TokenRecord(
+    int Id,
+    int NodeIndex,
+    int Attempts,
+    bool NodeEntered,
+    TokenPhase Phase);
+
+/// <summary>
+/// A serialization-friendly capture of a token machine's runtime state: the multiset of live
+/// tokens plus per-join arrival counts. Produced by <c>Suspend()</c> and consumed by
+/// <c>Resume(...)</c> on a <see cref="TokenMachine"/> or <see cref="AsyncTokenMachine"/> built
+/// over an equivalent graph (same node indices); snapshots are interchangeable between the two
+/// token runtimes. This is a separate contract from <see cref="StateMachineSnapshot"/> — the
+/// flat FSM snapshot shape is deliberately untouched.
+/// <para>
+/// The snapshot contains only primitives and plain records, so it serializes cleanly with any
+/// serializer. Node-scope scratch is transient by definition and resumes as defaults; the user
+/// context (agent/blackboards) is owned by the caller and must be re-attached after resuming.
+/// </para>
+/// </summary>
+public sealed record TokenMachineSnapshot(
+    ExecutionStatus Status,
+    bool MidRun,
+    int NextTokenId,
+    TokenRecord[] Tokens,
+    int[] JoinArrivals)
+{
+    /// <summary>
+    /// Whether any token had already died (failed terminally) before the snapshot was taken —
+    /// the resumed run must still report <see cref="Result.Failure"/> at its natural end.
+    /// </summary>
+    public bool AnyTokenDied { get; init; }
+
+    /// <summary>
+    /// Per-node "this join has fired at least once this run" flags (indexed by node index;
+    /// empty when the graph has no joins). Distinguishes benign quorum leftovers from join
+    /// starvation after a resume.
+    /// </summary>
+    public bool[] JoinsFired { get; init; } = [];
+}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The core package targets `net8.0` and `netstandard2.1`.
   - [Unity integration](#unity-integration)
   - [Nested machines](#nested-machines)
   - [Composites: subgraphs, history, and parallel regions](#composites-subgraphs-history-and-parallel-regions)
+  - [Token runtime: fork, join, and mid-graph merge](#token-runtime-fork-join-and-mid-graph-merge)
   - [Durable suspend / resume](#durable-suspend--resume)
   - [Restart policy](#restart-policy)
 - [Validation](#validation)
@@ -231,8 +232,9 @@ Every fan-out construct answers two questions: **how many successors run**, and 
 |---|---|---|
 | **One of many** | Conditional — [`.If(...)`](#branching-with-if) / [`.Switch(...)`](#branching-with-switch) declare the branches and the routing rule | Director — [`IDirector`](#custom-directors) selects any node in code; `ChoiceState`/`SwitchState<TKey>` are the built-ins |
 | **Many at once** | Parallel — [`.Parallel(regions...)`](#parallel-regions-and-states) runs **all** region graphs | Dynamic parallel — [`.Parallel(selector, ...)`](#dynamic-some-of-many-regions) runs the **subset** a blackboard selector picks |
+| **Many in one flat graph** | Token runtime — [`.ForkTo(...)` + `JoinState`](#token-runtime-fork-join-and-mid-graph-merge) fan tokens out and merge them mid-graph (all / any / M-of-N) | The same fork/join graph — which tokens reach a join, and when, is decided by each token's own path at runtime |
 
-There is deliberately no free-form fan-out inside one flat graph (several nodes of the same graph active at once): the runtimes keep exactly one active node, and many-at-once execution lives inside the parallel composites, which join back into the single-active flow at the composite boundary. A token-based (Petri-net-style) runner that would lift this — mid-graph rejoin, the same node active k times — is a recorded, deliberately deferred design; if it ever lands it will be a third runtime beside the sync/async machines, not a change to them.
+The FSM runtimes keep exactly one active node, and many-at-once execution lives inside the parallel composites, which join back into the single-active flow at the composite boundary. When the flow genuinely needs several active nodes in **one flat graph** — a forked path that rejoins the parent flow mid-graph, the same node active k times, M-of-N merges — that is the [token runtime](#token-runtime-fork-join-and-mid-graph-merge): a third runtime beside the sync/async machines (`TokenMachine`/`AsyncTokenMachine`), not a change to them.
 
 ### Waits and timeouts
 
@@ -613,6 +615,60 @@ StateMachine fsm = GraphBuilder
 
 The selector runs once per composite execution and fixes the selected set for that run; unselected regions are never stepped. An empty mask is a vacuous join (immediate `Success`); mask bits at or above the region count throw; up to 64 regions per composite. Selectors execute on the measured zero-allocation path, so compose masks with `RegionMask.Bit(i) | ...` as above — allocation-free — while `RegionMask.Of(params)` allocates its array and belongs at setup time only. Both variants exist in both runtimes (`.Parallel(selector, ...)` for async, `.Parallel(mode, selector, ...)` for sync). See `NxFSM.Examples/ParallelDemo` for runnable sync and async demos.
 
+### Token runtime: fork, join, and mid-graph merge
+
+Parallel composites join at the composite boundary. When forked paths must **rejoin the parent flow mid-graph** — or the same node must be active for several work items at once — use the token runtime (`NxGraph.Tokens`): N pooled tokens flow through one flat graph, scheduled in cooperative rounds (one node per token per round, deliberately not thread-concurrent).
+
+```csharp
+using NxGraph.Tokens;
+
+JoinState join = new(JoinPolicy.All(2)); // or JoinPolicy.Any (merge), JoinPolicy.Quorum(m)
+
+Graph graph = GraphBuilder
+    .StartWith(() => Result.Success).SetName("Load")
+    .ForkTo(
+        b => b.To(() => Result.Success)   // branch 0 continues the arriving token
+              .To(join)                   // converge by routing chains to the same JoinState
+              .To(() => Result.Success),  // the surviving token carries on past the join
+        b => b.To(() => Result.Success)   // every other branch spawns a new token
+              .To(join))
+    .Build();
+
+TokenMachine machine = graph.ToTokenMachine();      // sync twin; frame-stepped like StateMachine
+machine.SetStepMode(ParallelStepMode.RunToJoin);    // or RoundPerTick (default): one round per Execute()
+Result result = machine.Execute();
+
+AsyncTokenMachine asyncMachine = graph.ToAsyncTokenMachine(); // async twin: ExecuteAsync / StepAsync
+```
+
+- **Fork** (`.ForkTo(branch, branch, ...)`): a token passing through continues into the first branch; each remaining branch spawns a new token. Forks carry no logic and no outgoing edge — the branches replace it.
+- **Join** (`JoinState` + `JoinPolicy`): arriving tokens park until the policy's count is met, then the join **fires** — one token continues along the join's ordinary success edge, the consumed ones retire, and the join re-arms. `Any` fires on every arrival, which makes it a mid-graph merge point; `All(n)` is the classic AND-join; `Quorum(m)` fires at m-of-n, and the late leftovers absorb benignly at run end.
+- **Per-token fault model**: a failing token consumes its node's `.Retry(...)` budget in place (the async machine honors backoff, the sync one retries next round), then follows the failure edge, else *that token* dies. The machine fails if any token died or a join starved (parked tokens at a join that never fired); surviving tokens always run to their natural end first.
+- **Per-token scratch**: Node-scoped blackboard keys are per token — each token carries its own transient board, reset exactly when that token's attempt counter resets.
+- **Durability**: `Suspend()` captures a `TokenMachineSnapshot` (the multiset of live tokens plus join bookkeeping) at a round boundary; `Resume(snapshot)` restores it on either token machine. The FSM `StateMachineSnapshot` contract is untouched.
+- **Boundaries**: fork/join nodes are interpreted only by the token machines — the FSM runtimes throw on them (and the validator flags token graphs with an Info). Graphs *without* fork/join nodes run identically under either family. Fork/join graphs ride `GraphSerializer` payloads like any other graph — branch order and join policies are plain structure — and `TokenMachineSnapshot` serializes independently with any serializer.
+- **Visualization**: `graph.ToMermaid()` renders fork/join first-class — bar shapes (`[[...]]`), solid `fork`-labeled branch edges (an AND-split, not a dashed runtime choice), and the join's policy in its label. The diamond above exports as:
+
+```mermaid
+flowchart LR
+  n0(["Load"])
+  n1["Audio"]
+  n2[["Join : All(2)"]]
+  n3["Ready"]
+  n4["Terrain"]
+  n5[["Fork"]]
+  End(("End"))
+  n0 --> n5
+  n1 --> n2
+  n2 --> n3
+  n3 --> End
+  n4 --> n2
+  n5 -- fork --> n1
+  n5 -- fork --> n4
+```
+
+See `NxFSM.Examples/ReadmeExamples/TokenRunnerExamples.cs` for the runnable version, including an M-of-N quorum flow and the Mermaid export.
+
 ### Durable suspend / resume
 
 Both runtimes can pause a run at a step boundary, persist it, and continue later — on the same machine, a fresh machine, another process, or even the **other runtime** (snapshots are interchangeable):
@@ -905,6 +961,7 @@ Notes:
 - serializer usage is instance-based
 - JSON and MessagePack are both supported through `GraphSerializer`
 - your codec controls how node logic is persisted and restored
+- nested machines, history/parallel composites, and token fork/join nodes serialize out of the box; dynamic parallel composites need a `GraphSerializerOptions.SelectorRegistry` (the selector delegate rides as a named key — author graphs with the delegate instance `RegionSelectorRegistry.Register` returns), and custom `ISubGraphProvider` containers need a `GraphSerializerOptions.ContainerCodec` (you own the reconstruction recipe; the serializer recurses into `SubGraphs` for you, order-preserving)
 
 ---
 


### PR DESCRIPTION
## Summary

- **Token runtime** (`NxGraph/Tokens/`): `TokenMachine` (sync) / `AsyncTokenMachine` (async) run N pooled tokens through one flat graph in cooperative rounds. `ForkState` fans out (branch 0 continues the arriving token, other branches spawn), `JoinState` + `JoinPolicy` (`All`/`Any`/`Quorum`) merges — arrivals park, the join fires at the required count and re-arms. Machine fails iff any token died or starved at a never-fired join. Durable pause/resume via `TokenMachineSnapshot`; per-token Node-scope blackboards; token-id-aware observers (`ITokenMachineObserver`/`IAsyncTokenMachineObserver`). The FSM runtimes are untouched — graphs without fork/join run identically under either family.
- **Authoring**: `.ForkTo(b => b.To(...), ...)` DSL, converge by routing chains at a shared `JoinState`, `graph.ToTokenMachine()` / `.ToAsyncTokenMachine()`. Validator lints fork/join graphs (wired fork success edge = Error, unsatisfiable quorum = Warning); Mermaid renders fork/join first-class (bar shapes, solid branch edges, policy-labeled joins).
- **Stable node UIDs**: `.WithUid(guid)` attaches editor-tooling UIDs as a sidecar `Guid[]` on `Graph` with O(1) `TryGetNodeByUid`; `Guid.Empty` rejected, duplicates are a validator Error; never read by any runtime.
- **Serialization payload v6**: fork/join nodes ride as sparse `ForkDto`/`JoinDto` sections; per-node UIDs as a sparse `UidDto` section; dynamic parallel composites become first-class composite kinds with selector delegates riding as named keys via `IRegionSelectorRegistry`; custom `ISubGraphProvider` containers serialize through `IContainerCodec` on `GraphSerializerOptions`; explicit disjointness check across SubGraphs/Composites/Containers/Forks/Joins. Without options configured, dynamic parallel and custom containers keep targeted `NotSupportedException`s.

## Tests

- New suites: `NxGraph.Tests/Tokens/` (machine, observer, snapshot, validation), `NodeUidTests`, and serialization coverage for fork/join, dynamic parallel, containers, and UIDs.
- Public API baselines updated for the new surface; allocation gate extended to the token round loop.
- README token-runner snippets mirrored as runnable examples under `NxFSM.Examples/ReadmeExamples/`.