### PR TITLE
Step I/O ports, deep suspend, and in-node concurrency

### DIFF
--- a/NxFSM.Examples/Program.cs
+++ b/NxFSM.Examples/Program.cs
@@ -87,6 +87,8 @@ await FeatureExamples.RunAsync();
 Console.WriteLine();
 await FanOutExamples.RunAsync();
 Console.WriteLine();
+await InNodeConcurrencyExample.RunAsync();
+Console.WriteLine();
 await TokenRunnerExamples.RunAsync();
 
 return 0;

--- a/NxFSM.Examples/Program.cs
+++ b/NxFSM.Examples/Program.cs
@@ -79,6 +79,8 @@ await AgentExample.RunAsync();
 Console.WriteLine();
 await BlackboardExample.RunAsync();
 Console.WriteLine();
+await PortsExample.RunAsync();
+Console.WriteLine();
 ObserverExample.Run();
 Console.WriteLine();
 await FeatureExamples.RunAsync();

--- a/NxFSM.Examples/ReadmeExamples/FeatureExamples.cs
+++ b/NxFSM.Examples/ReadmeExamples/FeatureExamples.cs
@@ -10,7 +10,7 @@ namespace NxFSM.Examples.ReadmeExamples;
 /// <summary>
 /// Runnable versions of the README sections added with the 2.x feature wave:
 /// error handling (retries + failure edges), Goto loops, named outcomes,
-/// subgraph composites, and durable suspend/resume.
+/// subgraph composites, and durable suspend/resume (shallow and deep).
 /// </summary>
 public static class FeatureExamples
 {
@@ -21,6 +21,7 @@ public static class FeatureExamples
         await NamedOutcomesAsync();
         await SubGraphCompositeAsync();
         await DurableSuspendResumeAsync();
+        await DeepSuspendResumeAsync();
     }
 
     // ── Error handling: retries and failure edges ─────────────────────────
@@ -164,5 +165,56 @@ public static class FeatureExamples
             result = second.Execute();
 
         Console.WriteLine($"Resumed run finished: {result}");
+    }
+
+    // ── Deep suspend / resume: composite internals survive the boundary ───
+
+    static async ValueTask DeepSuspendResumeAsync()
+    {
+        Console.WriteLine("=== Feature: Deep suspend/resume (composite internals) ===");
+
+        bool repaired = false;
+
+        Graph BuildFlow()
+        {
+            Graph child = GraphBuilder
+                .StartWithAsync(_ =>
+                {
+                    Console.WriteLine("  child: step 1");
+                    return ResultHelpers.Success;
+                })
+                .ToAsync(_ =>
+                {
+                    Console.WriteLine("  child: step 2");
+                    return repaired ? ResultHelpers.Success : ResultHelpers.Failure;
+                })
+                .Build();
+
+            StateToken sub = GraphBuilder.Start().SubGraph(child, history: true).SetName("Work");
+            StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new AsyncRelayState(_ =>
+            {
+                repaired = true;
+                Console.WriteLine("  repair ran");
+                return ResultHelpers.Success;
+            })));
+            repair.Goto("Work");
+            return sub.OnError(repair).Build();
+        }
+
+        AsyncStateMachine first = BuildFlow().ToAsyncStateMachine();
+        await first.StepAsync();                              // child failed at step 2; parent at repair
+        StateMachineDeepSnapshot deep = first.SuspendDeep();  // position + composite internals
+
+        string json = JsonSerializer.Serialize(deep);         // still plain records — any serializer works
+
+        // Later — fresh machine over an equivalent (rebuilt) graph:
+        AsyncStateMachine second = BuildFlow().ToAsyncStateMachine();
+        second.ResumeDeep(JsonSerializer.Deserialize<StateMachineDeepSnapshot>(json)!);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+            result = await second.StepAsync();
+
+        Console.WriteLine($"Deep-resumed run finished: {result} (child resumed at step 2 — step 1 did not re-run)");
     }
 }

--- a/NxFSM.Examples/ReadmeExamples/InNodeConcurrencyExample.cs
+++ b/NxFSM.Examples/ReadmeExamples/InNodeConcurrencyExample.cs
@@ -1,0 +1,93 @@
+using NxGraph;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxFSM.Examples.ReadmeExamples;
+
+/// <summary>
+/// In-node concurrency (README "In-node concurrency: .ToAllAsync(...)"): parallel regions
+/// interleave cooperatively and never overlap in time — wall-clock concurrency lives inside
+/// a single node. <c>.ToAllAsync(...)</c> starts every work with the node's token, awaits all,
+/// and joins (Success iff every work succeeded); each work writes its own disjoint port and
+/// the next node combines them. <c>.ToAll(...)</c> is the sequential sync twin.
+/// </summary>
+public static class InNodeConcurrencyExample
+{
+    private static class ScoutIo
+    {
+        public static readonly BlackboardSchema Schema = new("scout-io"); // Graph scope (default)
+        public static readonly BlackboardKey<string> Weather = Schema.Register<string>("weather", "");
+        public static readonly BlackboardKey<string> Terrain = Schema.Register<string>("terrain", "");
+    }
+
+    private static async ValueTask<string> FetchWeatherAsync(CancellationToken ct)
+    {
+        await Task.Delay(20, ct); // stands in for a slow I/O call
+        return "clear skies";
+    }
+
+    private static async ValueTask<string> FetchTerrainAsync(CancellationToken ct)
+    {
+        await Task.Delay(20, ct); // overlaps with the weather call — ~max(t1, t2), not t1 + t2
+        return "open plains";
+    }
+
+    private static ValueTask<Result> PlanRouteAsync(string weather, string terrain)
+    {
+        Console.WriteLine($"  Planning route for {weather} over {terrain}.");
+        return ResultHelpers.Success;
+    }
+
+    public static async ValueTask RunAsync()
+    {
+        Console.WriteLine("=== In-node concurrency (.ToAllAsync + ports) ===");
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAllAsync( // both calls in flight at once — ~max(t1, t2), not t1 + t2
+                async (bb, ct) => { bb.Set(ScoutIo.Weather, await FetchWeatherAsync(ct)); return Result.Success; },
+                async (bb, ct) => { bb.Set(ScoutIo.Terrain, await FetchTerrainAsync(ct)); return Result.Success; })
+            .ToAsync(ScoutIo.Weather, (weather, bb, ct) => // the next node combines the ports
+                PlanRouteAsync(weather, bb.Get(ScoutIo.Terrain)))
+            .WithSchema(ScoutIo.Schema)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine()
+            .WithBlackboard(new Blackboard(ScoutIo.Schema))
+            .ExecuteAsync();
+        Console.WriteLine($"  Concurrent scout report joined: {result}");
+
+        RunSync();
+    }
+
+    private static void RunSync()
+    {
+        Console.WriteLine("=== In-node concurrency (sync twin .ToAll, sequential in one tick) ===");
+
+        // Same join semantics (all works run, Success iff all succeeded) without wall-clock
+        // overlap — the works run sequentially, in order, within one Execute() call.
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAll(
+                bb => { bb.Set(ScoutIo.Weather, "drizzle"); return Result.Success; },
+                bb => { bb.Set(ScoutIo.Terrain, "marshland"); return Result.Success; })
+            .To(ScoutIo.Weather, (weather, bb) =>
+            {
+                Console.WriteLine($"  Planning route for {weather} over {bb.Get(ScoutIo.Terrain)}.");
+                return Result.Success;
+            })
+            .WithSchema(ScoutIo.Schema)
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine().WithBlackboard(new Blackboard(ScoutIo.Schema));
+        Result result = machine.Execute();
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Console.WriteLine($"  Sync twin joined: {result}");
+    }
+}

--- a/NxFSM.Examples/ReadmeExamples/PortsExample.cs
+++ b/NxFSM.Examples/ReadmeExamples/PortsExample.cs
@@ -1,0 +1,78 @@
+using NxGraph;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxFSM.Examples.ReadmeExamples;
+
+/// <summary>
+/// Step I/O ports (README "Step I/O (ports)"): a port is an ordinary Graph-scoped
+/// <see cref="BlackboardKey{T}"/> — one per producing step, named for the datum. The port DSL
+/// overloads read/write the port around the step lambda, so a produce → pipe → consume chain
+/// needs no manual Get/Set and the graph stays a shareable template.
+/// </summary>
+public static class PortsExample
+{
+    private static class FlowIo
+    {
+        public static readonly BlackboardSchema Schema = new("flow-io"); // Graph scope (default)
+        public static readonly BlackboardKey<string> Draft = Schema.Register<string>("draft", "");
+        public static readonly BlackboardKey<string> Final = Schema.Register<string>("final", "");
+    }
+
+    private static Result Publish(string text)
+    {
+        Console.WriteLine($"  Publishing: {text}");
+        return Result.Success;
+    }
+
+    private static ValueTask<Result> PublishAsync(string text)
+    {
+        return new ValueTask<Result>(Publish(text));
+    }
+
+    public static async ValueTask RunAsync()
+    {
+        Console.WriteLine("=== Step I/O Ports (async produce → pipe → consume) ===");
+
+        // Async: produce → pipe → consume.
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAsync(FlowIo.Draft, (bb, ct) => new ValueTask<string>("a draft"))                  // producer: value → port
+            .ToAsync(FlowIo.Draft, FlowIo.Final, (draft, bb, ct) => new ValueTask<string>($"[polished] {draft}")) // pipe
+            .ToAsync(FlowIo.Final, (text, bb, ct) => PublishAsync(text))                          // consumer: port → Result
+            .WithSchema(FlowIo.Schema)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine()
+            .WithBlackboard(new Blackboard(FlowIo.Schema))
+            .ExecuteAsync();
+        Console.WriteLine($"  Async port chain: {result}");
+
+        RunSync();
+    }
+
+    private static void RunSync()
+    {
+        Console.WriteLine("=== Step I/O Ports (sync twin) ===");
+
+        // Sync twin — the same shapes without the CancellationToken.
+        Graph graph = GraphBuilder
+            .Start()
+            .To(FlowIo.Draft, bb => "a draft")
+            .To(FlowIo.Draft, FlowIo.Final, (draft, bb) => $"[polished] {draft}")
+            .To(FlowIo.Final, (text, bb) => Publish(text))
+            .WithSchema(FlowIo.Schema)
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine().WithBlackboard(new Blackboard(FlowIo.Schema));
+        Result result = machine.Execute();
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Console.WriteLine($"  Sync port chain: {result}");
+    }
+}

--- a/NxGraph.Serialization/Docs/readme.md
+++ b/NxGraph.Serialization/Docs/readme.md
@@ -7,7 +7,7 @@ This project provides serialization and deserialization functionalities for [NxG
 A durable flow is shipped as separate artifacts, each with its own lifecycle:
 
 1. **Graph structure** — `GraphSerializer.ToJsonAsync`/`ToBinaryAsync` (node logic encoded via your `ILogicCodec`).
-2. **Machine position** — `StateMachineSnapshot`, a primitives-only record you serialize with any serializer.
+2. **Machine position** — a shallow `StateMachineSnapshot` or, when the flow's suspension points live inside composites, a deep `StateMachineDeepSnapshot` from `SuspendDeep()` (which additionally captures composite-internal position — nested machines, history children, sync parallel regions). Both are primitives-only records you serialize with any serializer; the library never serializes them itself.
 3. **One payload per blackboard** — `BlackboardSerializer.ToJsonAsync`/`ToBinaryAsync`; a global board saves once per world, graph boards per entity.
 
 Restore is *restore-into*: schemas are code and cannot be reconstructed from a payload, so you create a live `Blackboard` over the current schema and apply the payload over its defaults (`RestoreFromJsonAsync`/`RestoreFromBinaryAsync`). Post-state is always defaults + payload — keys added to the schema after the save keep their defaults, and stale pre-restore values never survive.

--- a/NxGraph.Tests/AllStateTests.cs
+++ b/NxGraph.Tests/AllStateTests.cs
@@ -1,0 +1,436 @@
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// In-node concurrency (spec 012): <c>.ToAllAsync(...)</c> runs N works truly concurrently
+/// inside one node and joins on all of them (Success iff every work succeeded); failures never
+/// cancel siblings — all works settle before the combine. The sync twin <c>.ToAll(...)</c>
+/// runs the works sequentially in one tick with identical join semantics and also runs under
+/// the async machine via the adapter.
+/// </summary>
+[TestFixture]
+public class AllStateTests
+{
+    private static Result RunToCompletion(StateMachine machine)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+
+    // ── Concurrency is real: deterministic handshake, no timing asserts ───
+
+    [Test]
+    public async Task async_works_genuinely_overlap_in_time()
+    {
+        // Each work signals its own start, then awaits the other's signal. The node completes
+        // only if both works were started before either finished — i.e. under true overlap.
+        // Sequential execution (await one work to completion before starting the next) would
+        // never finish; no timing assertions are involved.
+        TaskCompletionSource first = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource second = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAllAsync(
+                async (_, _) =>
+                {
+                    first.SetResult();
+                    await second.Task;
+                    return Result.Success;
+                },
+                async (_, _) =>
+                {
+                    second.SetResult();
+                    await first.Task;
+                    return Result.Success;
+                })
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
+
+    // ── Join semantics: all-success / one-failure, all works always run ───
+
+    [Test]
+    public async Task async_all_success_joins_to_success()
+    {
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAllAsync(
+                (_, _) => ResultHelpers.Success,
+                (_, _) => ResultHelpers.Success,
+                (_, _) => ResultHelpers.Success)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
+
+    [Test]
+    public async Task async_one_failure_joins_to_failure_after_all_works_ran()
+    {
+        bool[] ran = new bool[3];
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAllAsync(
+                (_, _) =>
+                {
+                    ran[0] = true;
+                    return ResultHelpers.Success;
+                },
+                (_, _) =>
+                {
+                    ran[1] = true;
+                    return ResultHelpers.Failure;
+                },
+                (_, _) =>
+                {
+                    ran[2] = true;
+                    return ResultHelpers.Success;
+                })
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(ran, Is.All.True, "A failing work must not abort or cancel its siblings.");
+        });
+    }
+
+    // ── One node failure feeding the unified fault model ──────────────────
+
+    [Test]
+    public async Task async_failure_consumes_retry_and_rerun_covers_all_works()
+    {
+        int flakyCalls = 0;
+        int steadyCalls = 0;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAllAsync(
+                (_, _) => ++flakyCalls < 2 ? ResultHelpers.Failure : ResultHelpers.Success,
+                (_, _) =>
+                {
+                    steadyCalls++;
+                    return ResultHelpers.Success;
+                })
+            .Retry(maxAttempts: 2)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(flakyCalls, Is.EqualTo(2), "The retry re-runs the whole node.");
+            Assert.That(steadyCalls, Is.EqualTo(2), "All works re-run on retry, succeeded ones included.");
+        });
+    }
+
+    [Test]
+    public async Task async_failure_follows_the_failure_edge()
+    {
+        bool handled = false;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAllAsync(
+                (_, _) => ResultHelpers.Success,
+                (_, _) => ResultHelpers.Failure)
+            .OnErrorAsync(_ =>
+            {
+                handled = true;
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(handled, Is.True, "The join failure is one ordinary node failure.");
+        });
+    }
+
+    // ── Exceptions and cancellation ───────────────────────────────────────
+
+    [Test]
+    public void async_exception_propagates_after_siblings_settle()
+    {
+        bool siblingCompleted = false;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAllAsync(
+                (_, _) => throw new InvalidOperationException("boom"),
+                async (_, _) =>
+                {
+                    await Task.Yield();
+                    siblingCompleted = true;
+                    return Result.Success;
+                })
+            .Build();
+
+        Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await graph.ToAsyncStateMachine().ExecuteAsync());
+        Assert.That(siblingCompleted, Is.True,
+            "WhenAll semantics: the exception surfaces only after every work settled.");
+    }
+
+    [Test]
+    public void async_machine_cancellation_cancels_all_works()
+    {
+        bool[] cancelled = new bool[2];
+        CancellationTokenSource cts = new(10);
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAllAsync(
+                async (_, ct) =>
+                {
+                    try
+                    {
+                        await Task.Delay(System.Threading.Timeout.Infinite, ct);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        cancelled[0] = true;
+                        throw;
+                    }
+
+                    return Result.Success;
+                },
+                async (_, ct) =>
+                {
+                    try
+                    {
+                        await Task.Delay(System.Threading.Timeout.Infinite, ct);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        cancelled[1] = true;
+                        throw;
+                    }
+
+                    return Result.Success;
+                })
+            .Build();
+
+        Assert.That(async () => await graph.ToAsyncStateMachine().ExecuteAsync(cts.Token),
+            Throws.InstanceOf<OperationCanceledException>());
+        Assert.That(cancelled, Is.All.True, "The node's token reaches and cancels every work.");
+    }
+
+    // ── Disjoint keys: concurrent writes to distinct slots land correctly ─
+
+    [Test]
+    public async Task async_disjoint_key_writes_from_overlapping_works_land_correctly()
+    {
+        BlackboardSchema io = new("all-io");
+        BlackboardKey<int> left = io.Register<int>("left");
+        BlackboardKey<int> right = io.Register<int>("right");
+        Blackboard board = new(io);
+
+        // The handshake forces both works to be mid-flight while writing, so the writes
+        // genuinely overlap — distinct keys mean distinct slots, which is the contract.
+        TaskCompletionSource leftStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource rightStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAllAsync(
+                async (bb, _) =>
+                {
+                    leftStarted.SetResult();
+                    await rightStarted.Task;
+                    bb.Set(left, 21);
+                    return Result.Success;
+                },
+                async (bb, _) =>
+                {
+                    rightStarted.SetResult();
+                    await leftStarted.Task;
+                    bb.Set(right, 42);
+                    return Result.Success;
+                })
+            .ToAsync((bb, _) =>
+                bb.Get(left) == 21 && bb.Get(right) == 42 ? ResultHelpers.Success : ResultHelpers.Failure)
+            .WithSchema(io)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success), "The next node reads both port values.");
+            Assert.That(board.Get(left), Is.EqualTo(21));
+            Assert.That(board.Get(right), Is.EqualTo(42));
+        });
+    }
+
+    // ── Sync twin: sequential order, identical join, both machines ────────
+
+    [Test]
+    public void sync_works_run_sequentially_in_declaration_order()
+    {
+        List<string> order = [];
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAll(
+                _ =>
+                {
+                    order.Add("a");
+                    return Result.Success;
+                },
+                _ =>
+                {
+                    order.Add("b");
+                    return Result.Success;
+                },
+                _ =>
+                {
+                    order.Add("c");
+                    return Result.Success;
+                })
+            .Build();
+
+        Result result = RunToCompletion(graph.ToStateMachine());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(order, Is.EqualTo(new[] { "a", "b", "c" }), "Sequential, in declaration order.");
+        });
+    }
+
+    [Test]
+    public void sync_one_failure_joins_to_failure_after_all_works_ran()
+    {
+        bool[] ran = new bool[3];
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAll(
+                _ =>
+                {
+                    ran[0] = true;
+                    return Result.Success;
+                },
+                _ =>
+                {
+                    ran[1] = true;
+                    return Result.Failure;
+                },
+                _ =>
+                {
+                    ran[2] = true;
+                    return Result.Success;
+                })
+            .Build();
+
+        Result result = RunToCompletion(graph.ToStateMachine());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(ran, Is.All.True, "No early abort: every work runs even after a Failure.");
+        });
+    }
+
+    [Test]
+    public async Task sync_all_node_runs_under_both_machines()
+    {
+        int calls = 0;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAll(
+                _ =>
+                {
+                    calls++;
+                    return Result.Success;
+                },
+                _ =>
+                {
+                    calls++;
+                    return Result.Success;
+                })
+            .Build();
+
+        Result syncResult = RunToCompletion(graph.ToStateMachine());
+        Result asyncResult = await graph.ToAsyncStateMachine().ExecuteAsync(); // adapter path
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncResult, Is.EqualTo(Result.Success));
+            Assert.That(asyncResult, Is.EqualTo(Result.Success));
+            Assert.That(calls, Is.EqualTo(4), "Both machines ran both works once.");
+        });
+    }
+
+    // ── Wiring-time validation ────────────────────────────────────────────
+
+    [Test]
+    public void empty_works_throw_at_wiring_time()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => GraphBuilder.Start().ToAllAsync(),
+                Throws.ArgumentException, "async, empty");
+            Assert.That(() => GraphBuilder.Start().ToAll(),
+                Throws.ArgumentException, "sync, empty");
+        });
+    }
+
+    [Test]
+    public void null_work_entries_throw_at_wiring_time()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => GraphBuilder.Start().ToAllAsync((_, _) => ResultHelpers.Success, null!),
+                Throws.ArgumentException, "async, null entry");
+            Assert.That(() => GraphBuilder.Start().ToAll(_ => Result.Success, null!),
+                Throws.ArgumentException, "sync, null entry");
+        });
+    }
+
+    [Test]
+    public async Task single_work_is_legal()
+    {
+        Graph asyncGraph = GraphBuilder
+            .Start()
+            .ToAllAsync((_, _) => ResultHelpers.Success)
+            .Build();
+        Graph syncGraph = GraphBuilder
+            .Start()
+            .ToAll(_ => Result.Success)
+            .Build();
+
+        Result asyncResult = await asyncGraph.ToAsyncStateMachine().ExecuteAsync();
+        Result syncResult = RunToCompletion(syncGraph.ToStateMachine());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(asyncResult, Is.EqualTo(Result.Success));
+            Assert.That(syncResult, Is.EqualTo(Result.Success));
+        });
+    }
+}

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -430,6 +430,46 @@ public class AllocationGateTests
         AssertZeroAlloc(machine);
     }
 
