### PR TITLE
Release prep for 2.1.0-alpha: UPM changelog, docs, and token source staging

### DIFF
--- a/NxGraph.Build/Program.cs
+++ b/NxGraph.Build/Program.cs
@@ -17,6 +17,7 @@ public static class Program
         Path.Combine("Fsm"),
         Path.Combine("Graphs"),
         Path.Combine("Shims"),
+        Path.Combine("Tokens"),
     ];
 
     private static readonly string[] FilesToCopy =

--- a/upm/com.enzx.nxgraph/CHANGELOG.md
+++ b/upm/com.enzx.nxgraph/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 All notable changes to this package will be documented in this file.
 
-## [Unreleased]
+## [2.1.0-alpha]
+
+### Runtime (staged NxGraph core)
+- Unified fault model: per-node retry policies with backoff, failure edges (`.OnError(...)`), timeouts as ordinary failures, and terminal outcome codes.
+- Scoped blackboards (`Global`/`Graph`/`Node`) with typed keys, machine-bound boards, and blackboard-aware DSL overloads; graphs stay shareable templates.
+- Step I/O ports: typed producer/consumer/pipe DSL overloads that pipe one step's output into the next through Graph-scoped blackboard keys.
+- Token runtime: `TokenMachine`/`AsyncTokenMachine` run pooled tokens through one flat graph with `.ForkTo(...)` fan-out and `JoinState` merges (all / any / quorum).
+- Durable suspend/resume: shallow `Suspend()`/`Resume(...)` plus deep `SuspendDeep()`/`ResumeDeep(...)` capturing composite trees; snapshots are interchangeable between runtimes.
+- Sync/async parity across composites: nested machines, history, static and dynamic parallel regions, with one-tick and per-tick stepping modes.
+- In-node wall-clock concurrency via `.ToAllAsync(...)` (sync twin `.ToAll(...)`).
+- Stable per-node UIDs (`.WithUid(...)`) for editor tooling.
+
+### Package
+- Source staging now includes the `Tokens` folder (the source-mode package could not compile without it after the token runtime landed).
 - Staging documentation now describes the actual mechanism (`dotnet run --project NxGraph.Build -- stage-source|stage-binary`); the previously referenced `scripts/build-upm.ps1` no longer exists.
 - Source staging now includes the `Blackboards` and `Shims` folders (the source-mode package could not compile without them).
 - Refreshed the staged binary (`Runtime/Plugins/NxGraph.dll`) — the previously committed DLL was a stale 1.0.0 build predating failure edges, suspend/resume, parallel composites, and blackboards.

--- a/upm/com.enzx.nxgraph/Documentation~/build-and-release.md
+++ b/upm/com.enzx.nxgraph/Documentation~/build-and-release.md
@@ -21,6 +21,7 @@ Source staging copies:
 - `Fsm`
 - `Graphs`
 - `Shims`
+- `Tokens`
 - `Result.cs`
 - `ResultHelpers.cs`
 

--- a/upm/com.enzx.nxgraph/README.md
+++ b/upm/com.enzx.nxgraph/README.md
@@ -5,9 +5,11 @@ NxGraph is a lean finite state machine / stateflow library with:
 - a fluent authoring DSL
 - sync and async runtimes
 - failure edges, retries, and timeouts (unified fault model)
-- composites: subgraphs, history, parallel regions
-- durable suspend/resume via snapshots
-- scoped blackboards
+- composites: subgraphs, history, parallel regions (static and dynamic selection)
+- a token runtime with fork/join for many-active-tokens flows (all / any / quorum merges)
+- durable suspend/resume via snapshots, including deep suspend of composite trees
+- scoped blackboards and typed step I/O ports
+- in-node wall-clock concurrency (`.ToAllAsync(...)`)
 - graph validation, observers, replay, and Mermaid export
 
 ## Install
@@ -29,7 +31,7 @@ Or pin a specific release tag:
 ```json
 {
   "dependencies": {
-    "com.enzx.nxgraph": "https://github.com/Enzx/NxGraph.git#upm/v2.0.1-alpha"
+    "com.enzx.nxgraph": "https://github.com/Enzx/NxGraph.git#upm/v2.1.0-alpha"
   }
 }
 ```


### PR DESCRIPTION
Prepares the UPM package for the 2.1.0-alpha release:

- Rolls the changelog's Unreleased section into a `[2.1.0-alpha]` entry summarizing the runtime features shipping since 2.0.1-alpha (unified fault model, scoped blackboards, step I/O ports, token runtime, deep suspend, composite parity, in-node concurrency, stable UIDs).
- Fixes source staging to include the `Tokens` folder — the source-mode package could not compile without it after the token runtime landed (same gap previously fixed for `Blackboards`/`Shims`). Verified locally that `stage-source` now stages `Tokens`.
- Updates the UPM README feature list and bumps the pinned install tag to `upm/v2.1.0-alpha`.
- Adds `Tokens` to the staged-folder list in `Documentation~/build-and-release.md`.

After merge, `v2.1.0-alpha` (NuGet, all three packages) and `upm/v2.1.0-alpha` (UPM) will be tagged from main.