+    // ── Step I/O ports: produce → pipe → consume over one Graph board ───
+
+    private static (Blackboard io, BlackboardKey<int> raw, BlackboardKey<int> doubled) PortBoards()
+    {
+        BlackboardSchema schema = new("flow-io");
+        BlackboardKey<int> raw = schema.Register<int>("raw");
+        BlackboardKey<int> doubled = schema.Register<int>("doubled");
+        return (new Blackboard(schema), raw, doubled);
+    }
+
+    [Test]
+    public async Task async_port_produce_pipe_consume_is_allocation_free()
+    {
+        (Blackboard io, BlackboardKey<int> raw, BlackboardKey<int> doubled) = PortBoards();
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAsync(raw, (bb, _) => new ValueTask<int>(bb.Get(raw) + 1))
+            .ToAsync(raw, doubled, (value, _, _) => new ValueTask<int>(value * 2))
+            .ToAsync(doubled, (value, _, _) => value > 0 ? ResultHelpers.Success : ResultHelpers.Failure)
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine().WithBlackboard(io));
+    }
+
+    [Test]
+    public void sync_port_produce_pipe_consume_is_allocation_free()
+    {
+        (Blackboard io, BlackboardKey<int> raw, BlackboardKey<int> doubled) = PortBoards();
+
+        Graph graph = GraphBuilder
+            .Start()
+            .To(raw, bb => bb.Get(raw) + 1)
+            .To(raw, doubled, (value, _) => value * 2)
+            .To(doubled, (value, _) => value > 0 ? Result.Success : Result.Failure)
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine().WithBlackboard(io));
+    }
+
     [Test]
     public async Task async_blackboard_if_branch_is_allocation_free()
     {

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -690,6 +690,22 @@ public class AllocationGateTests
     }
 
     [Test]
+    public void sync_to_all_join_is_allocation_free()
+    {
+        // The async AsyncAllState allocates per execution by design (task materialization
+        // dwarfed by the I/O it overlaps) — exemption recorded in spec 012, no async case.
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAll(
+                _ => Result.Success,
+                _ => Result.Success,
+                _ => Result.Success)
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine());
+    }
+
+    [Test]
     public void sync_chain_of_10_is_allocation_free()
     {
         StateToken token = GraphBuilder.StartWith(() => Result.Success);

--- a/NxGraph.Tests/Blackboards/PortRelayTests.cs
+++ b/NxGraph.Tests/Blackboards/PortRelayTests.cs
@@ -1,0 +1,512 @@
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests.Blackboards;
+
+/// <summary>
+/// Step I/O ports (spec 010): a port is an ordinary Graph-scoped <see cref="BlackboardKey{T}"/>
+/// and the port DSL overloads read/write it around the step lambda. Producer/pipe steps cannot
+/// fail; Node-scoped keys are rejected at wiring time; Graph scope keeps templates shareable.
+/// </summary>
+[TestFixture]
+public class PortRelayTests
+{
+    private static BlackboardSchema NewIoSchema(out BlackboardKey<int> raw, out BlackboardKey<int> doubled)
+    {
+        BlackboardSchema io = new("flow-io");
+        raw = io.Register<int>("raw", 41);
+        doubled = io.Register<int>("doubled");
+        return io;
+    }
+
+    private static BlackboardSchema NewNodeSchema(out BlackboardKey<int> scratch)
+    {
+        BlackboardSchema schema = new("scratch", BlackboardScope.Node);
+        scratch = schema.Register<int>("value");
+        return schema;
+    }
+
+    // ── Producer: step computes, relay writes and succeeds ────────────────
+
+    [Test]
+    public async Task async_producer_writes_port_and_returns_success()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out _);
+        Blackboard board = new(io);
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAsync(raw, (bb, _) => new ValueTask<int>(7))
+            .WithSchema(io)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(board.Get(raw), Is.EqualTo(7));
+        });
+    }
+
+    [Test]
+    public void sync_producer_writes_port_and_returns_success()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out _);
+        Blackboard board = new(io);
+
+        Graph graph = GraphBuilder
+            .Start()
+            .To(raw, bb => 7)
+            .WithSchema(io)
+            .Build();
+
+        Result result = RunToCompletion(graph.ToStateMachine().WithBlackboard(board));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(board.Get(raw), Is.EqualTo(7));
+        });
+    }
+
+    // ── Consumer: relay reads, step decides ───────────────────────────────
+
+    [Test]
+    public async Task async_consumer_receives_the_produced_value()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out _);
+        int seen = -1;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAsync(raw, (bb, _) => new ValueTask<int>(7))
+            .ToAsync(raw, (value, bb, _) =>
+            {
+                seen = value;
+                return ResultHelpers.Success;
+            })
+            .WithSchema(io)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(io)).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(seen, Is.EqualTo(7));
+        });
+    }
+
+    [Test]
+    public void sync_consumer_receives_the_produced_value()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out _);
+        int seen = -1;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .To(raw, bb => 7)
+            .To(raw, (value, bb) =>
+            {
+                seen = value;
+                return Result.Success;
+            })
+            .WithSchema(io)
+            .Build();
+
+        Result result = RunToCompletion(graph.ToStateMachine().WithBlackboard(new Blackboard(io)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(seen, Is.EqualTo(7));
+        });
+    }
+
+    // ── Consumer result flows into the fault model ────────────────────────
+
+    [Test]
+    public async Task async_consumer_failure_is_an_ordinary_node_failure()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out _);
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAsync(raw, (bb, _) => new ValueTask<int>(-1))
+            .ToAsync(raw, (value, bb, _) => value > 0 ? ResultHelpers.Success : ResultHelpers.Failure)
+            .WithSchema(io)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(io)).ExecuteAsync();
+
+        Assert.That(result, Is.EqualTo(Result.Failure));
+    }
+
+    // ── Pipe: read → transform → write ────────────────────────────────────
+
+    [Test]
+    public async Task async_pipe_chains_produce_transform_consume()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out BlackboardKey<int> doubled);
+        Blackboard board = new(io);
+        int seen = -1;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAsync(raw, (bb, _) => new ValueTask<int>(7))
+            .ToAsync(raw, doubled, (value, bb, _) => new ValueTask<int>(value * 2))
+            .ToAsync(doubled, (value, bb, _) =>
+            {
+                seen = value;
+                return ResultHelpers.Success;
+            })
+            .WithSchema(io)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(seen, Is.EqualTo(14));
+            Assert.That(board.Get(doubled), Is.EqualTo(14));
+        });
+    }
+
+    [Test]
+    public void sync_pipe_chains_produce_transform_consume()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out BlackboardKey<int> doubled);
+        Blackboard board = new(io);
+        int seen = -1;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .To(raw, bb => 7)
+            .To(raw, doubled, (value, bb) => value * 2)
+            .To(doubled, (value, bb) =>
+            {
+                seen = value;
+                return Result.Success;
+            })
+            .WithSchema(io)
+            .Build();
+
+        Result result = RunToCompletion(graph.ToStateMachine().WithBlackboard(board));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(seen, Is.EqualTo(14));
+            Assert.That(board.Get(doubled), Is.EqualTo(14));
+        });
+    }
+
+    // ── Consumer before any producer reads the registered default ─────────
+
+    [Test]
+    public async Task async_consumer_before_any_producer_sees_the_registered_default()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out _);
+        int seen = -1;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAsync(raw, (value, bb, _) =>
+            {
+                seen = value;
+                return ResultHelpers.Success;
+            })
+            .WithSchema(io)
+            .Build();
+
+        await graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(io)).ExecuteAsync();
+
+        Assert.That(seen, Is.EqualTo(41), "Consumers ahead of any producer read the key's registered default.");
+    }
+
+    [Test]
+    public void sync_consumer_before_any_producer_sees_the_registered_default()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out _);
+        int seen = -1;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .To(raw, (value, bb) =>
+            {
+                seen = value;
+                return Result.Success;
+            })
+            .WithSchema(io)
+            .Build();
+
+        RunToCompletion(graph.ToStateMachine().WithBlackboard(new Blackboard(io)));
+
+        Assert.That(seen, Is.EqualTo(41));
+    }
+
+    // ── Wiring-time validation ────────────────────────────────────────────
+
+    [Test]
+    public void node_scoped_key_throws_at_wiring_time_for_all_six_overloads()
+    {
+        _ = NewNodeSchema(out BlackboardKey<int> scratch);
+        StateToken prev = GraphBuilder.StartWith(() => Result.Success);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => prev.To(scratch, bb => 1),
+                Throws.ArgumentException.With.Message.Contain("'value'").And.Message.Contain("Graph-scoped"),
+                "sync producer");
+            Assert.That(() => prev.ToAsync(scratch, (bb, _) => new ValueTask<int>(1)),
+                Throws.ArgumentException.With.Message.Contain("'value'").And.Message.Contain("Graph-scoped"),
+                "async producer");
+            Assert.That(() => prev.To(scratch, (value, bb) => Result.Success),
+                Throws.ArgumentException.With.Message.Contain("'value'").And.Message.Contain("Graph-scoped"),
+                "sync consumer");
+            Assert.That(() => prev.ToAsync(scratch, (value, bb, _) => ResultHelpers.Success),
+                Throws.ArgumentException.With.Message.Contain("'value'").And.Message.Contain("Graph-scoped"),
+                "async consumer");
+            Assert.That(() => prev.To(scratch, scratch, (value, bb) => value),
+                Throws.ArgumentException.With.Message.Contain("'value'").And.Message.Contain("Graph-scoped"),
+                "sync pipe");
+            Assert.That(() => prev.ToAsync(scratch, scratch, (value, bb, _) => new ValueTask<int>(value)),
+                Throws.ArgumentException.With.Message.Contain("'value'").And.Message.Contain("Graph-scoped"),
+                "async pipe");
+        });
+    }
+
+    [Test]
+    public void pipe_rejects_a_node_scoped_output_even_with_a_graph_scoped_input()
+    {
+        _ = NewIoSchema(out BlackboardKey<int> raw, out _);
+        _ = NewNodeSchema(out BlackboardKey<int> scratch);
+        StateToken prev = GraphBuilder.StartWith(() => Result.Success);
+
+        Assert.That(() => prev.To(raw, scratch, (value, bb) => value),
+            Throws.ArgumentException.With.Message.Contain("'value'").And.Message.Contain("Graph-scoped"));
+    }
+
+    [Test]
+    public void invalid_default_key_throws_at_wiring_time()
+    {
+        BlackboardKey<int> invalid = default;
+        StateToken prev = GraphBuilder.StartWith(() => Result.Success);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => prev.To(invalid, bb => 1),
+                Throws.ArgumentException.With.Message.Contain("Invalid port key"));
+            Assert.That(() => prev.ToAsync(invalid, (value, bb, _) => ResultHelpers.Success),
+                Throws.ArgumentException.With.Message.Contain("Invalid port key"));
+        });
+    }
+
+    [Test]
+    public async Task global_scoped_key_is_accepted()
+    {
+        BlackboardSchema world = new("world", BlackboardScope.Global);
+        BlackboardKey<int> sightings = world.Register<int>("sightings");
+        Blackboard board = new(world);
+        int seen = -1;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAsync(sightings, (bb, _) => new ValueTask<int>(bb.Get(sightings) + 1))
+            .ToAsync(sightings, (value, bb, _) =>
+            {
+                seen = value;
+                return ResultHelpers.Success;
+            })
+            .WithSchema(world)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(seen, Is.EqualTo(1), "Global ports pipe mechanically — they are just shared across machines.");
+        });
+    }
+
+    // ── Template shareability: the feature's core promise ─────────────────
+
+    [Test]
+    public async Task async_two_machines_over_one_template_never_see_each_others_port_values()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out BlackboardKey<int> doubled);
+
+        // The consumer succeeds only when the piped value matches this machine's own board.
+        Graph shared = GraphBuilder
+            .Start()
+            .ToAsync(raw, doubled, (value, bb, _) => new ValueTask<int>(value * 2))
+            .ToAsync(doubled, (value, bb, _) =>
+                value == bb.Get(raw) * 2 ? ResultHelpers.Success : ResultHelpers.Failure)
+            .WithSchema(io)
+            .Build();
+
+        Blackboard boardA = new(io);
+        Blackboard boardB = new(io);
+        boardA.Set(raw, 10);
+        boardB.Set(raw, 20);
+
+        AsyncStateMachine machineA = shared.ToAsyncStateMachine().WithBlackboard(boardA);
+        AsyncStateMachine machineB = shared.ToAsyncStateMachine().WithBlackboard(boardB);
+
+        Result firstA = await machineA.ExecuteAsync();
+        Result firstB = await machineB.ExecuteAsync();
+        Result secondA = await machineA.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstA, Is.EqualTo(Result.Success));
+            Assert.That(firstB, Is.EqualTo(Result.Success));
+            Assert.That(secondA, Is.EqualTo(Result.Success));
+            Assert.That(boardA.Get(doubled), Is.EqualTo(20), "Machine A's ports live on machine A's board.");
+            Assert.That(boardB.Get(doubled), Is.EqualTo(40), "Machine B's ports live on machine B's board.");
+        });
+    }
+
+    [Test]
+    public void sync_two_machines_over_one_template_never_see_each_others_port_values()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out BlackboardKey<int> doubled);
+
+        Graph shared = GraphBuilder
+            .Start()
+            .To(raw, doubled, (value, bb) => value * 2)
+            .To(doubled, (value, bb) => value == bb.Get(raw) * 2 ? Result.Success : Result.Failure)
+            .WithSchema(io)
+            .Build();
+
+        Blackboard boardA = new(io);
+        Blackboard boardB = new(io);
+        boardA.Set(raw, 10);
+        boardB.Set(raw, 20);
+
+        StateMachine machineA = shared.ToStateMachine().WithBlackboard(boardA);
+        StateMachine machineB = shared.ToStateMachine().WithBlackboard(boardB);
+
+        Result firstA = RunToCompletion(machineA);
+        Result firstB = RunToCompletion(machineB);
+        Result secondA = RunToCompletion(machineA);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstA, Is.EqualTo(Result.Success));
+            Assert.That(firstB, Is.EqualTo(Result.Success));
+            Assert.That(secondA, Is.EqualTo(Result.Success));
+            Assert.That(boardA.Get(doubled), Is.EqualTo(20));
+            Assert.That(boardB.Get(doubled), Is.EqualTo(40));
+        });
+    }
+
+    // ── Branch receivers ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task async_branch_receivers_support_ports()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out BlackboardKey<int> doubled);
+        Blackboard board = new(io);
+
+        // StartToken producer → If(true) → BranchBuilder pipe on the "then" branch.
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAsync(raw, (bb, _) => new ValueTask<int>(3))
+            .If(bb => bb.Get(raw) > 0)
+            .ThenAsync((bb, _) => ResultHelpers.Success)
+            .ToAsync(raw, doubled, (value, bb, _) => new ValueTask<int>(value * 2))
+            .ElseAsync((bb, _) => ResultHelpers.Success)
+            .WithSchema(io)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(board.Get(doubled), Is.EqualTo(6));
+        });
+    }
+
+    [Test]
+    public void sync_branch_receivers_support_ports()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out _);
+        int seen = -1;
+
+        // StartToken producer → If(false) → BranchEnd consumer after the "else" branch.
+        Graph graph = GraphBuilder
+            .Start()
+            .To(raw, bb => 3)
+            .If(bb => bb.Get(raw) < 0)
+            .Then(bb => Result.Success)
+            .Else(bb => Result.Success)
+            .To(raw, (value, bb) =>
+            {
+                seen = value;
+                return Result.Success;
+            })
+            .WithSchema(io)
+            .Build();
+
+        Result result = RunToCompletion(graph.ToStateMachine().WithBlackboard(new Blackboard(io)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(seen, Is.EqualTo(3));
+        });
+    }
+
+    // ── Unbound Graph scope keeps the precise runtime error ───────────────
+
+    [Test]
+    public void async_unbound_graph_scope_at_run_time_keeps_the_precise_error()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out _);
+        _ = io;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .ToAsync(raw, (bb, _) => new ValueTask<int>(7))
+            .Build();
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await graph.ToAsyncStateMachine().ExecuteAsync());
+        Assert.That(ex!.Message, Does.Contain("graph key 'raw'").And.Contain("WithBlackboard"));
+    }
+
+    [Test]
+    public void sync_unbound_graph_scope_at_run_time_keeps_the_precise_error()
+    {
+        BlackboardSchema io = NewIoSchema(out BlackboardKey<int> raw, out _);
+        _ = io;
+
+        Graph graph = GraphBuilder
+            .Start()
+            .To(raw, bb => 7)
+            .Build();
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => RunToCompletion(graph.ToStateMachine()));
+        Assert.That(ex!.Message, Does.Contain("graph key 'raw'").And.Contain("WithBlackboard"));
+    }
+
+    private static Result RunToCompletion(StateMachine machine)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+}

--- a/NxGraph.Tests/DeepSuspendResumeTests.cs
+++ b/NxGraph.Tests/DeepSuspendResumeTests.cs
@@ -1,0 +1,781 @@
+using System.Text.Json;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Deep suspend/resume (spec 011): <c>SuspendDeep()</c>/<c>ResumeDeep(...)</c> capture
+/// composite-internal position — nested machine positions, history's remembered child,
+/// the sync RoundPerTick composites' mid-visit bookkeeping — into
+/// <see cref="StateMachineDeepSnapshot"/>, resumable on a fresh machine over an equivalent
+/// (rebuilt) graph. The shallow pair and <see cref="StateMachineSnapshot"/> are untouched;
+/// <see cref="SuspendResumeTests"/>/<see cref="SyncSuspendResumeTests"/> pin that separately.
+/// </summary>
+[TestFixture]
+public class DeepSuspendResumeTests
+{
+    private static Result RunToCompletion(StateMachine machine)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+
+    private static async Task<Result> RunToCompletionAsync(AsyncStateMachine machine)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await machine.StepAsync();
+        }
+
+        return result;
+    }
+
+    private static StateMachineDeepSnapshot JsonRoundTrip(StateMachineDeepSnapshot snapshot)
+    {
+        string json = JsonSerializer.Serialize(snapshot);
+        return JsonSerializer.Deserialize<StateMachineDeepSnapshot>(json)!;
+    }
+
+    private static Graph SyncLoggingChain(List<string> log, string prefix, int length)
+    {
+        StateToken token = GraphBuilder.StartWith(() =>
+        {
+            log.Add($"{prefix}0");
+            return Result.Success;
+        });
+
+        for (int i = 1; i < length; i++)
+        {
+            int step = i;
+            token = token.To(() =>
+            {
+                log.Add($"{prefix}{step}");
+                return Result.Success;
+            });
+        }
+
+        return token.Build();
+    }
+
+    // ── Async history: the flagship durable case ──────────────────────────
+
+    [Test]
+    public async Task async_history_deep_snapshot_resumes_child_position_on_a_fresh_machine()
+    {
+        List<string> log = [];
+        bool repaired = false;
+
+        Graph BuildParent()
+        {
+            Graph child = GraphBuilder
+                .StartWithAsync(_ =>
+                {
+                    log.Add("c0");
+                    return ResultHelpers.Success;
+                })
+                .ToAsync(_ =>
+                {
+                    log.Add("c1");
+                    return repaired ? ResultHelpers.Success : ResultHelpers.Failure;
+                })
+                .ToAsync(_ =>
+                {
+                    log.Add("c2");
+                    return ResultHelpers.Success;
+                })
+                .Build();
+
+            StateToken sub = GraphBuilder.Start().SubGraph(child, history: true).SetName("Sub");
+            StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new AsyncRelayState(_ =>
+            {
+                repaired = true;
+                log.Add("repair");
+                return ResultHelpers.Success;
+            })));
+            repair.Goto("Sub");
+            return sub.OnError(repair).Build();
+        }
+
+        AsyncStateMachine first = BuildParent().ToAsyncStateMachine();
+        Result tick = await first.StepAsync(); // child runs c0, fails at c1; parent reroutes to repair
+        Assert.Multiple(() =>
+        {
+            Assert.That(tick, Is.EqualTo(Result.InProgress));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1" }));
+        });
+
+        StateMachineDeepSnapshot deep = first.SuspendDeep();
+        Assert.That(deep.Composites, Has.Length.EqualTo(1), "The history composite emitted one entry.");
+
+        StateMachineDeepSnapshot restored = JsonRoundTrip(deep);
+
+        AsyncStateMachine second = BuildParent().ToAsyncStateMachine();
+        second.ResumeDeep(restored);
+        Result result = await RunToCompletionAsync(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1", "repair", "c1", "c2" }),
+                "The fresh machine's history child resumed at the failed node c1 — c0 did not re-run.");
+        });
+    }
+
+    [Test]
+    public async Task completed_child_restarts_from_top_after_deep_resume()
+    {
+        List<string> log = [];
+        int laps = 0;
+
+        Graph BuildParent()
+        {
+            Graph child = GraphBuilder
+                .StartWithAsync(_ =>
+                {
+                    log.Add("c0");
+                    return ResultHelpers.Success;
+                })
+                .Build();
+
+            return GraphBuilder
+                .Start()
+                .SubGraph(child, history: true).SetName("Sub")
+                .ToAsync(_ => ++laps < 2 ? ResultHelpers.Success : ResultHelpers.Failure)
+                .Goto("Sub")
+                .Build();
+        }
+
+        AsyncStateMachine first = BuildParent().ToAsyncStateMachine();
+        Result tick = await first.StepAsync(); // child completed; parent at the lap node
+        Assert.That(tick, Is.EqualTo(Result.InProgress));
+
+        StateMachineDeepSnapshot deep = JsonRoundTrip(first.SuspendDeep());
+
+        AsyncStateMachine second = BuildParent().ToAsyncStateMachine();
+        second.ResumeDeep(deep);
+        Result result = await RunToCompletionAsync(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c0" }),
+                "A child captured as Completed restarts from its start node on re-entry — history only remembers failures.");
+        });
+    }
+
+    [Test]
+    public async Task deep_history_two_levels_down_survives_a_durable_boundary()
+    {
+        List<string> log = [];
+        bool repaired = false;
+
+        Graph BuildParent()
+        {
+            Graph inner = GraphBuilder
+                .StartWithAsync(_ =>
+                {
+                    log.Add("i0");
+                    return ResultHelpers.Success;
+                })
+                .ToAsync(_ =>
+                {
+                    log.Add("i1");
+                    return repaired ? ResultHelpers.Success : ResultHelpers.Failure;
+                })
+                .Build();
+
+            Graph middle = GraphBuilder
+                .StartWithAsync(_ =>
+                {
+                    log.Add("m0");
+                    return ResultHelpers.Success;
+                })
+                .SubGraph(inner, history: true)
+                .Build();
+
+            StateToken sub = GraphBuilder.Start().SubGraph(middle, history: true).SetName("Sub");
+            StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new AsyncRelayState(_ =>
+            {
+                repaired = true;
+                log.Add("repair");
+                return ResultHelpers.Success;
+            })));
+            repair.Goto("Sub");
+            return sub.OnError(repair).Build();
+        }
+
+        AsyncStateMachine first = BuildParent().ToAsyncStateMachine();
+        Result tick = await first.StepAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(tick, Is.EqualTo(Result.InProgress));
+            Assert.That(log, Is.EqualTo(new[] { "m0", "i0", "i1" }));
+        });
+
+        StateMachineDeepSnapshot deep = JsonRoundTrip(first.SuspendDeep());
+
+        AsyncStateMachine second = BuildParent().ToAsyncStateMachine();
+        second.ResumeDeep(deep);
+        Result result = await RunToCompletionAsync(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "m0", "i0", "i1", "repair", "i1" }),
+                "Both nesting levels resumed their own position on the fresh machine: neither m0 nor i0 re-ran.");
+        });
+    }
+
+    // ── Sync RoundPerTick composites: mid-visit capture ───────────────────
+
+    [Test]
+    public void sync_round_per_tick_parallel_resumes_mid_visit_on_a_fresh_machine()
+    {
+        List<string> log = [];
+
+        Graph BuildParent()
+        {
+            return GraphBuilder
+                .Start()
+                .Parallel(ParallelStepMode.RoundPerTick,
+                    SyncLoggingChain(log, "a", 2), SyncLoggingChain(log, "b", 3))
+                .Build();
+        }
+
+        StateMachine first = BuildParent().ToStateMachine();
+        first.Execute(); // round 1: a0 b0
+        first.Execute(); // round 2: a1 (region a joins) b1
+        Assert.That(log, Is.EqualTo(new[] { "a0", "b0", "a1", "b1" }));
+
+        StateMachineDeepSnapshot deep = JsonRoundTrip(first.SuspendDeep());
+
+        StateMachine second = BuildParent().ToStateMachine();
+        second.ResumeDeep(deep);
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "a0", "b0", "a1", "b1", "b2" }),
+                "Regions continued from their exact nodes: a did not re-run, b picked up at b2.");
+        });
+    }
+
+    [Test]
+    public void sync_parallel_failure_aggregation_survives_deep_resume()
+    {
+        List<string> log = [];
+
+        Graph BuildParent()
+        {
+            Graph failing = GraphBuilder
+                .StartWith(() =>
+                {
+                    log.Add("f0");
+                    return Result.Failure;
+                })
+                .Build();
+
+            return GraphBuilder
+                .Start()
+                .Parallel(ParallelStepMode.RoundPerTick, failing, SyncLoggingChain(log, "b", 3))
+                .Build();
+        }
+
+        StateMachine first = BuildParent().ToStateMachine();
+        first.Execute(); // round 1: f0 fails (region done, failed), b0
+        Assert.That(log, Is.EqualTo(new[] { "f0", "b0" }));
+
+        StateMachineDeepSnapshot deep = JsonRoundTrip(first.SuspendDeep());
+
+        StateMachine second = BuildParent().ToStateMachine();
+        second.ResumeDeep(deep);
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure),
+                "The pre-suspend region failure still fails the join — aggregation is recomputed, not lost.");
+            Assert.That(log, Is.EqualTo(new[] { "f0", "b0", "b1", "b2" }),
+                "The healthy region still ran to completion before the join.");
+        });
+    }
+
+    [Test]
+    public void dynamic_parallel_deselection_survives_deep_resume()
+    {
+        List<string> log = [];
+        int selectorRuns = 0;
+
+        Graph BuildParent()
+        {
+            return GraphBuilder
+                .Start()
+                .Parallel(ParallelStepMode.RoundPerTick, _ =>
+                    {
+                        selectorRuns++;
+                        return RegionMask.Of(0, 2);
+                    },
+                    SyncLoggingChain(log, "a", 2), SyncLoggingChain(log, "b", 2), SyncLoggingChain(log, "c", 2))
+                .Build();
+        }
+
+        StateMachine first = BuildParent().ToStateMachine();
+        first.Execute(); // selector fixes {a, c}; round 1: a0 c0
+        Assert.Multiple(() =>
+        {
+            Assert.That(selectorRuns, Is.EqualTo(1));
+            Assert.That(log, Is.EqualTo(new[] { "a0", "c0" }));
+        });
+
+        StateMachineDeepSnapshot deep = JsonRoundTrip(first.SuspendDeep());
+
+        StateMachine second = BuildParent().ToStateMachine();
+        second.ResumeDeep(deep);
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(selectorRuns, Is.EqualTo(1),
+                "The selector is not re-evaluated on resume — the captured Done bits carry the visit's selection.");
+            Assert.That(log, Is.EqualTo(new[] { "a0", "c0", "a1", "c1" }),
+                "The deselected region b stayed deselected after the resume (Done is captured, not derived).");
+        });
+    }
+
+    [Test]
+    public void sync_nested_machine_mid_run_resumes_in_place()
+    {
+        List<string> log = [];
+
+        Graph BuildParent()
+        {
+            Graph child = SyncLoggingChain(log, "c", 3);
+            return GraphBuilder
+                .StartWith(() =>
+                {
+                    log.Add("p0");
+                    return Result.Success;
+                })
+                .SubGraph(ParallelStepMode.RoundPerTick, child)
+                .To(() =>
+                {
+                    log.Add("p1");
+                    return Result.Success;
+                })
+                .Build();
+        }
+
+        StateMachine first = BuildParent().ToStateMachine();
+        first.Execute(); // p0
+        first.Execute(); // child c0
+        first.Execute(); // child c1
+        Assert.That(log, Is.EqualTo(new[] { "p0", "c0", "c1" }));
+
+        StateMachineDeepSnapshot deep = JsonRoundTrip(first.SuspendDeep());
+
+        StateMachine second = BuildParent().ToStateMachine();
+        second.ResumeDeep(deep);
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "p0", "c0", "c1", "c2", "p1" }),
+                "The nested machine resumed mid-run at c2; the parent then continued past the composite.");
+        });
+    }
+
+    // ── Cross-runtime interchange ─────────────────────────────────────────
+
+    private static Graph BuildCrossRuntimeHistoryParent(List<string> log, Func<bool> isRepaired,
+        Action markRepaired)
+    {
+        Graph child = GraphBuilder
+            .StartWith(() =>
+            {
+                log.Add("c0");
+                return Result.Success;
+            })
+            .To(() =>
+            {
+                log.Add("c1");
+                return isRepaired() ? Result.Success : Result.Failure;
+            })
+            .To(() =>
+            {
+                log.Add("c2");
+                return Result.Success;
+            })
+            .Build();
+
+        StateToken sub = GraphBuilder
+            .Start()
+            .SubGraph(ParallelStepMode.RunToJoin, child, history: true)
+            .SetName("Sub");
+        StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new RelayState(() =>
+        {
+            markRepaired();
+            log.Add("repair");
+            return Result.Success;
+        })));
+        repair.Goto("Sub");
+        return sub.OnError(repair).Build();
+    }
+
+    [Test]
+    public async Task async_captured_history_deep_snapshot_resumes_on_the_sync_machine()
+    {
+        List<string> log = [];
+        bool repaired = false;
+
+        AsyncStateMachine first = BuildCrossRuntimeHistoryParent(log, () => repaired, () => repaired = true)
+            .ToAsyncStateMachine();
+        Result tick = await first.StepAsync(); // sync history composite runs under the adapter, child fails
+        Assert.Multiple(() =>
+        {
+            Assert.That(tick, Is.EqualTo(Result.InProgress));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1" }));
+        });
+
+        StateMachineDeepSnapshot deep = JsonRoundTrip(first.SuspendDeep());
+
+        StateMachine second = BuildCrossRuntimeHistoryParent(log, () => repaired, () => repaired = true)
+            .ToStateMachine();
+        second.ResumeDeep(deep);
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1", "repair", "c1", "c2" }),
+                "History captured under the async runtime resumed at c1 on the sync machine.");
+        });
+    }
+
+    [Test]
+    public async Task sync_captured_history_deep_snapshot_resumes_on_the_async_machine()
+    {
+        List<string> log = [];
+        bool repaired = false;
+
+        StateMachine first = BuildCrossRuntimeHistoryParent(log, () => repaired, () => repaired = true)
+            .ToStateMachine();
+        Result tick = first.Execute(); // history composite fails, parent reroutes to repair
+        Assert.Multiple(() =>
+        {
+            Assert.That(tick, Is.EqualTo(Result.InProgress));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1" }));
+        });
+
+        StateMachineDeepSnapshot deep = JsonRoundTrip(first.SuspendDeep());
+
+        AsyncStateMachine second = BuildCrossRuntimeHistoryParent(log, () => repaired, () => repaired = true)
+            .ToAsyncStateMachine();
+        second.ResumeDeep(deep);
+        Result result = await RunToCompletionAsync(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1", "repair", "c1", "c2" }),
+                "History captured under the sync runtime resumed at c1 on the async machine.");
+        });
+    }
+
+    // ── Sparse capture semantics ──────────────────────────────────────────
+
+    [Test]
+    public async Task stateless_deep_snapshot_behaves_exactly_like_shallow()
+    {
+        List<int> executed = [];
+
+        Graph BuildGraph()
+        {
+            return GraphBuilder
+                .StartWithAsync(_ =>
+                {
+                    executed.Add(0);
+                    return ResultHelpers.Success;
+                })
+                .ToAsync(_ =>
+                {
+                    executed.Add(1);
+                    return ResultHelpers.Success;
+                })
+                .ToAsync(_ =>
+                {
+                    executed.Add(2);
+                    return ResultHelpers.Success;
+                })
+                .Build();
+        }
+
+        AsyncStateMachine first = BuildGraph().ToAsyncStateMachine();
+        await first.StepAsync();
+
+        StateMachineDeepSnapshot deep = first.SuspendDeep();
+        Assert.That(deep.Composites, Is.Empty, "No composite holds durable state — sparse capture is empty.");
+
+        StateMachineDeepSnapshot restored = JsonRoundTrip(deep);
+
+        AsyncStateMachine second = BuildGraph().ToAsyncStateMachine();
+        second.ResumeDeep(restored);
+        Result result = await RunToCompletionAsync(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executed, Is.EqualTo(new[] { 0, 1, 2 }),
+                "Identical to the shallow contract: the resumed machine continued at node 1.");
+        });
+    }
+
+    [Test]
+    public async Task composite_absent_from_the_snapshot_reenters_fresh()
+    {
+        List<string> log = [];
+        bool repaired = false;
+
+        Graph BuildParent()
+        {
+            Graph child = GraphBuilder
+                .StartWithAsync(_ =>
+                {
+                    log.Add("c0");
+                    return ResultHelpers.Success;
+                })
+                .ToAsync(_ =>
+                {
+                    log.Add("c1");
+                    return repaired ? ResultHelpers.Success : ResultHelpers.Failure;
+                })
+                .ToAsync(_ =>
+                {
+                    log.Add("c2");
+                    return ResultHelpers.Success;
+                })
+                .Build();
+
+            StateToken sub = GraphBuilder.Start().SubGraph(child, history: true).SetName("Sub");
+            StateToken repair = sub.Builder.TokenFor(sub.Builder.AddNode(new AsyncRelayState(_ =>
+            {
+                repaired = true;
+                log.Add("repair");
+                return ResultHelpers.Success;
+            })));
+            repair.Goto("Sub");
+            return sub.OnError(repair).Build();
+        }
+
+        AsyncStateMachine first = BuildParent().ToAsyncStateMachine();
+        await first.StepAsync();
+
+        StateMachineDeepSnapshot withoutComposites = first.SuspendDeep() with { Composites = [] };
+
+        AsyncStateMachine second = BuildParent().ToAsyncStateMachine();
+        second.ResumeDeep(withoutComposites);
+        Result result = await RunToCompletionAsync(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(log, Is.EqualTo(new[] { "c0", "c1", "repair", "c0", "c1", "c2" }),
+                "Without a captured entry the history composite re-entered fresh — c0 ran again.");
+        });
+    }
+
+    // ── Resume validation ─────────────────────────────────────────────────
+
+    [Test]
+    public void resume_deep_rejects_out_of_range_composite_node_index()
+    {
+        Graph graph = GraphBuilder.StartWith(() => Result.Success).Build();
+        StateMachineDeepSnapshot deep = graph.ToStateMachine().SuspendDeep() with
+        {
+            Composites = [new CompositeSnapshot(42, false, [], [])],
+        };
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => graph.ToStateMachine().ResumeDeep(deep));
+        Assert.That(ex!.Message, Does.Contain("42"));
+    }
+
+    [Test]
+    public void resume_deep_rejects_a_non_composite_node_claim()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success)
+            .To(() => Result.Success)
+            .Build();
+        StateMachineDeepSnapshot deep = graph.ToStateMachine().SuspendDeep() with
+        {
+            Composites = [new CompositeSnapshot(1, false, [], [])],
+        };
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => graph.ToStateMachine().ResumeDeep(deep));
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Message, Does.Contain("node index 1"));
+            Assert.That(ex.Message, Does.Contain(nameof(ISuspendableComposite)));
+        });
+    }
+
+    [Test]
+    public async Task resume_deep_rejects_a_children_count_mismatch()
+    {
+        Graph BuildParent()
+        {
+            Graph child = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+            return GraphBuilder.Start().SubGraph(child, history: true).Build();
+        }
+
+        AsyncStateMachine first = BuildParent().ToAsyncStateMachine();
+        await first.StepAsync();
+        StateMachineDeepSnapshot deep = first.SuspendDeep();
+        int compositeIndex = deep.Composites[0].NodeIndex;
+        StateMachineDeepSnapshot tampered = deep with
+        {
+            Composites = [deep.Composites[0] with { Children = [] }],
+        };
+
+        AsyncStateMachine second = BuildParent().ToAsyncStateMachine();
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => second.ResumeDeep(tampered));
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Message, Does.Contain($"composite node {compositeIndex}"));
+            Assert.That(ex.Message, Does.Contain("child snapshot"));
+        });
+    }
+
+    [Test]
+    public void resume_deep_rejects_a_done_length_mismatch()
+    {
+        Graph BuildParent()
+        {
+            return GraphBuilder
+                .Start()
+                .Parallel(ParallelStepMode.RoundPerTick,
+                    GraphBuilder.StartWith(() => Result.Success).Build(),
+                    GraphBuilder.StartWith(() => Result.Success).Build())
+                .Build();
+        }
+
+        StateMachineDeepSnapshot deep = BuildParent().ToStateMachine().SuspendDeep();
+        int compositeIndex = deep.Composites[0].NodeIndex;
+        StateMachineDeepSnapshot tampered = deep with
+        {
+            Composites = [deep.Composites[0] with { Done = [true] }],
+        };
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => BuildParent().ToStateMachine().ResumeDeep(tampered));
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Message, Does.Contain($"composite node {compositeIndex}"));
+            Assert.That(ex.Message, Does.Contain("done bit"));
+        });
+    }
+
+    [Test]
+    public async Task resume_deep_rejects_a_transient_status_child_snapshot()
+    {
+        Graph BuildParent()
+        {
+            Graph child = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+            return GraphBuilder.Start().SubGraph(child, history: true).Build();
+        }
+
+        AsyncStateMachine first = BuildParent().ToAsyncStateMachine();
+        await first.StepAsync();
+        StateMachineDeepSnapshot deep = first.SuspendDeep();
+        CompositeSnapshot entry = deep.Composites[0];
+        StateMachineDeepSnapshot tampered = deep with
+        {
+            Composites =
+            [
+                entry with
+                {
+                    Children =
+                    [
+                        entry.Children[0] with
+                        {
+                            Self = entry.Children[0].Self with { Status = ExecutionStatus.Starting },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        AsyncStateMachine second = BuildParent().ToAsyncStateMachine();
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => second.ResumeDeep(tampered));
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Message, Does.Contain($"composite node {entry.NodeIndex}"));
+            Assert.That(ex.Message, Does.Contain("transient"));
+        });
+    }
+
+    // ── Node boards stay transient at every level ─────────────────────────
+
+    [Test]
+    public void node_board_is_back_at_defaults_after_deep_resume_at_a_nested_level()
+    {
+        BlackboardSchema schema = new("deep-scratch", BlackboardScope.Node);
+        BlackboardKey<int> counter = schema.Register<int>("n");
+        List<int> seen = [];
+
+        Graph BuildParent()
+        {
+            Graph child = GraphBuilder
+                .StartWith(bb =>
+                {
+                    int n = bb.Get(counter);
+                    bb.Set(counter, n + 1);
+                    seen.Add(n);
+                    return n >= 2 ? Result.Success : Result.Failure;
+                })
+                .Retry(maxAttempts: 5)
+                .WithSchema(schema)
+                .Build();
+
+            return GraphBuilder
+                .Start()
+                .SubGraph(ParallelStepMode.RoundPerTick, child)
+                .Build();
+        }
+
+        StateMachine first = BuildParent().ToStateMachine();
+        first.Execute(); // child attempt 1: scratch 0 → 1
+        first.Execute(); // child attempt 2 (in-place retry keeps the scratch): 1 → 2
+        Assert.That(seen, Is.EqualTo(new[] { 0, 1 }));
+
+        StateMachineDeepSnapshot deep = JsonRoundTrip(first.SuspendDeep());
+
+        StateMachine second = BuildParent().ToStateMachine();
+        second.ResumeDeep(deep);
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(seen, Is.EqualTo(new[] { 0, 1, 0, 1, 2 }),
+                "The nested machine's Node scratch is transient: the deep resume restored the retry budget " +
+                "(attempts survived) but the scratch restarted from its registered default.");
+        });
+    }
+}

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -13,6 +13,12 @@ static class NxGraph.Authoring.Dsl
   method BranchBuilder To(BranchBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method BranchBuilder ToAsync(BranchBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method BranchBuilder ToAsync(BranchBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method BranchBuilder ToAsync[TIn,TOut](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method BranchBuilder ToAsync[TIn](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method BranchBuilder ToAsync[TOut](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method BranchBuilder To[TIn,TOut](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
+  method BranchBuilder To[TIn](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method BranchBuilder To[TOut](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
   method BranchBuilder WithSchema(BranchBuilder, NxGraph.Blackboards.BlackboardSchema)
   method BranchEnd Else(BranchBuilder, System.Func`1[NxGraph.Result])
   method BranchEnd Else(BranchBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
@@ -53,6 +59,15 @@ static class NxGraph.Authoring.Dsl
   method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StateToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StateToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken ToAsync[TAgent](NxGraph.Authoring.StateToken, System.Func`4[TAgent,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn,TOut](BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn,TOut](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn,TOut](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn](BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TOut](BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToAsync[TOut](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToAsync[TOut](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
   method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StartToken, System.TimeSpan, NxGraph.Graphs.ILogic, NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StartToken, System.TimeSpan, System.Func`1[NxGraph.Result], NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StateToken, System.TimeSpan, NxGraph.Graphs.ILogic, NxGraph.Fsm.TimeoutBehavior)
@@ -65,6 +80,15 @@ static class NxGraph.Authoring.Dsl
   method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, System.TimeSpan, NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken To[TAgent](NxGraph.Authoring.StateToken, System.Func`3[TAgent,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken To[TIn,TOut](BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken To[TIn,TOut](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken To[TIn,TOut](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken To[TIn](BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken To[TIn](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken To[TIn](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken To[TOut](BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken To[TOut](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken To[TOut](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
   method NxGraph.Authoring.StateToken WaitFor(NxGraph.Authoring.StartToken, System.TimeSpan)
   method NxGraph.Authoring.StateToken WaitFor(NxGraph.Authoring.StateToken, System.TimeSpan)
   method NxGraph.Authoring.StateToken WaitForAsync(NxGraph.Authoring.StartToken, System.TimeSpan)
@@ -406,6 +430,15 @@ sealed class NxGraph.Fsm.Async.AsyncParallelState : NxGraph.Blackboards.IBlackbo
   ctor Void .ctor(NxGraph.Graphs.Graph[])
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
   property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.Async.AsyncStateMachine] Regions { get; }
+sealed class NxGraph.Fsm.Async.AsyncPortConsumerRelayState`1 : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.Async.AsyncPortPipeRelayState`2 : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.Async.AsyncPortProducerRelayState`1 : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
 sealed class NxGraph.Fsm.Async.AsyncRelayState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   ctor Void .ctor(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
@@ -550,6 +583,15 @@ sealed class NxGraph.Fsm.ParallelState : NxGraph.Blackboards.IBlackboardSettable
 enum NxGraph.Fsm.ParallelStepMode : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
   RoundPerTick = 1
   RunToJoin = 0
+sealed class NxGraph.Fsm.PortConsumerRelayState`1 : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Result OnRun()
+sealed class NxGraph.Fsm.PortPipeRelayState`2 : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Result OnRun()
+sealed class NxGraph.Fsm.PortProducerRelayState`1 : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Result OnRun()
 struct NxGraph.Fsm.RegionMask : System.IEquatable`1[[NxGraph.Fsm.RegionMask, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
   method Boolean Contains(Int32)
   method Boolean Equals(NxGraph.Fsm.RegionMask)

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -11,6 +11,8 @@ static class NxGraph.Authoring.Dsl
   method BranchBuilder ThenAsync(IfBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method BranchBuilder To(BranchBuilder, System.Func`1[NxGraph.Result])
   method BranchBuilder To(BranchBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method BranchBuilder ToAll(BranchBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result][])
+  method BranchBuilder ToAllAsync(BranchBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]][])
   method BranchBuilder ToAsync(BranchBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method BranchBuilder ToAsync(BranchBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method BranchBuilder ToAsync[TIn,TOut](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
@@ -53,6 +55,12 @@ static class NxGraph.Authoring.Dsl
   method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken, System.Func`1[NxGraph.Result])
   method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken ToAll(BranchEnd, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result][])
+  method NxGraph.Authoring.StateToken ToAll(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result][])
+  method NxGraph.Authoring.StateToken ToAll(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result][])
+  method NxGraph.Authoring.StateToken ToAllAsync(BranchEnd, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]][])
+  method NxGraph.Authoring.StateToken ToAllAsync(NxGraph.Authoring.StartToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]][])
+  method NxGraph.Authoring.StateToken ToAllAsync(NxGraph.Authoring.StateToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]][])
   method NxGraph.Authoring.StateToken ToAsync(BranchEnd, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken ToAsync(BranchEnd, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StartToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
@@ -407,6 +415,12 @@ enum NxGraph.Diagnostics.Validations.Severity : System.IComparable, System.IConv
   Error = 2
   Info = 0
   Warning = 1
+sealed class NxGraph.Fsm.AllState : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result][])
+  method NxGraph.Result OnRun()
+sealed class NxGraph.Fsm.Async.AsyncAllState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]][])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
 sealed class NxGraph.Fsm.Async.AsyncChoiceState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.IAsyncDirector, NxGraph.Graphs.IAsyncLogic
   ctor Void .ctor(System.Func`1[System.Threading.Tasks.ValueTask`1[System.Boolean]], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
   ctor Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Threading.Tasks.ValueTask`1[System.Boolean]], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -422,7 +422,7 @@ sealed class NxGraph.Fsm.Async.AsyncDynamicParallelState : NxGraph.Blackboards.I
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
   property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.Async.AsyncStateMachine] Regions { get; }
   property System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask] Selector { get; }
-sealed class NxGraph.Fsm.Async.AsyncHistoryState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+sealed class NxGraph.Fsm.Async.AsyncHistoryState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
   property NxGraph.Fsm.Async.AsyncStateMachine Child { get; }
@@ -463,6 +463,7 @@ abstract class NxGraph.Fsm.Async.AsyncState : NxGraph.Blackboards.IBlackboardSet
 class NxGraph.Fsm.Async.AsyncStateMachine : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
   field readonly NxGraph.Graphs.Graph Graph
+  method NxGraph.Fsm.StateMachineDeepSnapshot SuspendDeep()
   method NxGraph.Fsm.StateMachineSnapshot Suspend()
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
@@ -470,6 +471,7 @@ class NxGraph.Fsm.Async.AsyncStateMachine : NxGraph.Fsm.Async.AsyncState, NxGrap
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] Reset(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] StepAsync(System.Threading.CancellationToken)
   method Void Resume(NxGraph.Fsm.StateMachineSnapshot)
+  method Void ResumeDeep(NxGraph.Fsm.StateMachineDeepSnapshot)
   method Void SetAutoReset(Boolean)
   method Void SetBlackboard(NxGraph.Blackboards.Blackboard)
   method Void SetRestartPolicy(NxGraph.Fsm.RestartPolicy)
@@ -507,7 +509,21 @@ sealed class NxGraph.Fsm.ChoiceState : NxGraph.Blackboards.IBlackboardSettable, 
   method NxGraph.Graphs.NodeId SelectNext()
   method NxGraph.Result Execute()
   method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
-sealed class NxGraph.Fsm.DynamicParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+sealed class NxGraph.Fsm.CompositeSnapshot : System.IEquatable`1[[NxGraph.Fsm.CompositeSnapshot, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+  ctor Void .ctor(Int32, Boolean, Boolean[], NxGraph.Fsm.StateMachineDeepSnapshot[])
+  method Boolean Equals(NxGraph.Fsm.CompositeSnapshot)
+  method Boolean Equals(System.Object)
+  method Int32 GetHashCode()
+  method NxGraph.Fsm.CompositeSnapshot <Clone>$()
+  method System.String ToString()
+  method Void Deconstruct(Int32 ByRef, Boolean ByRef, Boolean[] ByRef, NxGraph.Fsm.StateMachineDeepSnapshot[] ByRef)
+  operator Boolean op_Equality(NxGraph.Fsm.CompositeSnapshot, NxGraph.Fsm.CompositeSnapshot)
+  operator Boolean op_Inequality(NxGraph.Fsm.CompositeSnapshot, NxGraph.Fsm.CompositeSnapshot)
+  property Boolean InFlight { get; set; }
+  property Boolean[] Done { get; set; }
+  property Int32 NodeIndex { get; set; }
+  property NxGraph.Fsm.StateMachineDeepSnapshot[] Children { get; set; }
+sealed class NxGraph.Fsm.DynamicParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Fsm.ParallelStepMode, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
   method NxGraph.Result Execute()
   property NxGraph.Fsm.ParallelStepMode Mode { get; }
@@ -523,7 +539,7 @@ enum NxGraph.Fsm.ExecutionStatus : System.IComparable, System.IConvertible, Syst
   Running = 2
   Starting = 1
   Transitioning = 3
-sealed class NxGraph.Fsm.HistoryState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+sealed class NxGraph.Fsm.HistoryState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.ParallelStepMode)
   method NxGraph.Result Execute()
   property NxGraph.Fsm.ParallelStepMode Mode { get; }
@@ -557,6 +573,9 @@ interface NxGraph.Fsm.IStateMachineObserver
   method Void OnStateMachineStarted(NxGraph.Graphs.NodeId)
   method Void OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
   method Void StateMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus)
+interface NxGraph.Fsm.ISuspendableComposite
+  method NxGraph.Fsm.CompositeSnapshot SuspendComposite(Int32)
+  method Void ResumeComposite(NxGraph.Fsm.CompositeSnapshot)
 sealed class NxGraph.Fsm.NodeStatusTracker
   ctor Void .ctor()
   method NxGraph.Fsm.ExecutionStatus Get(NxGraph.Graphs.NodeId)
@@ -575,7 +594,7 @@ sealed class NxGraph.Fsm.NodeStatusTrackingObserver : NxGraph.Fsm.IAsyncStateMac
   method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
-sealed class NxGraph.Fsm.ParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+sealed class NxGraph.Fsm.ParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph[])
   method NxGraph.Result Execute()
   property NxGraph.Fsm.ParallelStepMode Mode { get; }
@@ -639,15 +658,17 @@ abstract class NxGraph.Fsm.State : NxGraph.Blackboards.IBlackboardSettable, NxGr
   method Void OnExit()
   property NxGraph.Blackboards.BlackboardContext Bb { get; }
   property System.Action`1[System.String] SyncLogReport { get; set; }
-class NxGraph.Fsm.StateMachine : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+class NxGraph.Fsm.StateMachine : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
   field readonly NxGraph.Graphs.Graph Graph
+  method NxGraph.Fsm.StateMachineDeepSnapshot SuspendDeep()
   method NxGraph.Fsm.StateMachineSnapshot Suspend()
   method NxGraph.Result OnRun()
   method NxGraph.Result Reset()
   method Void OnEnter()
   method Void OnExit()
   method Void Resume(NxGraph.Fsm.StateMachineSnapshot)
+  method Void ResumeDeep(NxGraph.Fsm.StateMachineDeepSnapshot)
   method Void SetAutoReset(Boolean)
   method Void SetBlackboard(NxGraph.Blackboards.Blackboard)
   method Void SetResetPolicy(NxGraph.Fsm.RestartPolicy)
@@ -657,6 +678,18 @@ class NxGraph.Fsm.StateMachine : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackbo
   property NxGraph.Fsm.ExecutionStatus Status { get; }
   property NxGraph.Fsm.ParallelStepMode StepMode { get; }
   property System.String LastOutcomeName { get; }
+sealed class NxGraph.Fsm.StateMachineDeepSnapshot : System.IEquatable`1[[NxGraph.Fsm.StateMachineDeepSnapshot, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+  ctor Void .ctor(NxGraph.Fsm.StateMachineSnapshot, NxGraph.Fsm.CompositeSnapshot[])
+  method Boolean Equals(NxGraph.Fsm.StateMachineDeepSnapshot)
+  method Boolean Equals(System.Object)
+  method Int32 GetHashCode()
+  method NxGraph.Fsm.StateMachineDeepSnapshot <Clone>$()
+  method System.String ToString()
+  method Void Deconstruct(NxGraph.Fsm.StateMachineSnapshot ByRef, NxGraph.Fsm.CompositeSnapshot[] ByRef)
+  operator Boolean op_Equality(NxGraph.Fsm.StateMachineDeepSnapshot, NxGraph.Fsm.StateMachineDeepSnapshot)
+  operator Boolean op_Inequality(NxGraph.Fsm.StateMachineDeepSnapshot, NxGraph.Fsm.StateMachineDeepSnapshot)
+  property NxGraph.Fsm.CompositeSnapshot[] Composites { get; set; }
+  property NxGraph.Fsm.StateMachineSnapshot Self { get; set; }
 sealed class NxGraph.Fsm.StateMachineSnapshot : System.IEquatable`1[[NxGraph.Fsm.StateMachineSnapshot, NxGraph, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
   ctor Void .ctor(Int32, NxGraph.Fsm.ExecutionStatus, Int32, Boolean, Boolean, Int32)
   method Boolean Equals(NxGraph.Fsm.StateMachineSnapshot)
@@ -673,7 +706,7 @@ sealed class NxGraph.Fsm.StateMachineSnapshot : System.IEquatable`1[[NxGraph.Fsm
   property Int32 CurrentNodeIndex { get; set; }
   property Int32 LastOutcome { get; set; }
   property NxGraph.Fsm.ExecutionStatus Status { get; set; }
-class NxGraph.Fsm.StateMachine`1 : NxGraph.Fsm.StateMachine, IAgentSettable`1, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+class NxGraph.Fsm.StateMachine`1 : NxGraph.Fsm.StateMachine, IAgentSettable`1, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
   ctor Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
   method Void SetAgent(TAgent)
 abstract class NxGraph.Fsm.State`1 : NxGraph.Fsm.State, IAgentSettable`1, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic

--- a/NxGraph/Authoring/Dsl.All.cs
+++ b/NxGraph/Authoring/Dsl.All.cs
@@ -1,0 +1,107 @@
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+
+namespace NxGraph.Authoring;
+
+public static partial class Dsl
+{
+    // ── In-node concurrency: run N works inside one node, join on all ────
+    //
+    // .ToAllAsync(...) is the wall-clock concurrency primitive: none of the fan-out
+    // constructs (parallel regions, token fork/join) overlap in time — they structure
+    // logic via cooperative interleaving. Overlapping I/O belongs inside a single node.
+
+    /// <summary>
+    /// Starts the graph with a node that runs all <paramref name="works"/> <b>concurrently</b>
+    /// (each started with the node's own <see cref="CancellationToken"/>, all awaited) and joins
+    /// on the combined result: <c>Success</c> iff every work returned <c>Success</c>, else
+    /// <c>Failure</c>. This is the recommended shape for overlapping I/O — parallel regions and
+    /// token fork/join interleave cooperatively and never overlap in time.
+    /// <para>
+    /// No early abort: a failing work does not cancel its siblings — all works run to completion
+    /// before the results combine, so partial effects are never timing-dependent and a per-node
+    /// <c>.Retry(...)</c> re-runs all works. A throwing work propagates its exception after all
+    /// works settle (first exception, <c>WhenAll</c> semantics); cancelling the machine's token
+    /// cancels all works.
+    /// </para>
+    /// <para>
+    /// <b>Disjoint-keys contract:</b> the works share one routed <see cref="BlackboardContext"/>,
+    /// which is not thread-safe — concurrent works must touch <b>disjoint</b> keys. Same-key
+    /// access from two works is a data race; distinct keys write to distinct slots and are
+    /// genuinely safe. The recommended shape is one Graph-scoped output port per work, combined
+    /// by the next node. An empty or null works array throws <see cref="ArgumentException"/> at
+    /// wiring time, as does a null entry; a single work is legal (it degenerates to
+    /// <c>ToAsync</c>).
+    /// </para>
+    /// </summary>
+    public static StateToken ToAllAsync(this StartToken token,
+        params Func<BlackboardContext, CancellationToken, ValueTask<Result>>[] works)
+    {
+        return token.ToAsync(new AsyncAllState(works));
+    }
+
+    /// <inheritdoc cref="ToAllAsync(StartToken, Func{BlackboardContext, CancellationToken, ValueTask{Result}}[])"/>
+    public static StateToken ToAllAsync(this StateToken prev,
+        params Func<BlackboardContext, CancellationToken, ValueTask<Result>>[] works)
+    {
+        return prev.ToAsync(new AsyncAllState(works));
+    }
+
+    /// <inheritdoc cref="ToAllAsync(StartToken, Func{BlackboardContext, CancellationToken, ValueTask{Result}}[])"/>
+    public static BranchBuilder ToAllAsync(this BranchBuilder branch,
+        params Func<BlackboardContext, CancellationToken, ValueTask<Result>>[] works)
+    {
+        return branch.ToAsync(new AsyncAllState(works));
+    }
+
+    /// <inheritdoc cref="ToAllAsync(StartToken, Func{BlackboardContext, CancellationToken, ValueTask{Result}}[])"/>
+    public static StateToken ToAllAsync(this BranchEnd branchEnd,
+        params Func<BlackboardContext, CancellationToken, ValueTask<Result>>[] works)
+    {
+        return branchEnd.ToAsync(new AsyncAllState(works));
+    }
+
+    /// <summary>
+    /// Starts the graph with the sync twin of
+    /// <see cref="ToAllAsync(StartToken, Func{BlackboardContext, CancellationToken, ValueTask{Result}}[])"/>:
+    /// all <paramref name="works"/> run <b>sequentially, in order</b>, within one tick, and the
+    /// results combine identically — <c>Success</c> iff every work returned <c>Success</c>, else
+    /// <c>Failure</c>. Wall-clock overlap is an async-only mechanic; the join semantics are the
+    /// same, including no early abort: all works always run, even after an early <c>Failure</c>,
+    /// so a graph moved between runtimes sees the same board effects. The node is plain
+    /// <see cref="Fsm.ILogic"/> and also runs under the async machine via the sync-logic adapter.
+    /// <para>
+    /// The disjoint-keys contract of the async twin is not load-bearing here (works never
+    /// overlap), but keeping each work on its own keys makes the graph portable to
+    /// <c>ToAllAsync</c>. An empty or null works array throws <see cref="ArgumentException"/> at
+    /// wiring time, as does a null entry; a single work is legal.
+    /// </para>
+    /// </summary>
+    public static StateToken ToAll(this StartToken token,
+        params Func<BlackboardContext, Result>[] works)
+    {
+        return token.To(new AllState(works));
+    }
+
+    /// <inheritdoc cref="ToAll(StartToken, Func{BlackboardContext, Result}[])"/>
+    public static StateToken ToAll(this StateToken prev,
+        params Func<BlackboardContext, Result>[] works)
+    {
+        return prev.To(new AllState(works));
+    }
+
+    /// <inheritdoc cref="ToAll(StartToken, Func{BlackboardContext, Result}[])"/>
+    public static BranchBuilder ToAll(this BranchBuilder branch,
+        params Func<BlackboardContext, Result>[] works)
+    {
+        return branch.To(new AllState(works));
+    }
+
+    /// <inheritdoc cref="ToAll(StartToken, Func{BlackboardContext, Result}[])"/>
+    public static StateToken ToAll(this BranchEnd branchEnd,
+        params Func<BlackboardContext, Result>[] works)
+    {
+        return branchEnd.To(new AllState(works));
+    }
+}

--- a/NxGraph/Authoring/Dsl.Ports.cs
+++ b/NxGraph/Authoring/Dsl.Ports.cs
@@ -1,0 +1,308 @@
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+
+namespace NxGraph.Authoring;
+
+public static partial class Dsl
+{
+    // ── Step I/O ports: typed produce → pipe → consume sugar over the blackboard ──
+    //
+    // A "port" is an ordinary Graph-scoped BlackboardKey<T> — no wrapper type. These
+    // overloads only read/write ports around the step lambda; routing, validation, and
+    // durability are the blackboard's existing machinery.
+
+    private static void ThrowIfNotPortScope<T>(in BlackboardKey<T> key, string paramName)
+    {
+        if (key.Schema is null)
+        {
+            throw new ArgumentException(
+                "Invalid port key — obtain keys via BlackboardSchema.Register<T>(...) on a Graph-scoped schema.",
+                paramName);
+        }
+
+        if (key.Schema.Scope == BlackboardScope.Node)
+        {
+            throw new ArgumentException(
+                $"Port key '{key.Name}' is Node-scoped — Node scratch resets on the success transition, " +
+                "so the value would be gone before the consumer runs. Register step I/O ports on a " +
+                "Graph-scoped schema.", paramName);
+        }
+    }
+
+    // ── Start relays ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Starts the graph with a port-producing step: the lambda computes a value from the
+    /// machine-bound routed blackboard context, the relay writes it to
+    /// <paramref name="output"/> and returns <c>Success</c>. A port is an ordinary
+    /// Graph-scoped <see cref="BlackboardKey{T}"/> — one key per producing step, named for
+    /// the datum, not the step (several steps may legally produce the same port). Declare its
+    /// schema on the graph via <c>WithSchema(...)</c> and bind a board per machine via
+    /// <c>WithBlackboard(...)</c>, so one graph template serves N machines with distinct
+    /// port values.
+    /// <para>
+    /// Producer steps cannot fail — the relay always succeeds after the write. A step that
+    /// can fail keeps using <c>To(Func&lt;BlackboardContext, Result&gt;)</c> with an explicit
+    /// <c>bb.Set(...)</c> on its success path; exceptions propagate as from any relay.
+    /// Node-scoped keys are rejected at wiring time (their value resets before the consumer
+    /// runs). Global-scoped keys are allowed but shared across machines — two machines over
+    /// one template overwrite each other's values, so prefer Graph scope.
+    /// </para>
+    /// </summary>
+    public static StateToken To<TOut>(this StartToken token, BlackboardKey<TOut> output,
+        Func<BlackboardContext, TOut> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(output, nameof(output));
+        return token.To(new PortProducerRelayState<TOut>(output, step));
+    }
+
+    /// <inheritdoc cref="To{TOut}(StartToken, BlackboardKey{TOut}, Func{BlackboardContext, TOut})"/>
+    public static StateToken ToAsync<TOut>(this StartToken token, BlackboardKey<TOut> output,
+        Func<BlackboardContext, CancellationToken, ValueTask<TOut>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(output, nameof(output));
+        return token.ToAsync(new AsyncPortProducerRelayState<TOut>(output, step));
+    }
+
+    /// <summary>
+    /// Starts the graph with a port-consuming step: the relay reads <paramref name="input"/>
+    /// and hands the value (plus the routed context) to the lambda, returning its result.
+    /// A consumer that can run before any producer sees the key's registered default —
+    /// register a meaningful default or guard in the step. Node-scoped keys are rejected at
+    /// wiring time; Global-scoped keys are allowed but shared across machines — prefer
+    /// Graph scope.
+    /// </summary>
+    public static StateToken To<TIn>(this StartToken token, BlackboardKey<TIn> input,
+        Func<TIn, BlackboardContext, Result> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        return token.To(new PortConsumerRelayState<TIn>(input, step));
+    }
+
+    /// <inheritdoc cref="To{TIn}(StartToken, BlackboardKey{TIn}, Func{TIn, BlackboardContext, Result})"/>
+    public static StateToken ToAsync<TIn>(this StartToken token, BlackboardKey<TIn> input,
+        Func<TIn, BlackboardContext, CancellationToken, ValueTask<Result>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        return token.ToAsync(new AsyncPortConsumerRelayState<TIn>(input, step));
+    }
+
+    /// <summary>
+    /// Starts the graph with a port-piping step: the relay reads <paramref name="input"/>,
+    /// hands the value (plus the routed context) to the lambda, writes the transformed value
+    /// to <paramref name="output"/>, and returns <c>Success</c>. Pipe steps cannot fail —
+    /// a step that can keeps using <c>To(Func&lt;BlackboardContext, Result&gt;)</c> with
+    /// explicit <c>Get</c>/<c>Set</c>. Node-scoped keys are rejected at wiring time;
+    /// Global-scoped keys are allowed but shared across machines — prefer Graph scope.
+    /// </summary>
+    public static StateToken To<TIn, TOut>(this StartToken token, BlackboardKey<TIn> input,
+        BlackboardKey<TOut> output, Func<TIn, BlackboardContext, TOut> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        ThrowIfNotPortScope(output, nameof(output));
+        return token.To(new PortPipeRelayState<TIn, TOut>(input, output, step));
+    }
+
+    /// <inheritdoc cref="To{TIn, TOut}(StartToken, BlackboardKey{TIn}, BlackboardKey{TOut}, Func{TIn, BlackboardContext, TOut})"/>
+    public static StateToken ToAsync<TIn, TOut>(this StartToken token, BlackboardKey<TIn> input,
+        BlackboardKey<TOut> output, Func<TIn, BlackboardContext, CancellationToken, ValueTask<TOut>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        ThrowIfNotPortScope(output, nameof(output));
+        return token.ToAsync(new AsyncPortPipeRelayState<TIn, TOut>(input, output, step));
+    }
+
+    // ── Chain relays ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Chains a port-producing step (see
+    /// <see cref="To{TOut}(StartToken, BlackboardKey{TOut}, Func{BlackboardContext, TOut})"/>).
+    /// </summary>
+    /// <inheritdoc cref="To{TOut}(StartToken, BlackboardKey{TOut}, Func{BlackboardContext, TOut})"/>
+    public static StateToken To<TOut>(this StateToken prev, BlackboardKey<TOut> output,
+        Func<BlackboardContext, TOut> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(output, nameof(output));
+        return prev.To(new PortProducerRelayState<TOut>(output, step));
+    }
+
+    /// <inheritdoc cref="To{TOut}(StartToken, BlackboardKey{TOut}, Func{BlackboardContext, TOut})"/>
+    public static StateToken ToAsync<TOut>(this StateToken prev, BlackboardKey<TOut> output,
+        Func<BlackboardContext, CancellationToken, ValueTask<TOut>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(output, nameof(output));
+        return prev.ToAsync(new AsyncPortProducerRelayState<TOut>(output, step));
+    }
+
+    /// <summary>
+    /// Chains a port-consuming step (see
+    /// <see cref="To{TIn}(StartToken, BlackboardKey{TIn}, Func{TIn, BlackboardContext, Result})"/>).
+    /// </summary>
+    /// <inheritdoc cref="To{TIn}(StartToken, BlackboardKey{TIn}, Func{TIn, BlackboardContext, Result})"/>
+    public static StateToken To<TIn>(this StateToken prev, BlackboardKey<TIn> input,
+        Func<TIn, BlackboardContext, Result> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        return prev.To(new PortConsumerRelayState<TIn>(input, step));
+    }
+
+    /// <inheritdoc cref="To{TIn}(StartToken, BlackboardKey{TIn}, Func{TIn, BlackboardContext, Result})"/>
+    public static StateToken ToAsync<TIn>(this StateToken prev, BlackboardKey<TIn> input,
+        Func<TIn, BlackboardContext, CancellationToken, ValueTask<Result>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        return prev.ToAsync(new AsyncPortConsumerRelayState<TIn>(input, step));
+    }
+
+    /// <summary>
+    /// Chains a port-piping step (see
+    /// <see cref="To{TIn, TOut}(StartToken, BlackboardKey{TIn}, BlackboardKey{TOut}, Func{TIn, BlackboardContext, TOut})"/>).
+    /// </summary>
+    /// <inheritdoc cref="To{TIn, TOut}(StartToken, BlackboardKey{TIn}, BlackboardKey{TOut}, Func{TIn, BlackboardContext, TOut})"/>
+    public static StateToken To<TIn, TOut>(this StateToken prev, BlackboardKey<TIn> input,
+        BlackboardKey<TOut> output, Func<TIn, BlackboardContext, TOut> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        ThrowIfNotPortScope(output, nameof(output));
+        return prev.To(new PortPipeRelayState<TIn, TOut>(input, output, step));
+    }
+
+    /// <inheritdoc cref="To{TIn, TOut}(StartToken, BlackboardKey{TIn}, BlackboardKey{TOut}, Func{TIn, BlackboardContext, TOut})"/>
+    public static StateToken ToAsync<TIn, TOut>(this StateToken prev, BlackboardKey<TIn> input,
+        BlackboardKey<TOut> output, Func<TIn, BlackboardContext, CancellationToken, ValueTask<TOut>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        ThrowIfNotPortScope(output, nameof(output));
+        return prev.ToAsync(new AsyncPortPipeRelayState<TIn, TOut>(input, output, step));
+    }
+
+    // ── "Then" branch relays ─────────────────────────────────────────────
+
+    /// <inheritdoc cref="To{TOut}(StartToken, BlackboardKey{TOut}, Func{BlackboardContext, TOut})"/>
+    public static BranchBuilder To<TOut>(this BranchBuilder branch, BlackboardKey<TOut> output,
+        Func<BlackboardContext, TOut> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(output, nameof(output));
+        return branch.To(new PortProducerRelayState<TOut>(output, step));
+    }
+
+    /// <inheritdoc cref="To{TOut}(StartToken, BlackboardKey{TOut}, Func{BlackboardContext, TOut})"/>
+    public static BranchBuilder ToAsync<TOut>(this BranchBuilder branch, BlackboardKey<TOut> output,
+        Func<BlackboardContext, CancellationToken, ValueTask<TOut>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(output, nameof(output));
+        return branch.ToAsync(new AsyncPortProducerRelayState<TOut>(output, step));
+    }
+
+    /// <inheritdoc cref="To{TIn}(StartToken, BlackboardKey{TIn}, Func{TIn, BlackboardContext, Result})"/>
+    public static BranchBuilder To<TIn>(this BranchBuilder branch, BlackboardKey<TIn> input,
+        Func<TIn, BlackboardContext, Result> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        return branch.To(new PortConsumerRelayState<TIn>(input, step));
+    }
+
+    /// <inheritdoc cref="To{TIn}(StartToken, BlackboardKey{TIn}, Func{TIn, BlackboardContext, Result})"/>
+    public static BranchBuilder ToAsync<TIn>(this BranchBuilder branch, BlackboardKey<TIn> input,
+        Func<TIn, BlackboardContext, CancellationToken, ValueTask<Result>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        return branch.ToAsync(new AsyncPortConsumerRelayState<TIn>(input, step));
+    }
+
+    /// <inheritdoc cref="To{TIn, TOut}(StartToken, BlackboardKey{TIn}, BlackboardKey{TOut}, Func{TIn, BlackboardContext, TOut})"/>
+    public static BranchBuilder To<TIn, TOut>(this BranchBuilder branch, BlackboardKey<TIn> input,
+        BlackboardKey<TOut> output, Func<TIn, BlackboardContext, TOut> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        ThrowIfNotPortScope(output, nameof(output));
+        return branch.To(new PortPipeRelayState<TIn, TOut>(input, output, step));
+    }
+
+    /// <inheritdoc cref="To{TIn, TOut}(StartToken, BlackboardKey{TIn}, BlackboardKey{TOut}, Func{TIn, BlackboardContext, TOut})"/>
+    public static BranchBuilder ToAsync<TIn, TOut>(this BranchBuilder branch, BlackboardKey<TIn> input,
+        BlackboardKey<TOut> output, Func<TIn, BlackboardContext, CancellationToken, ValueTask<TOut>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        ThrowIfNotPortScope(output, nameof(output));
+        return branch.ToAsync(new AsyncPortPipeRelayState<TIn, TOut>(input, output, step));
+    }
+
+    // ── Post-"else" relays ───────────────────────────────────────────────
+
+    /// <inheritdoc cref="To{TOut}(StartToken, BlackboardKey{TOut}, Func{BlackboardContext, TOut})"/>
+    public static StateToken To<TOut>(this BranchEnd branchEnd, BlackboardKey<TOut> output,
+        Func<BlackboardContext, TOut> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(output, nameof(output));
+        return branchEnd.To(new PortProducerRelayState<TOut>(output, step));
+    }
+
+    /// <inheritdoc cref="To{TOut}(StartToken, BlackboardKey{TOut}, Func{BlackboardContext, TOut})"/>
+    public static StateToken ToAsync<TOut>(this BranchEnd branchEnd, BlackboardKey<TOut> output,
+        Func<BlackboardContext, CancellationToken, ValueTask<TOut>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(output, nameof(output));
+        return branchEnd.ToAsync(new AsyncPortProducerRelayState<TOut>(output, step));
+    }
+
+    /// <inheritdoc cref="To{TIn}(StartToken, BlackboardKey{TIn}, Func{TIn, BlackboardContext, Result})"/>
+    public static StateToken To<TIn>(this BranchEnd branchEnd, BlackboardKey<TIn> input,
+        Func<TIn, BlackboardContext, Result> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        return branchEnd.To(new PortConsumerRelayState<TIn>(input, step));
+    }
+
+    /// <inheritdoc cref="To{TIn}(StartToken, BlackboardKey{TIn}, Func{TIn, BlackboardContext, Result})"/>
+    public static StateToken ToAsync<TIn>(this BranchEnd branchEnd, BlackboardKey<TIn> input,
+        Func<TIn, BlackboardContext, CancellationToken, ValueTask<Result>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        return branchEnd.ToAsync(new AsyncPortConsumerRelayState<TIn>(input, step));
+    }
+
+    /// <inheritdoc cref="To{TIn, TOut}(StartToken, BlackboardKey{TIn}, BlackboardKey{TOut}, Func{TIn, BlackboardContext, TOut})"/>
+    public static StateToken To<TIn, TOut>(this BranchEnd branchEnd, BlackboardKey<TIn> input,
+        BlackboardKey<TOut> output, Func<TIn, BlackboardContext, TOut> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        ThrowIfNotPortScope(output, nameof(output));
+        return branchEnd.To(new PortPipeRelayState<TIn, TOut>(input, output, step));
+    }
+
+    /// <inheritdoc cref="To{TIn, TOut}(StartToken, BlackboardKey{TIn}, BlackboardKey{TOut}, Func{TIn, BlackboardContext, TOut})"/>
+    public static StateToken ToAsync<TIn, TOut>(this BranchEnd branchEnd, BlackboardKey<TIn> input,
+        BlackboardKey<TOut> output, Func<TIn, BlackboardContext, CancellationToken, ValueTask<TOut>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        ThrowIfNotPortScope(input, nameof(input));
+        ThrowIfNotPortScope(output, nameof(output));
+        return branchEnd.ToAsync(new AsyncPortPipeRelayState<TIn, TOut>(input, output, step));
+    }
+}

--- a/NxGraph/Fsm/AllState.cs
+++ b/NxGraph/Fsm/AllState.cs
@@ -1,0 +1,61 @@
+using NxGraph.Blackboards;
+using NxGraph.Fsm.Async;
+
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// Synchronous counterpart of <see cref="AsyncAllState"/>: runs N independent works
+/// sequentially, in declaration order, within one <see cref="State.Execute"/> call and joins
+/// on all of them — <c>Success</c> iff every work returned <c>Success</c>, else <c>Failure</c>.
+/// Wall-clock overlap is an async-only mechanic (like retry backoff); the essence — N works,
+/// one node, all-succeed join — is identical, so a graph moved between runtimes sees the same
+/// board effects.
+/// <para>
+/// All works always run, even after an early <c>Failure</c> — the same no-early-abort
+/// semantics as the async twin — and a per-node <c>.Retry(...)</c> re-runs all works. Each
+/// work receives the machine-bound routed <see cref="BlackboardContext"/>; the disjoint-keys
+/// contract of the async twin is not load-bearing here (works never overlap) but keeping it
+/// makes the graph portable to <c>.ToAllAsync</c>. Allocation-free per tick: the works array
+/// is construction-time state. Being <see cref="ILogic"/>, this node also runs under the
+/// async machine via the sync-logic adapter.
+/// </para>
+/// </summary>
+public sealed class AllState : State
+{
+    private readonly Func<BlackboardContext, Result>[] _works;
+
+    /// <param name="works">The works to run in order. At least one is required (a single
+    /// work degenerates to an ordinary relay); null entries are rejected.</param>
+    public AllState(params Func<BlackboardContext, Result>[] works)
+    {
+        if (works is null || works.Length == 0)
+        {
+            throw new ArgumentException("At least one work is required.", nameof(works));
+        }
+
+        foreach (Func<BlackboardContext, Result>? work in works)
+        {
+            if (work is null)
+            {
+                throw new ArgumentException("Works must not contain null entries.", nameof(works));
+            }
+        }
+
+        _works = works;
+    }
+
+    protected override Result OnRun()
+    {
+        bool allSucceeded = true;
+        Func<BlackboardContext, Result>[] works = _works;
+        for (int i = 0; i < works.Length; i++)
+        {
+            if (works[i](Bb) != Result.Success)
+            {
+                allSucceeded = false;
+            }
+        }
+
+        return allSucceeded ? Result.Success : Result.Failure;
+    }
+}

--- a/NxGraph/Fsm/Async/AsyncAllState.cs
+++ b/NxGraph/Fsm/Async/AsyncAllState.cs
@@ -1,0 +1,78 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Fsm.Async;
+
+/// <summary>
+/// Runs N independent async works truly concurrently inside one node and joins on all of them:
+/// every work is started with the node's own <see cref="CancellationToken"/>, all are awaited
+/// (<see cref="Task.WhenAll(Task[])"/> over the materialized tasks), and the results combine
+/// afterwards — <c>Success</c> iff every work returned <c>Success</c>, else <c>Failure</c>.
+/// This is the wall-clock concurrency primitive: regions structure logic, nodes structure time.
+/// <para>
+/// A failing work does <b>not</b> cancel its siblings — all works run to completion and the
+/// result is combined afterwards, so partial effects are never timing-dependent and a per-node
+/// <c>.Retry(...)</c> re-runs all works. A throwing work propagates its exception out of the
+/// node after all works settle (first exception, <c>WhenAll</c> semantics); cancelling the
+/// machine's token cancels all works. Each work receives the machine-bound routed
+/// <see cref="BlackboardContext"/>: concurrent works must touch <b>disjoint</b> keys — same-key
+/// access from two works is a data race, while distinct keys write to distinct slots and are
+/// genuinely safe.
+/// </para>
+/// </summary>
+public sealed class AsyncAllState : AsyncState
+{
+    private readonly Func<BlackboardContext, CancellationToken, ValueTask<Result>>[] _works;
+
+    /// <param name="works">The works to run concurrently. At least one is required (a single
+    /// work degenerates to an ordinary async relay); null entries are rejected.</param>
+    public AsyncAllState(params Func<BlackboardContext, CancellationToken, ValueTask<Result>>[] works)
+    {
+        if (works is null || works.Length == 0)
+        {
+            throw new ArgumentException("At least one work is required.", nameof(works));
+        }
+
+        foreach (Func<BlackboardContext, CancellationToken, ValueTask<Result>>? work in works)
+        {
+            if (work is null)
+            {
+                throw new ArgumentException("Works must not contain null entries.", nameof(works));
+            }
+        }
+
+        _works = works;
+    }
+
+    protected override async ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        Task<Result>[] tasks = new Task<Result>[_works.Length];
+        for (int i = 0; i < _works.Length; i++)
+        {
+            tasks[i] = RunWork(_works[i], Bb, ct);
+        }
+
+        Result[] results = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        foreach (Result result in results)
+        {
+            if (result != Result.Success)
+            {
+                return Result.Failure;
+            }
+        }
+
+        return Result.Success;
+    }
+
+    /// <summary>
+    /// Materializes one work as a task so that a synchronously-throwing work faults its task
+    /// instead of aborting the start loop — every sibling still starts, and the exception
+    /// propagates only after all works settle.
+    /// </summary>
+    private static async Task<Result> RunWork(
+        Func<BlackboardContext, CancellationToken, ValueTask<Result>> work,
+        BlackboardContext bb, CancellationToken ct)
+    {
+        return await work(bb, ct).ConfigureAwait(false);
+    }
+}

--- a/NxGraph/Fsm/Async/AsyncCompositeState.cs
+++ b/NxGraph/Fsm/Async/AsyncCompositeState.cs
@@ -7,6 +7,14 @@ namespace NxGraph.Fsm.Async;
 /// A composite state that contains a single child node. Surfaces the child's sub-graphs via
 /// <see cref="ISubGraphProvider"/> and forwards the blackboard context, so agent and
 /// blackboard stamping reach wrapped machines instead of stopping at this wrapper.
+/// <para>
+/// Deep suspend cannot capture an arbitrary <see cref="IAsyncLogic"/> child generically, so
+/// this base contributes nothing to a <see cref="StateMachineDeepSnapshot"/> and re-enters
+/// fresh after a deep resume. Subclasses (and custom containers) that hold durable position
+/// opt in by implementing <see cref="ISuspendableComposite"/> — the third leg of the
+/// container contract beside <see cref="ISubGraphProvider"/> and
+/// <see cref="IBlackboardSettable"/> forwarding.
+/// </para>
 /// </summary>
 /// <param name="child">The child node to execute.</param>
 public class AsyncCompositeState(IAsyncLogic child) : AsyncState, ISubGraphProvider, IBlackboardSettable

--- a/NxGraph/Fsm/Async/AsyncDynamicParallelState.cs
+++ b/NxGraph/Fsm/Async/AsyncDynamicParallelState.cs
@@ -26,6 +26,13 @@ namespace NxGraph.Fsm.Async;
 /// every region machine itself. Agent stamping still reaches regions via
 /// <see cref="ISubGraphProvider"/>.
 /// </para>
+/// <para>
+/// Deliberately does <b>not</b> implement <see cref="ISuspendableComposite"/>: like
+/// <see cref="AsyncParallelState"/>, every execution evaluates the selector, runs the
+/// selected regions to terminal inside one <c>ExecuteAsync</c>, and keeps no durable visit
+/// or cross-visit state at a parent step boundary — there is nothing for a deep snapshot to
+/// capture, and its absence from one is correct, not a gap.
+/// </para>
 /// </summary>
 public sealed class AsyncDynamicParallelState : IAsyncLogic, ISubGraphProvider, IBlackboardSettable
 {

--- a/NxGraph/Fsm/Async/AsyncHistoryState.cs
+++ b/NxGraph/Fsm/Async/AsyncHistoryState.cs
@@ -19,7 +19,7 @@ namespace NxGraph.Fsm.Async;
 /// only on the failure-recovery path, which is off the hot loop by definition.
 /// </para>
 /// </summary>
-public sealed class AsyncHistoryState : IAsyncLogic, ISubGraphProvider, IBlackboardSettable
+public sealed class AsyncHistoryState : IAsyncLogic, ISubGraphProvider, IBlackboardSettable, ISuspendableComposite
 {
     /// <summary>The wrapped child machine.</summary>
     public AsyncStateMachine Child { get; }
@@ -41,6 +41,25 @@ public sealed class AsyncHistoryState : IAsyncLogic, ISubGraphProvider, IBlackbo
         // Manual keeps the child's position (current node) intact after a failure instead of
         // auto-resetting to the start — that position is exactly the history to resume from.
         Child.SetRestartPolicy(RestartPolicy.Manual);
+    }
+
+    // ── ISuspendableComposite ─────────────────────────────────────────────
+    // History's memory *is* the child machine's terminal position, kept live under
+    // RestartPolicy.Manual. Capturing the child's deep snapshot (Failed status included —
+    // machine Suspend rejects only transient statuses) preserves exactly the shape the
+    // re-entry lift in ExecuteAsync consumes, so a deep-resumed fresh machine re-enters
+    // at the remembered node with no new lift logic. Async composites are never mid-visit
+    // at a parent step boundary, so InFlight is always false here.
+
+    CompositeSnapshot ISuspendableComposite.SuspendComposite(int nodeIndex)
+    {
+        return new CompositeSnapshot(nodeIndex, InFlight: false, Done: [], Children: [Child.SuspendDeep()]);
+    }
+
+    void ISuspendableComposite.ResumeComposite(CompositeSnapshot snapshot)
+    {
+        DeepSnapshots.ValidateShape(snapshot, expectedChildren: 1, expectedDoneBits: 0);
+        DeepSnapshots.ResumeChild(Child, snapshot, 0);
     }
 
     public async ValueTask<Result> ExecuteAsync(CancellationToken ct = default)

--- a/NxGraph/Fsm/Async/AsyncParallelState.cs
+++ b/NxGraph/Fsm/Async/AsyncParallelState.cs
@@ -18,6 +18,13 @@ namespace NxGraph.Fsm.Async;
 /// gives AND-state semantics at 0 B per step, which covers the game/agent use cases this
 /// library targets; run truly CPU-parallel work inside a single node instead.
 /// </para>
+/// <para>
+/// Deliberately does <b>not</b> implement <see cref="ISuspendableComposite"/>: every
+/// execution runs all regions to terminal inside one <c>ExecuteAsync</c> and resets its
+/// bookkeeping on entry, so the composite holds no durable visit or cross-visit state at a
+/// parent step boundary — there is nothing for a deep snapshot to capture, and its absence
+/// from one is correct, not a gap.
+/// </para>
 /// </summary>
 public sealed class AsyncParallelState : IAsyncLogic, ISubGraphProvider, IBlackboardSettable
 {

--- a/NxGraph/Fsm/Async/AsyncPortRelayStates.cs
+++ b/NxGraph/Fsm/Async/AsyncPortRelayStates.cs
@@ -1,0 +1,73 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Fsm.Async;
+
+/// <summary>
+/// Port-producing relay: runs the step with the machine-bound routed context, writes its value
+/// to the output port (an ordinary <see cref="BlackboardKey{T}"/>), and returns <c>Success</c>.
+/// The step cannot fail — a step that can must use the plain context relay with an explicit
+/// <c>Set</c>. Steps completing synchronously keep the hot path allocation-free.
+/// </summary>
+public sealed class AsyncPortProducerRelayState<TOut> : AsyncState
+{
+    private readonly BlackboardKey<TOut> _output;
+    private readonly Func<BlackboardContext, CancellationToken, ValueTask<TOut>> _step;
+
+    public AsyncPortProducerRelayState(BlackboardKey<TOut> output,
+        Func<BlackboardContext, CancellationToken, ValueTask<TOut>> step)
+    {
+        _output = output;
+        _step = step ?? throw new ArgumentNullException(nameof(step));
+    }
+
+    protected override async ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        Bb.Set(_output, await _step(Bb, ct).ConfigureAwait(false));
+        return Result.Success;
+    }
+}
+
+/// <summary>
+/// Port-consuming relay: reads the input port and hands the value (plus the routed context)
+/// to the step, returning its result.
+/// </summary>
+public sealed class AsyncPortConsumerRelayState<TIn> : AsyncState
+{
+    private readonly BlackboardKey<TIn> _input;
+    private readonly Func<TIn, BlackboardContext, CancellationToken, ValueTask<Result>> _step;
+
+    public AsyncPortConsumerRelayState(BlackboardKey<TIn> input,
+        Func<TIn, BlackboardContext, CancellationToken, ValueTask<Result>> step)
+    {
+        _input = input;
+        _step = step ?? throw new ArgumentNullException(nameof(step));
+    }
+
+    protected override ValueTask<Result> OnRunAsync(CancellationToken ct) => _step(Bb.Get(_input), Bb, ct);
+}
+
+/// <summary>
+/// Port-piping relay: reads the input port, transforms, writes the output port, and returns
+/// <c>Success</c>. The step cannot fail — a step that can must use the plain context relay
+/// with an explicit <c>Set</c>.
+/// </summary>
+public sealed class AsyncPortPipeRelayState<TIn, TOut> : AsyncState
+{
+    private readonly BlackboardKey<TIn> _input;
+    private readonly BlackboardKey<TOut> _output;
+    private readonly Func<TIn, BlackboardContext, CancellationToken, ValueTask<TOut>> _step;
+
+    public AsyncPortPipeRelayState(BlackboardKey<TIn> input, BlackboardKey<TOut> output,
+        Func<TIn, BlackboardContext, CancellationToken, ValueTask<TOut>> step)
+    {
+        _input = input;
+        _output = output;
+        _step = step ?? throw new ArgumentNullException(nameof(step));
+    }
+
+    protected override async ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        Bb.Set(_output, await _step(Bb.Get(_input), Bb, ct).ConfigureAwait(false));
+        return Result.Success;
+    }
+}

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -553,6 +553,42 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
     }
 
     /// <summary>
+    /// Deep variant of <see cref="Suspend"/>: captures this machine's position plus the
+    /// internal state of every composite in its graph that holds durable state (nested
+    /// machine positions, history's remembered child position, sync RoundPerTick mid-visit
+    /// bookkeeping) into a <see cref="StateMachineDeepSnapshot"/>. Same gates as
+    /// <see cref="Suspend"/>; the extra cost is one linear walk over the graph's nodes plus
+    /// the composites' own recursive captures — cold path by contract, allocation is expected.
+    /// The shallow pair and <see cref="StateMachineSnapshot"/> are untouched; use them when
+    /// flows keep suspension points at the top level.
+    /// </summary>
+    public StateMachineDeepSnapshot SuspendDeep()
+    {
+        StateMachineSnapshot self = Suspend();
+        return new StateMachineDeepSnapshot(self, DeepSnapshots.Capture(Graph));
+    }
+
+    /// <summary>
+    /// Restores a snapshot produced by <see cref="SuspendDeep"/> onto this machine: first the
+    /// machine's own position via <see cref="Resume"/> (all its gates and checks apply
+    /// unchanged), then each captured composite via
+    /// <see cref="ISuspendableComposite.ResumeComposite"/> after validating that the claimed
+    /// node exists and implements the interface. A composite node absent from
+    /// <see cref="StateMachineDeepSnapshot.Composites"/> re-enters fresh (sparse capture).
+    /// Node-scoped scratch resumes as defaults at every nesting level.
+    /// </summary>
+    public void ResumeDeep(StateMachineDeepSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        Resume(snapshot.Self);
+        DeepSnapshots.ResumeComposites(Graph, snapshot.Composites);
+    }
+
+    /// <summary>
     /// Advances the machine by exactly one node execution, mirroring the sync machine's
     /// frame-stepped <c>Execute()</c>. Returns <see cref="Result.InProgress"/> while more nodes
     /// remain and the terminal result when the run finishes. The first call begins a run

--- a/NxGraph/Fsm/DynamicParallelState.cs
+++ b/NxGraph/Fsm/DynamicParallelState.cs
@@ -8,7 +8,9 @@ namespace NxGraph.Fsm;
 /// Sync twin of <see cref="Async.AsyncDynamicParallelState"/> (runtime parity): at the start
 /// of each visit a selector reads the machine-bound <see cref="BlackboardContext"/> and
 /// returns a <see cref="RegionMask"/> deciding which region graphs run. Only selected regions
-/// are stepped; unselected regions are never stepped and never reset. Join semantics match
+/// are stepped; unselected regions are never stepped (a region left terminal by an earlier
+/// visit is reset on the next visit's first tick, selected or not, so stale results never
+/// leak across visits). Join semantics match
 /// <see cref="ParallelState"/>: <see cref="Result.Success"/> only when every selected region
 /// succeeded, else <see cref="Result.Failure"/> through the parent's unified fault model.
 /// <para>
@@ -20,7 +22,7 @@ namespace NxGraph.Fsm;
 /// (compose with <see cref="RegionMask.Bit"/> and <c>|</c>, or precompute masks at setup).
 /// </para>
 /// </summary>
-public sealed class DynamicParallelState : ILogic, ISubGraphProvider, IBlackboardSettable
+public sealed class DynamicParallelState : ILogic, ISubGraphProvider, IBlackboardSettable, ISuspendableComposite
 {
     private readonly Func<BlackboardContext, RegionMask> _selector;
     private readonly StateMachine[] _regions;
@@ -81,9 +83,82 @@ public sealed class DynamicParallelState : ILogic, ISubGraphProvider, IBlackboar
         for (int i = 0; i < regions.Length; i++)
         {
             _regions[i] = new StateMachine(regions[i]);
+            // Manual keeps a finished region's terminal status readable between the join and
+            // the next visit — deep suspend recomputes the join's failure aggregation from
+            // those statuses. The fresh-visit reset happens in ResetTerminalRegions instead.
+            _regions[i].SetRestartPolicy(RestartPolicy.Manual);
         }
 
         _done = new bool[regions.Length];
+    }
+
+    // ── ISuspendableComposite ─────────────────────────────────────────────
+    // Same durable state as ParallelState, with one addition that makes Done capture (not
+    // derivation) mandatory: a deselected region is done-without-terminal-status (its machine
+    // never ran), so child statuses alone cannot reconstruct the selection projected into
+    // _done at the visit's first tick. The selector is NOT re-evaluated on resume — the
+    // captured Done bits carry the visit's fixed selection.
+
+    CompositeSnapshot ISuspendableComposite.SuspendComposite(int nodeIndex)
+    {
+        StateMachineDeepSnapshot[] children = new StateMachineDeepSnapshot[_regions.Length];
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            children[i] = _regions[i].SuspendDeep();
+        }
+
+        return new CompositeSnapshot(nodeIndex, _inFlight, (bool[])_done.Clone(), children);
+    }
+
+    void ISuspendableComposite.ResumeComposite(CompositeSnapshot snapshot)
+    {
+        DeepSnapshots.ValidateShape(snapshot, expectedChildren: _regions.Length, expectedDoneBits: _done.Length);
+        _inFlight = snapshot.InFlight;
+        for (int i = 0; i < _done.Length; i++)
+        {
+            _done[i] = snapshot.Done[i];
+        }
+
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            DeepSnapshots.ResumeChild(_regions[i], snapshot, i);
+        }
+
+        RecomputeJoinBookkeeping();
+    }
+
+    private void RecomputeJoinBookkeeping()
+    {
+        // _remaining and _anyFailed are deliberately not captured — recompute them so the
+        // wire shape cannot self-contradict. A deselected region is done with a non-terminal
+        // machine status and therefore never counts as failed.
+        _remaining = 0;
+        _anyFailed = false;
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            if (!_done[i])
+            {
+                _remaining++;
+            }
+            else if (_regions[i].Status == ExecutionStatus.Failed)
+            {
+                _anyFailed = true;
+            }
+        }
+    }
+
+    private void ResetTerminalRegions()
+    {
+        // Fresh visit: regions left terminal by the previous visit start over (selected or
+        // not this time). Mid-run regions are left as-is, matching ParallelState.
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            if (_regions[i].Status is ExecutionStatus.Completed or ExecutionStatus.Failed
+                or ExecutionStatus.Cancelled)
+            {
+                _regions[i].Reset();
+            }
+        }
     }
 
     void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
@@ -101,6 +176,7 @@ public sealed class DynamicParallelState : ILogic, ISubGraphProvider, IBlackboar
     {
         if (!_inFlight)
         {
+            ResetTerminalRegions();
             RegionMask selected = _selector(_blackboards);
             ValidateMask(selected);
 

--- a/NxGraph/Fsm/HistoryState.cs
+++ b/NxGraph/Fsm/HistoryState.cs
@@ -21,12 +21,14 @@ namespace NxGraph.Fsm;
 /// <see cref="Execute"/> call (usable from both runtimes via the sync-logic adapter);
 /// <see cref="ParallelStepMode.RoundPerTick"/> advances one child node per call and returns
 /// <see cref="Result.InProgress"/> in between (sync runtime only — the async loop rejects
-/// node-level <see cref="Result.InProgress"/>). A parent suspend between RoundPerTick ticks
-/// does not capture composite-internal position (snapshots are primitives-only); resuming on
-/// a fresh graph restarts the visit.
+/// node-level <see cref="Result.InProgress"/>). A parent <c>Suspend()</c> between
+/// RoundPerTick ticks does not capture composite-internal position (flat snapshots are
+/// primitives-only); resuming that on a fresh graph restarts the visit. Use the parent's
+/// <c>SuspendDeep()</c>/<c>ResumeDeep(...)</c> to carry the mid-visit position and the
+/// remembered history across a durable boundary (see <see cref="ISuspendableComposite"/>).
 /// </para>
 /// </summary>
-public sealed class HistoryState : ILogic, ISubGraphProvider, IBlackboardSettable
+public sealed class HistoryState : ILogic, ISubGraphProvider, IBlackboardSettable, ISuspendableComposite
 {
     /// <summary>The wrapped child machine.</summary>
     public StateMachine Child { get; }
@@ -57,6 +59,24 @@ public sealed class HistoryState : ILogic, ISubGraphProvider, IBlackboardSettabl
         // auto-resetting to the start — that position is exactly the history to resume from.
         Child.SetRestartPolicy(RestartPolicy.Manual);
         Mode = mode;
+    }
+
+    // ── ISuspendableComposite ─────────────────────────────────────────────
+    // Two things persist across Execute() calls: the RoundPerTick visit flag (_inFlight)
+    // and the child machine's position — mid-run between ticks, or terminal-Failed history
+    // under RestartPolicy.Manual. Capturing the child's deep snapshot preserves exactly the
+    // shape the re-entry lift in Execute consumes, so no new lift logic is needed on resume.
+
+    CompositeSnapshot ISuspendableComposite.SuspendComposite(int nodeIndex)
+    {
+        return new CompositeSnapshot(nodeIndex, _inFlight, Done: [], Children: [Child.SuspendDeep()]);
+    }
+
+    void ISuspendableComposite.ResumeComposite(CompositeSnapshot snapshot)
+    {
+        DeepSnapshots.ValidateShape(snapshot, expectedChildren: 1, expectedDoneBits: 0);
+        _inFlight = snapshot.InFlight;
+        DeepSnapshots.ResumeChild(Child, snapshot, 0);
     }
 
     public Result Execute()

--- a/NxGraph/Fsm/ISuspendableComposite.cs
+++ b/NxGraph/Fsm/ISuspendableComposite.cs
@@ -1,0 +1,49 @@
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// Deep-suspend capture contract for composite node logic. <c>SuspendDeep()</c> on
+/// <see cref="Async.AsyncStateMachine"/>/<see cref="StateMachine"/> walks the machine's own
+/// graph once and collects a <see cref="CompositeSnapshot"/> from every logic node that
+/// implements this interface; <c>ResumeDeep(...)</c> hands each captured entry back. The
+/// machine walk never recurses — a composite recurses by calling <c>SuspendDeep()</c> /
+/// <c>ResumeDeep(...)</c> on its own child machine(s), exactly how the blackboard stamping
+/// walk stops at settable nodes and lets machines re-walk their own graphs.
+/// <para>
+/// The rule for implementing it: a composite implements <see cref="ISuspendableComposite"/>
+/// <b>iff</b> it persists visit or cross-visit state across <c>Execute</c>/<c>ExecuteAsync</c>
+/// calls (history's remembered child position, a sync RoundPerTick composite's mid-visit
+/// bookkeeping, a nested sync machine mid-run between parent ticks). Composites that run
+/// their children to terminal inside one execution and keep no durable fields — the async
+/// parallel composites — must not implement it: absence of capture is correct, not a gap.
+/// </para>
+/// <para>
+/// <b>Container contract.</b> This is the third leg of the contract for custom container
+/// nodes, beside <see cref="Graphs.ISubGraphProvider"/> (so the agent walk reaches child
+/// graphs) and <see cref="Blackboards.IBlackboardSettable"/> forwarding (so the stamped
+/// context reaches child machines): containers that hold durable position should also
+/// implement <see cref="ISuspendableComposite"/> so deep suspend can capture it. A container
+/// that does not implement it contributes nothing to the deep snapshot and re-enters fresh
+/// after a resume — today's shallow behavior.
+/// </para>
+/// </summary>
+public interface ISuspendableComposite
+{
+    /// <summary>
+    /// Captures this composite's internal state into a <see cref="CompositeSnapshot"/> whose
+    /// <see cref="CompositeSnapshot.NodeIndex"/> is <paramref name="nodeIndex"/> (the owner
+    /// node's index in the capturing machine's graph). Child/region machines are captured via
+    /// their own <c>SuspendDeep()</c>, in region order. Cold path — allocation is expected.
+    /// </summary>
+    CompositeSnapshot SuspendComposite(int nodeIndex);
+
+    /// <summary>
+    /// Restores a snapshot produced by <see cref="SuspendComposite"/> onto this composite.
+    /// Implementations must validate the entry's shape (child snapshot count, done-bit count)
+    /// against their own structure — throwing <see cref="InvalidOperationException"/> naming
+    /// <see cref="CompositeSnapshot.NodeIndex"/> on mismatch — and deep-resume their child
+    /// machines, which re-run the full resume validation recursively. Derivable bookkeeping
+    /// (remaining region count, failure aggregation) is recomputed here, never trusted from
+    /// the wire.
+    /// </summary>
+    void ResumeComposite(CompositeSnapshot snapshot);
+}

--- a/NxGraph/Fsm/ParallelState.cs
+++ b/NxGraph/Fsm/ParallelState.cs
@@ -28,7 +28,7 @@ namespace NxGraph.Fsm;
 /// (<see cref="ILogic"/>) node logic, as with any sync-run graph.
 /// </para>
 /// </summary>
-public sealed class ParallelState : ILogic, ISubGraphProvider, IBlackboardSettable
+public sealed class ParallelState : ILogic, ISubGraphProvider, IBlackboardSettable, ISuspendableComposite
 {
     private readonly StateMachine[] _regions;
     private readonly bool[] _done;
@@ -81,15 +81,89 @@ public sealed class ParallelState : ILogic, ISubGraphProvider, IBlackboardSettab
         for (int i = 0; i < regions.Length; i++)
         {
             _regions[i] = new StateMachine(regions[i]);
+            // Manual keeps a finished region's terminal status readable between the join and
+            // the next visit (instead of auto-resetting to Ready the instant it finishes) —
+            // deep suspend recomputes the join's failure aggregation from those statuses.
+            // The fresh-visit reset happens in ResetTerminalRegions instead, so visits still
+            // start clean exactly as they did under the regions' old auto-reset.
+            _regions[i].SetRestartPolicy(RestartPolicy.Manual);
         }
 
         _done = new bool[regions.Length];
+    }
+
+    // ── ISuspendableComposite ─────────────────────────────────────────────
+    // RoundPerTick join bookkeeping spans Execute() calls: the visit flag, the per-region
+    // done bits, and each region machine's own position persist between ticks. _remaining
+    // and _anyFailed are derivable (regions minus done popcount / any region Failed) and are
+    // deliberately not captured — they are recomputed on resume so the wire shape cannot
+    // self-contradict.
+
+    CompositeSnapshot ISuspendableComposite.SuspendComposite(int nodeIndex)
+    {
+        StateMachineDeepSnapshot[] children = new StateMachineDeepSnapshot[_regions.Length];
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            children[i] = _regions[i].SuspendDeep();
+        }
+
+        return new CompositeSnapshot(nodeIndex, _inFlight, (bool[])_done.Clone(), children);
+    }
+
+    void ISuspendableComposite.ResumeComposite(CompositeSnapshot snapshot)
+    {
+        DeepSnapshots.ValidateShape(snapshot, expectedChildren: _regions.Length, expectedDoneBits: _done.Length);
+        _inFlight = snapshot.InFlight;
+        for (int i = 0; i < _done.Length; i++)
+        {
+            _done[i] = snapshot.Done[i];
+        }
+
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            DeepSnapshots.ResumeChild(_regions[i], snapshot, i);
+        }
+
+        RecomputeJoinBookkeeping();
+    }
+
+    private void RecomputeJoinBookkeeping()
+    {
+        _remaining = 0;
+        _anyFailed = false;
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            if (!_done[i])
+            {
+                _remaining++;
+            }
+            else if (_regions[i].Status == ExecutionStatus.Failed)
+            {
+                _anyFailed = true;
+            }
+        }
+    }
+
+    private void ResetTerminalRegions()
+    {
+        // Fresh visit: regions left terminal by the previous visit start over. Mid-run
+        // regions (possible after an escaping exception dropped the join) are left as-is,
+        // matching the old behavior where they continued from their positions.
+        for (int i = 0; i < _regions.Length; i++)
+        {
+            if (_regions[i].Status is ExecutionStatus.Completed or ExecutionStatus.Failed
+                or ExecutionStatus.Cancelled)
+            {
+                _regions[i].Reset();
+            }
+        }
     }
 
     public Result Execute()
     {
         if (!_inFlight)
         {
+            ResetTerminalRegions();
             for (int i = 0; i < _done.Length; i++)
             {
                 _done[i] = false;

--- a/NxGraph/Fsm/PortRelayStates.cs
+++ b/NxGraph/Fsm/PortRelayStates.cs
@@ -1,0 +1,71 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// Synchronous counterpart of <see cref="Async.AsyncPortProducerRelayState{TOut}"/>: runs the
+/// step with the machine-bound routed context, writes its value to the output port
+/// (an ordinary <see cref="BlackboardKey{T}"/>), and returns <c>Success</c>. The step cannot
+/// fail — a step that can must use the plain context relay with an explicit <c>Set</c>.
+/// </summary>
+public sealed class PortProducerRelayState<TOut> : State
+{
+    private readonly BlackboardKey<TOut> _output;
+    private readonly Func<BlackboardContext, TOut> _step;
+
+    public PortProducerRelayState(BlackboardKey<TOut> output, Func<BlackboardContext, TOut> step)
+    {
+        _output = output;
+        _step = step ?? throw new ArgumentNullException(nameof(step));
+    }
+
+    protected override Result OnRun()
+    {
+        Bb.Set(_output, _step(Bb));
+        return Result.Success;
+    }
+}
+
+/// <summary>
+/// Synchronous counterpart of <see cref="Async.AsyncPortConsumerRelayState{TIn}"/>: reads the
+/// input port and hands the value (plus the routed context) to the step, returning its result.
+/// </summary>
+public sealed class PortConsumerRelayState<TIn> : State
+{
+    private readonly BlackboardKey<TIn> _input;
+    private readonly Func<TIn, BlackboardContext, Result> _step;
+
+    public PortConsumerRelayState(BlackboardKey<TIn> input, Func<TIn, BlackboardContext, Result> step)
+    {
+        _input = input;
+        _step = step ?? throw new ArgumentNullException(nameof(step));
+    }
+
+    protected override Result OnRun() => _step(Bb.Get(_input), Bb);
+}
+
+/// <summary>
+/// Synchronous counterpart of <see cref="Async.AsyncPortPipeRelayState{TIn,TOut}"/>: reads the
+/// input port, transforms, writes the output port, and returns <c>Success</c>. The step cannot
+/// fail — a step that can must use the plain context relay with an explicit <c>Set</c>.
+/// </summary>
+public sealed class PortPipeRelayState<TIn, TOut> : State
+{
+    private readonly BlackboardKey<TIn> _input;
+    private readonly BlackboardKey<TOut> _output;
+    private readonly Func<TIn, BlackboardContext, TOut> _step;
+
+    public PortPipeRelayState(BlackboardKey<TIn> input, BlackboardKey<TOut> output,
+        Func<TIn, BlackboardContext, TOut> step)
+    {
+        _input = input;
+        _output = output;
+        _step = step ?? throw new ArgumentNullException(nameof(step));
+    }
+
+    protected override Result OnRun()
+    {
+        Bb.Set(_output, _step(Bb.Get(_input), Bb));
+        return Result.Success;
+    }
+}

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -65,7 +65,8 @@ public class StateMachine<TAgent>(Graph graph, IStateMachineObserver? observer =
 /// must have its <see cref="INode.Logic"/> populated (i.e. implement <see cref="ILogic"/>).
 /// </para>
 /// </summary>
-public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlackboardSettable
+public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlackboardSettable,
+    ISuspendableComposite
 {
     public readonly Graph Graph;
     private BlackboardContext _blackboards;
@@ -400,6 +401,62 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         _executeGate = snapshot.MidRun;
         HasEntered = snapshot.MidRun;
         _status = snapshot.Status;
+    }
+
+    /// <summary>
+    /// Deep variant of <see cref="Suspend"/>: captures this machine's position plus the
+    /// internal state of every composite in its graph that holds durable state (nested
+    /// machine positions, history's remembered child position, RoundPerTick mid-visit
+    /// bookkeeping) into a <see cref="StateMachineDeepSnapshot"/>. Same gates as
+    /// <see cref="Suspend"/> — legal between any two <see cref="State.Execute"/> ticks,
+    /// mid-run included; the extra cost is one linear walk over the graph's nodes plus the
+    /// composites' own recursive captures — cold path by contract, allocation is expected.
+    /// The shallow pair and <see cref="StateMachineSnapshot"/> are untouched; use them when
+    /// flows keep suspension points at the top level.
+    /// </summary>
+    public StateMachineDeepSnapshot SuspendDeep()
+    {
+        StateMachineSnapshot self = Suspend();
+        return new StateMachineDeepSnapshot(self, DeepSnapshots.Capture(Graph));
+    }
+
+    /// <summary>
+    /// Restores a snapshot produced by <see cref="SuspendDeep"/> onto this machine: first the
+    /// machine's own position via <see cref="Resume"/> (all its gates and checks apply
+    /// unchanged), then each captured composite via
+    /// <see cref="ISuspendableComposite.ResumeComposite"/> after validating that the claimed
+    /// node exists and implements the interface. A composite node absent from
+    /// <see cref="StateMachineDeepSnapshot.Composites"/> re-enters fresh (sparse capture).
+    /// Node-scoped scratch resumes as defaults at every nesting level.
+    /// </summary>
+    public void ResumeDeep(StateMachineDeepSnapshot snapshot)
+    {
+        if (snapshot is null)
+        {
+            throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        Resume(snapshot.Self);
+        DeepSnapshots.ResumeComposites(Graph, snapshot.Composites);
+    }
+
+    // ── ISuspendableComposite — the sync machine nested as a node ─────────
+    // A sync StateMachine used directly as node logic (.SubGraph(mode, child) without
+    // history) persists cross-tick state under RoundPerTick: its child run is mid-flight
+    // between parent ticks. It therefore captures itself as a single-child composite —
+    // the mid-run flag rides inside the child snapshot's own MidRun, so InFlight stays
+    // false. The async machine deliberately has no counterpart: it always runs its child
+    // to terminal inside one ExecuteAsync and holds no durable visit state as a node.
+
+    CompositeSnapshot ISuspendableComposite.SuspendComposite(int nodeIndex)
+    {
+        return new CompositeSnapshot(nodeIndex, InFlight: false, Done: [], Children: [SuspendDeep()]);
+    }
+
+    void ISuspendableComposite.ResumeComposite(CompositeSnapshot snapshot)
+    {
+        DeepSnapshots.ValidateShape(snapshot, expectedChildren: 1, expectedDoneBits: 0);
+        DeepSnapshots.ResumeChild(this, snapshot, 0);
     }
 
     // ── State overrides — Execute() is the stepped entry point ────────────

--- a/NxGraph/Fsm/StateMachineDeepSnapshot.cs
+++ b/NxGraph/Fsm/StateMachineDeepSnapshot.cs
@@ -1,0 +1,225 @@
+using NxGraph.Graphs;
+
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// The deep counterpart of <see cref="StateMachineSnapshot"/>: the machine's own position
+/// (<see cref="Self"/>) plus the internal state of every composite node in its graph that
+/// holds durable state (<see cref="Composites"/>). Produced by <c>SuspendDeep()</c> and
+/// consumed by <c>ResumeDeep(...)</c> on <see cref="Async.AsyncStateMachine"/> or
+/// <see cref="StateMachine"/> built over an equivalent graph (same node indices, per nesting
+/// level). Deep snapshots are interchangeable between the two runtimes as long as the graph's
+/// nodes are executable by the target runtime.
+/// <para>
+/// Like the shallow snapshot, the records contain only primitives and arrays — no
+/// polymorphism — so any serializer (e.g. <c>System.Text.Json</c>) handles them with zero
+/// configuration; the library never serializes them itself. Capture is <b>sparse</b>: only
+/// composites that persist visit or cross-visit state (<see cref="ISuspendableComposite"/>
+/// implementors) emit entries, and a composite node absent from <see cref="Composites"/>
+/// simply re-enters fresh on resume. The user context (agent/blackboards) is owned by the
+/// caller and must be re-attached after resuming; Node-scoped scratch is transient by
+/// definition and resumes as defaults at every nesting level.
+/// </para>
+/// </summary>
+public sealed record StateMachineDeepSnapshot(
+    StateMachineSnapshot Self,
+    CompositeSnapshot[] Composites);
+
+/// <summary>
+/// One composite node's captured internals inside a <see cref="StateMachineDeepSnapshot"/>:
+/// the owner node's index in the capturing machine's graph, the sync RoundPerTick mid-visit
+/// flag (<see cref="InFlight"/>, always <c>false</c> from async composites), the parallel
+/// per-region done bits (<see cref="Done"/> — captured, not derived, because a dynamic
+/// parallel deselection is done-without-terminal-status; empty for single-child composites),
+/// and the child/region machines' own deep snapshots in region order
+/// (<see cref="Children"/> — length 1 for subgraph/history composites). Join bookkeeping that
+/// is derivable (<c>_remaining</c>, <c>_anyFailed</c>) is deliberately not captured — it is
+/// recomputed at resume so the wire shape cannot self-contradict.
+/// </summary>
+public sealed record CompositeSnapshot(
+    int NodeIndex,
+    bool InFlight,
+    bool[] Done,
+    StateMachineDeepSnapshot[] Children);
+
+/// <summary>
+/// Shared deep-suspend plumbing for both FSM machines: the linear capture walk over one
+/// graph's nodes, the resume-side validation/dispatch, and the composite-side shape checks.
+/// The walk itself never recurses — composites recurse by calling <c>SuspendDeep()</c> /
+/// <c>ResumeDeep(...)</c> on their own child machines, mirroring the agent/blackboard
+/// stamping walks — so a thread-local depth counter guards the machine-hop recursion with
+/// the same limit and error style as <c>Graph.MaxStampingDepth</c>.
+/// </summary>
+internal static class DeepSnapshots
+{
+    /// <summary>Mirrors <c>Graph.MaxStampingDepth</c>.</summary>
+    private const int MaxDepth = 64;
+
+    [ThreadStatic] private static int _captureDepth;
+    [ThreadStatic] private static int _resumeDepth;
+
+    /// <summary>
+    /// One linear O(nodes) walk over <paramref name="graph"/> collecting
+    /// <see cref="ISuspendableComposite.SuspendComposite"/> from every logic node whose
+    /// async-then-sync logic slot implements the interface (the same probing order as the
+    /// stamping walks). Cold path by contract — allocates the entry list and arrays.
+    /// </summary>
+    internal static CompositeSnapshot[] Capture(Graph graph)
+    {
+        if (_captureDepth >= MaxDepth)
+        {
+            throw new InvalidOperationException(
+                $"Composite nesting exceeds {MaxDepth} levels while capturing a deep snapshot — " +
+                "check for a cycle between graphs nested as composites.");
+        }
+
+        _captureDepth++;
+        try
+        {
+            List<CompositeSnapshot>? entries = null;
+            for (int i = 0; i < graph.NodeCount; i++)
+            {
+                ISuspendableComposite? composite = SuspendableAt(graph, i);
+                if (composite is null)
+                {
+                    continue;
+                }
+
+                (entries ??= []).Add(composite.SuspendComposite(i));
+            }
+
+            return entries?.ToArray() ?? [];
+        }
+        finally
+        {
+            _captureDepth--;
+        }
+    }
+
+    /// <summary>
+    /// Validates every composite entry against <paramref name="graph"/> (index in range, the
+    /// claimed node implements <see cref="ISuspendableComposite"/>) before dispatching any
+    /// restore, then hands each entry to its composite. Composite-side shape checks and the
+    /// recursive child validation run inside <see cref="ISuspendableComposite.ResumeComposite"/>.
+    /// </summary>
+    internal static void ResumeComposites(Graph graph, CompositeSnapshot[]? composites)
+    {
+        if (composites is null || composites.Length == 0)
+        {
+            return;
+        }
+
+        if (_resumeDepth >= MaxDepth)
+        {
+            throw new InvalidOperationException(
+                $"Composite nesting exceeds {MaxDepth} levels while resuming a deep snapshot — " +
+                "check for a cycle between graphs nested as composites.");
+        }
+
+        _resumeDepth++;
+        try
+        {
+            for (int i = 0; i < composites.Length; i++)
+            {
+                CompositeSnapshot entry = composites[i]
+                    ?? throw new InvalidOperationException(
+                        $"Deep snapshot composite entry at position {i} is null.");
+
+                if ((uint)entry.NodeIndex >= (uint)graph.NodeCount)
+                {
+                    throw new InvalidOperationException(
+                        $"Deep snapshot composite entry claims node index {entry.NodeIndex}, which is out of " +
+                        $"range for this graph (0..{graph.NodeCount - 1}).");
+                }
+
+                if (SuspendableAt(graph, entry.NodeIndex) is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Deep snapshot composite entry claims node index {entry.NodeIndex}, but that node's " +
+                        $"logic does not implement {nameof(ISuspendableComposite)} — the graph is not " +
+                        "equivalent to the one the snapshot was taken from.");
+                }
+            }
+
+            for (int i = 0; i < composites.Length; i++)
+            {
+                SuspendableAt(graph, composites[i].NodeIndex)!.ResumeComposite(composites[i]);
+            }
+        }
+        finally
+        {
+            _resumeDepth--;
+        }
+    }
+
+    private static ISuspendableComposite? SuspendableAt(Graph graph, int index)
+    {
+        if (!graph.TryGetNodeByIndex(index, out INode? node) || node is not LogicNode logicNode)
+        {
+            return null;
+        }
+
+        // Check the async logic first, then the sync logic (for States wrapped in
+        // SyncLogicAdapter) — the same probing order as the agent/blackboard stamping walks.
+        return logicNode.AsyncLogic as ISuspendableComposite ?? logicNode.Logic as ISuspendableComposite;
+    }
+
+    /// <summary>
+    /// Composite-side shape validation: the entry must carry exactly the child snapshots and
+    /// done bits this composite expects, else the graph is not equivalent to the snapshot's.
+    /// Errors name the composite's node index.
+    /// </summary>
+    internal static void ValidateShape(CompositeSnapshot snapshot, int expectedChildren, int expectedDoneBits)
+    {
+        if (snapshot.Children is null || snapshot.Children.Length != expectedChildren)
+        {
+            throw new InvalidOperationException(
+                $"Deep snapshot for composite node {snapshot.NodeIndex} carries " +
+                $"{snapshot.Children?.Length ?? 0} child snapshot(s), but this composite expects " +
+                $"{expectedChildren}.");
+        }
+
+        if (snapshot.Done is null || snapshot.Done.Length != expectedDoneBits)
+        {
+            throw new InvalidOperationException(
+                $"Deep snapshot for composite node {snapshot.NodeIndex} carries " +
+                $"{snapshot.Done?.Length ?? 0} done bit(s), but this composite expects {expectedDoneBits}.");
+        }
+    }
+
+    /// <summary>
+    /// Deep-resumes one child machine, contextualizing any validation error with the owning
+    /// composite's node index (the child machine's own messages have no parent-graph index).
+    /// </summary>
+    internal static void ResumeChild(Async.AsyncStateMachine child, CompositeSnapshot owner, int childIndex)
+    {
+        try
+        {
+            child.ResumeDeep(owner.Children[childIndex]);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw ChildResumeError(owner, childIndex, ex);
+        }
+    }
+
+    /// <inheritdoc cref="ResumeChild(Async.AsyncStateMachine, CompositeSnapshot, int)"/>
+    internal static void ResumeChild(StateMachine child, CompositeSnapshot owner, int childIndex)
+    {
+        try
+        {
+            child.ResumeDeep(owner.Children[childIndex]);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw ChildResumeError(owner, childIndex, ex);
+        }
+    }
+
+    private static InvalidOperationException ChildResumeError(
+        CompositeSnapshot owner, int childIndex, InvalidOperationException inner)
+    {
+        return new InvalidOperationException(
+            $"Deep snapshot for composite node {owner.NodeIndex}, child {childIndex}: {inner.Message}", inner);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The core package targets `net8.0` and `netstandard2.1`.
   - [Naming nodes](#naming-nodes)
   - [Agents / context injection](#agents--context-injection)
   - [Blackboards (scoped shared memory)](#blackboards-scoped-shared-memory)
+  - [Step I/O (ports)](#step-io-ports)
 - [Execution](#execution)
   - [Async execution](#async-execution)
   - [Sync execution, stepped model](#sync-execution-stepped-model)
@@ -428,6 +429,49 @@ Graph graph = GraphBuilder.StartWith(new UploadState()).Retry(3)
 > **Anti-pattern:** don't use `Dictionary<string, object>` as a context — every access pays string hashing plus boxing. A `BlackboardKey<T>` slot is a schema-checked array read: type-safe, allocation-free, and serializable (see `BlackboardSerializer` in `NxGraph.Serialization` — each board is its own durability artifact alongside the graph payload and machine snapshot; Node boards are transient and never serialize).
 
 Like the state machines, a blackboard is owned by a single runner at a time (not thread-safe).
+
+### Step I/O (ports)
+
+Steps communicate through the blackboard — there is deliberately no hidden output→input piping between nodes. The shipped convention for *this step's output feeds that step's input* is a **port**: an ordinary **Graph-scoped** `BlackboardKey<T>`, one per producing step, named for the **datum**, not the step (`io.Register<string>("draft")`, not `"writeDraft.out"` — several steps may legally produce the same port, e.g. a retry-rewrite step). Producers `Set`, consumers `Get`; a consumer that can run before any producer reads the key's registered default — register a meaningful default or guard in the step. Declare the schema on the graph with `.WithSchema(io)` and bind a board per machine with `.WithBlackboard(new Blackboard(io))` — the existing paths, unchanged.
+
+The port DSL overloads read/write ports around the step lambda, so the common produce→transform→consume chain needs no manual `bb.Get`/`bb.Set` and the graph stays a shareable template:
+
+```csharp
+static class FlowIo
+{
+    public static readonly BlackboardSchema Schema = new("flow-io"); // Graph scope (default)
+    public static readonly BlackboardKey<string> Draft = Schema.Register<string>("draft", "");
+    public static readonly BlackboardKey<string> Final = Schema.Register<string>("final", "");
+}
+
+// Async: produce → pipe → consume.
+Graph graph = GraphBuilder
+    .Start()
+    .ToAsync(FlowIo.Draft, (bb, ct) => new ValueTask<string>("a draft"))                  // producer: value → port
+    .ToAsync(FlowIo.Draft, FlowIo.Final, (draft, bb, ct) => new ValueTask<string>($"[polished] {draft}")) // pipe
+    .ToAsync(FlowIo.Final, (text, bb, ct) => PublishAsync(text))                          // consumer: port → Result
+    .WithSchema(FlowIo.Schema)
+    .Build();
+
+Result result = await graph.ToAsyncStateMachine()
+    .WithBlackboard(new Blackboard(FlowIo.Schema))
+    .ExecuteAsync();
+```
+
+```csharp
+// Sync twin — the same shapes without the CancellationToken.
+Graph graph = GraphBuilder
+    .Start()
+    .To(FlowIo.Draft, bb => "a draft")
+    .To(FlowIo.Draft, FlowIo.Final, (draft, bb) => $"[polished] {draft}")
+    .To(FlowIo.Final, (text, bb) => Publish(text))
+    .WithSchema(FlowIo.Schema)
+    .Build();
+```
+
+Producer and pipe steps **cannot fail** — their lambdas return the value, and the relay writes it to the port and returns `Success`. A step that both computes a value and can fail keeps using the plain context relay (`.To(bb => ...)`) with an explicit `bb.Set(...)` on its success path; exceptions thrown by a step propagate exactly as from every relay.
+
+> **Node-scope trap:** a Node-scoped key cannot pipe — Node scratch resets on the success transition, so the producer's write is back at its default before the consumer runs. The port overloads reject Node-scoped keys at wiring time with an `ArgumentException`. Global-scoped keys are accepted (legitimate for world-state ports) but shared across machines — two machines over one template would overwrite each other's values, so the default recommendation stays Graph scope.
 
 ---
 
@@ -975,6 +1019,7 @@ The solution includes a runnable examples project with:
 - a serialization round-trip example
 - a sync Dungeon Crawler example using the DSL, observers, director nodes, loops, and named states
 - a blackboard demo (scoped shared memory, schema declarations, per-entity boards)
+- a step I/O ports demo (typed produce → pipe → consume chains over Graph-scoped port keys)
 - **parallel-region demos**: the sync Stronghold Siege (`ParallelStepMode.RoundPerTick` frame ticking, `RunToJoin` waves, blackboard-selected dynamic regions) and the async Expedition Camp (cooperative round-robin interleaving under `AsyncStateMachine`, dynamic region selection)
 
 Run it with:

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Every fan-out construct answers two questions: **how many successors run**, and 
 
 The FSM runtimes keep exactly one active node, and many-at-once execution lives inside the parallel composites, which join back into the single-active flow at the composite boundary. When the flow genuinely needs several active nodes in **one flat graph** — a forked path that rejoins the parent flow mid-graph, the same node active k times, M-of-N merges — that is the [token runtime](#token-runtime-fork-join-and-mid-graph-merge): a third runtime beside the sync/async machines (`TokenMachine`/`AsyncTokenMachine`), not a change to them.
 
+> **None of these overlap in time.** Every construct in the table interleaves cooperatively — one node per region (or per token) per round, on the caller's thread — so two 20-second API calls placed in parallel regions still take about 40 seconds wall-clock. For genuine wall-clock concurrency, run the calls inside **one node** with [`.ToAllAsync(...)`](#in-node-concurrency-toallasync): the same two calls overlap and finish in about 20 seconds. Regions structure *logic*; nodes structure *time*.
+
 ### Waits and timeouts
 
 ```csharp
@@ -658,6 +660,33 @@ StateMachine fsm = GraphBuilder
 ```
 
 The selector runs once per composite execution and fixes the selected set for that run; unselected regions are never stepped. An empty mask is a vacuous join (immediate `Success`); mask bits at or above the region count throw; up to 64 regions per composite. Selectors execute on the measured zero-allocation path, so compose masks with `RegionMask.Bit(i) | ...` as above — allocation-free — while `RegionMask.Of(params)` allocates its array and belongs at setup time only. Both variants exist in both runtimes (`.Parallel(selector, ...)` for async, `.Parallel(mode, selector, ...)` for sync). See `NxFSM.Examples/ParallelDemo` for runnable sync and async demos.
+
+#### In-node concurrency: `.ToAllAsync(...)`
+
+Parallel regions are cooperative, not thread-concurrent — and that is a recorded design decision, not an oversight: truly concurrent regions would make every shared Global/Graph board access a data race (forcing a thread-safety mode onto the blackboards), deliver observer callbacks concurrently (breaking the event-ordering contracts the observer tests codify), allocate task machinery in what is today a zero-allocation round loop, and have no meaningful sync twin. The library's position is **regions structure logic, nodes structure time**: when two 20-second I/O calls must overlap in wall-clock time, run them inside a *single node* with `.ToAllAsync(...)` — every work starts with the node's own `CancellationToken`, all are awaited, and the results join afterwards: `Success` iff every work returned `Success`, else one ordinary node `Failure` feeding the unified fault model (`.Retry(...)` re-runs *all* works; `.OnError(...)` sees one node failure). There is no early abort — a failing work never cancels its siblings, so partial effects are never timing-dependent (a consumer wanting first-failure-cancels composes a linked CTS inside its works); a throwing work propagates its exception after all works settle, and cancelling the machine's token cancels all works.
+
+**Disjoint keys are the contract:** the works share one routed `BlackboardContext`, which is not thread-safe — concurrent works must touch **disjoint** keys. Same-key access from two works is a data race; distinct keys write to distinct slots and are genuinely safe. The recommended shape is one [output port](#step-io-ports) per work, combined by the next node:
+
+```csharp
+static class ScoutIo
+{
+    public static readonly BlackboardSchema Schema = new("scout-io"); // Graph scope (default)
+    public static readonly BlackboardKey<string> Weather = Schema.Register<string>("weather", "");
+    public static readonly BlackboardKey<string> Terrain = Schema.Register<string>("terrain", "");
+}
+
+Graph graph = GraphBuilder
+    .Start()
+    .ToAllAsync( // both calls in flight at once — ~max(t1, t2), not t1 + t2
+        async (bb, ct) => { bb.Set(ScoutIo.Weather, await FetchWeatherAsync(ct)); return Result.Success; },
+        async (bb, ct) => { bb.Set(ScoutIo.Terrain, await FetchTerrainAsync(ct)); return Result.Success; })
+    .ToAsync(ScoutIo.Weather, (weather, bb, ct) => // the next node combines the ports
+        PlanRouteAsync(weather, bb.Get(ScoutIo.Terrain)))
+    .WithSchema(ScoutIo.Schema)
+    .Build();
+```
+
+The sync twin `.ToAll(...)` runs its works sequentially, in order, within one tick — wall-clock overlap is an async-only mechanic, exactly like retry backoff — with identical join semantics, including no early abort, so a graph moved between runtimes sees the same board effects; as plain `ILogic` it also runs under the async machine via the adapter, and it stays allocation-free per tick. `.ToAllAsync` allocates per execution by design (task materialization is dwarfed by the I/O it overlaps). The join is deliberately all-or-nothing: for *some-of-many* joining ("succeed when m of n arrive"), use the token runtime's [`JoinPolicy.Quorum`](#token-runtime-fork-join-and-mid-graph-merge) — that is the logical quorum tool, and duplicating it at node level would blur the two models. See `NxFSM.Examples/ReadmeExamples/InNodeConcurrencyExample.cs` for the runnable version.
 
 ### Token runtime: fork, join, and mid-graph merge
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NxGraph is a lean, high-performance finite state machine / stateflow library for
 - stepped execution for Unity (`Update()`-loop friendly)
 - a unified fault model: per-node retries, failure edges (`.OnError`), and timeouts
 - composites: subgraphs (with history), parallel regions, and blackboard-selected dynamic regions
-- durable suspend/resume via serializable snapshots
+- durable suspend/resume via serializable snapshots (shallow, or deep with composite internals)
 - scoped blackboards (typed, zero-boxing shared memory)
 - graph validation
 - observers, tracing, replay, and Mermaid export
@@ -737,9 +737,35 @@ while (result == Result.InProgress)
 
 - `Suspend()` is legal between `StepAsync()`/`Execute()` calls of a stepped run, or on an idle/terminal machine; it captures the current node, status, retry attempts, and `LastOutcome`.
 - `Resume(snapshot)` requires a graph that is structurally equivalent (same node indices); re-attach agents/blackboards before continuing.
-- A fully durable flow persists three artifacts: the graph payload (`GraphSerializer`), the snapshot, and one `BlackboardSerializer` payload per bound board — see [Serialization](#serialization).
+- A fully durable flow persists three artifacts: the graph payload (`GraphSerializer`), one machine snapshot (shallow **or** deep, below), and one `BlackboardSerializer` payload per bound board — see [Serialization](#serialization).
 - Node-scoped blackboards are transient by definition and are **not** part of the durable flow: `Resume(snapshot)` restores Node keys to their registered defaults — a node suspended mid-visit loses its scratch.
-- Composite-internal progress (positions inside parallel regions or history children) is not part of the flat snapshot; a resumed composite starts its visit fresh.
+- Composite-internal progress (positions inside parallel regions or history children) is not part of the flat snapshot; a shallow-resumed composite starts its visit fresh. Use the deep pair below when suspension points live inside composites.
+
+#### Deep suspend — capturing composite internals
+
+`SuspendDeep()`/`ResumeDeep(...)` are the opt-in deep pair on both machines: same gates and rules as the shallow pair, but the snapshot additionally carries the composite tree — nested machine positions, a history composite's remembered child position, and the sync `RoundPerTick` composites' mid-visit bookkeeping (per-region done bits, dynamic-parallel deselection included):
+
+```csharp
+using System.Text.Json;
+
+AsyncStateMachine first = flow.ToAsyncStateMachine();    // flow nests a history subgraph
+await first.StepAsync();                                 // child failed; parent is at the repair step
+StateMachineDeepSnapshot deep = first.SuspendDeep();     // position + composite internals
+
+string json = JsonSerializer.Serialize(deep);            // still plain records — any serializer works
+
+// Later — fresh machine over an equivalent (rebuilt) graph:
+AsyncStateMachine second = rebuiltFlow.ToAsyncStateMachine();
+second.ResumeDeep(JsonSerializer.Deserialize<StateMachineDeepSnapshot>(json)!);
+// on re-entry the history child resumes at its last-active node — not from its start
+```
+
+- `StateMachineDeepSnapshot` = the shallow snapshot (`Self`) plus one `CompositeSnapshot` per composite that holds durable state; child machines carry their own deep snapshots recursively. Everything stays primitives/arrays — zero-configuration serializable, caller-serialized.
+- Capture is sparse and interface-driven (`ISuspendableComposite`): the sync nested machine, `AsyncHistoryState`/`HistoryState`, and the sync `ParallelState`/`DynamicParallelState` implement it; the async parallel composites run their regions to terminal within one execution, hold no durable state, and correctly contribute nothing. A composite absent from the snapshot re-enters fresh.
+- Custom containers opt in by implementing `ISuspendableComposite` — the third leg of the container contract beside `ISubGraphProvider` and `IBlackboardSettable` forwarding.
+- The shallow pair and `StateMachineSnapshot` are untouched — keep using them when flows put suspension points at the top level. Deep snapshots inherit the same rules: equivalent graph per nesting level, cross-runtime interchangeable, Node-scoped scratch resumes as defaults at every level.
+
+See `NxFSM.Examples/ReadmeExamples/FeatureExamples.cs` for the runnable version.
 
 ### Restart policy
 
@@ -1128,7 +1154,6 @@ The machine has more nodes to process but is returning control to the caller (e.
 ## Roadmap
 
 - sync twins for the remaining async-only constructs (history subgraphs, waits, timeouts)
-- hierarchical snapshots so composite-internal progress survives durable suspend/resume
 - validator and Mermaid-export awareness of composite interiors
 - continued ergonomics improvements around DSL authoring and serialization
 


### PR DESCRIPTION
Implements the three features from the 2026-07 Aitomata adopter feedback.

## Step I/O ports

- Documented convention: a "port" is an ordinary Graph-scoped `BlackboardKey<T>`, one per producing step, named for the datum, not the step. No wrapper type, zero changes under `Blackboards/`.
- 24 new `To`/`ToAsync` DSL overloads (producer/consumer/pipe x sync/async x StartToken/StateToken/BranchBuilder/BranchEnd) wrapping six new port relay states, so produce -> transform -> consume chains need no manual `bb.Get`/`bb.Set` and graphs stay shareable templates.
- Node-scoped keys are rejected at wiring time (their value resets before the consumer runs); Global is allowed with a documented caveat.
- Hot path stays 0 B - two new allocation gates (async + sync) pin it.

## Deep suspend

- New opt-in `SuspendDeep()`/`ResumeDeep(...)` on both FSM machines capturing composite-internal position: nested machine positions, history's remembered child position, and sync RoundPerTick mid-visit bookkeeping. `StateMachineSnapshot` and the shallow pair are untouched.
- `StateMachineDeepSnapshot`/`CompositeSnapshot` are primitives-only recursive records, caller-serialized with zero configuration; capture is sparse and derivable bookkeeping is recomputed on resume, never trusted from the wire.
- `ISuspendableComposite` is the capture contract and the third leg of the custom-container contract beside `ISubGraphProvider` and `IBlackboardSettable` forwarding. History, sync parallel/dynamic-parallel, and nested sync machines implement it; the async parallels deliberately do not (no durable state, documented).
- Sync parallel region machines now run under `RestartPolicy.Manual` with a fresh-visit reset at the next visit's first tick, so the join's failure aggregation survives the durable boundary; observable behavior is unchanged and pinned by tests.
- Deep snapshots stay interchangeable between runtimes under the existing executability caveat, pinned by cross-runtime tests.

## In-node concurrency

- `.ToAllAsync(params works)` -> `AsyncAllState`: N works run truly concurrently inside one node with the node's own token; all works run to completion (no sibling cancellation), then combine - Success iff every work succeeded. A deterministic handshake test proves real overlap.
- `.ToAll(params works)` -> `AllState`: sync twin, sequential in one tick, identical all-run/join semantics, allocation-free per tick (gated); runs under both machines via the adapter.
- Docs pass: "Fan-out at a glance" gains the wall-clock callout (two 20s calls in parallel regions take ~40s; in one `.ToAllAsync` node ~20s), plus a subsection recording why thread-concurrent regions were rejected and the disjoint-keys rule.

## Verification

- Full CI target green: 535 NxGraph.Tests + 131 NxGraph.Serialization.Tests, 0 failures; line coverage ~81% against the 70 threshold.
- Public API baseline regenerated for the new surface; README snippets mirrored as runnable examples and smoke-run.