### PR TITLE
Add typed event entry points and declarative behaviors with bounded repetition

### DIFF
--- a/NxFSM.Examples/Program.cs
+++ b/NxFSM.Examples/Program.cs
@@ -83,6 +83,8 @@ await PortsExample.RunAsync();
 Console.WriteLine();
 await EventEntryExample.RunAsync();
 Console.WriteLine();
+BehaviorsExample.Run();
+Console.WriteLine();
 ObserverExample.Run();
 Console.WriteLine();
 await FeatureExamples.RunAsync();

--- a/NxFSM.Examples/Program.cs
+++ b/NxFSM.Examples/Program.cs
@@ -81,6 +81,8 @@ await BlackboardExample.RunAsync();
 Console.WriteLine();
 await PortsExample.RunAsync();
 Console.WriteLine();
+await EventEntryExample.RunAsync();
+Console.WriteLine();
 ObserverExample.Run();
 Console.WriteLine();
 await FeatureExamples.RunAsync();

--- a/NxFSM.Examples/ReadmeExamples/BehaviorsExample.cs
+++ b/NxFSM.Examples/ReadmeExamples/BehaviorsExample.cs
@@ -12,7 +12,9 @@ namespace NxFSM.Examples.ReadmeExamples;
 /// sequence of small data-shaped behaviors — in order, fail-fast — with fields that are
 /// literals or <see cref="BlackboardValue{T}"/> key bindings. <see cref="Log"/> goes through
 /// the report channel (observer OnLogReport, never the console directly), and the same
-/// dual-interface instances author either runtime.
+/// dual-interface instances author either runtime. <see cref="Repeat"/> is the bounded
+/// leaf-level For: a key-bound trip count resolved once at entry, plus an optional 0-based
+/// index key written before each iteration.
 /// </summary>
 public static class BehaviorsExample
 {
@@ -33,11 +35,15 @@ public static class BehaviorsExample
         var stats = new BlackboardSchema("stats"); // Graph scope (default)
         BlackboardKey<string> playerName = stats.Register("playerName", "Hero");
         BlackboardKey<int> score = stats.Register("score", 0);
+        BlackboardKey<int> comboHits = stats.Register("comboHits", 3);
+        BlackboardKey<int> hitIndex = stats.Register("hitIndex", -1);
 
         Graph graph = GraphBuilder.Start()
             .ToBehaviors(
                 new Log(LogSeverity.Info, playerName), // message bound to a key, resolved per run
                 new SetValue<int>(score, 100),         // literal write — the typed copy/constant primitive
+                new Repeat(comboHits, hitIndex,        // key-bound trip count — resolved once at entry
+                    new Log("combo hit")),             // body runs comboHits times; hitIndex = 0, 1, 2…
                 new Log("checkpoint saved"))           // literal message, Info severity by default
             .WithSchema(stats)
             .Build();

--- a/NxFSM.Examples/ReadmeExamples/BehaviorsExample.cs
+++ b/NxFSM.Examples/ReadmeExamples/BehaviorsExample.cs
@@ -1,0 +1,52 @@
+using NxGraph;
+using NxGraph.Authoring;
+using NxGraph.Behaviors;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxFSM.Examples.ReadmeExamples;
+
+/// <summary>
+/// Behaviors (README "Behaviors (declarative state composition)"): a node authored as a
+/// sequence of small data-shaped behaviors — in order, fail-fast — with fields that are
+/// literals or <see cref="BlackboardValue{T}"/> key bindings. <see cref="Log"/> goes through
+/// the report channel (observer OnLogReport, never the console directly), and the same
+/// dual-interface instances author either runtime.
+/// </summary>
+public static class BehaviorsExample
+{
+    private sealed class ConsoleReportObserver : IStateMachineObserver
+    {
+        void IStateMachineObserver.OnLogReport(NodeId nodeId, string message)
+        {
+            Console.WriteLine($"  report: {message}");
+        }
+    }
+
+    public static void Run()
+    {
+        Console.WriteLine("=== Behaviors (declarative state composition) ===");
+
+        ConsoleReportObserver observer = new();
+
+        var stats = new BlackboardSchema("stats"); // Graph scope (default)
+        BlackboardKey<string> playerName = stats.Register("playerName", "Hero");
+        BlackboardKey<int> score = stats.Register("score", 0);
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(
+                new Log(LogSeverity.Info, playerName), // message bound to a key, resolved per run
+                new SetValue<int>(score, 100),         // literal write — the typed copy/constant primitive
+                new Log("checkpoint saved"))           // literal message, Info severity by default
+            .WithSchema(stats)
+            .Build();
+
+        Blackboard board = new(stats);
+        Result result = graph.ToStateMachine(observer)      // Log lands in the observer's OnLogReport
+            .WithBlackboard(board)
+            .Execute();
+
+        Console.WriteLine($"  Sync behaviors: {result}, score = {board.Get(score)}");
+    }
+}

--- a/NxFSM.Examples/ReadmeExamples/EventEntryExample.cs
+++ b/NxFSM.Examples/ReadmeExamples/EventEntryExample.cs
@@ -1,0 +1,124 @@
+using System.Threading.Channels;
+using NxGraph;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxFSM.Examples.ReadmeExamples;
+
+/// <summary>
+/// Event entry points (README "Event entry points"): one graph responding to several
+/// externally-raised, typed events, each entering the flow at its own entry chain. An event
+/// is a run trigger — one event, one run — and the payload travels through an ordinary
+/// Graph-scoped <see cref="BlackboardKey{T}"/>, so durability falls out of the blackboard.
+/// </summary>
+public static class EventEntryExample
+{
+    public sealed record OrderPlaced(string OrderId, decimal Amount);
+
+    public readonly record struct OrderCanceled(string OrderId);
+
+    private static ValueTask<Result> ReserveStockAsync(OrderPlaced order)
+    {
+        Console.WriteLine($"  Reserving stock for {order.OrderId}");
+        return ResultHelpers.Success;
+    }
+
+    private static ValueTask<Result> ChargeAsync(OrderPlaced order)
+    {
+        Console.WriteLine($"  Charging {order.Amount:C}");
+        return ResultHelpers.Success;
+    }
+
+    private static ValueTask<Result> RefundAsync(OrderCanceled order)
+    {
+        Console.WriteLine($"  Refunding {order.OrderId}");
+        return ResultHelpers.Success;
+    }
+
+    private static ValueTask<Result> LogUnsolicitedAsync()
+    {
+        Console.WriteLine("  Plain run — no event raised.");
+        return ResultHelpers.Success;
+    }
+
+    public static async ValueTask RunAsync()
+    {
+        Console.WriteLine("=== Event entry points (typed multi-entry dispatch) ===");
+
+        var shop = new BlackboardSchema("shop"); // Graph scope (default)
+        BlackboardKey<OrderPlaced> orderPlaced = shop.Register<OrderPlaced>("orderPlaced");
+        BlackboardKey<OrderCanceled> orderCanceled = shop.Register<OrderCanceled>("orderCanceled");
+
+        Graph graph = GraphBuilder.StartWithEvents()
+            .On(orderPlaced, e => e
+                .ToAsync(orderPlaced, (order, bb, ct) => ReserveStockAsync(order)) // payload via the consumer sugar
+                .ToAsync((bb, ct) => ChargeAsync(bb.Get(orderPlaced)))             // or via bb.Get
+                .WithOutcome(1, "Placed"))
+            .On(orderCanceled, e => e
+                .ToAsync(orderCanceled, (order, bb, ct) => RefundAsync(order))
+                .WithOutcome(2, "Canceled"))
+            .Otherwise(e => e.ToAsync((bb, ct) => LogUnsolicitedAsync()))          // optional plain-run entry
+            .WithSchema(shop)
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop));
+
+        Result placed = await machine.ExecuteAsync(new OrderPlaced("o-1", 42m)); // dispatch by CLR event type
+        Console.WriteLine($"  OrderPlaced run: {placed}, outcome: {machine.LastOutcomeName}");
+
+        Result canceled = await machine.ExecuteAsync(new OrderCanceled("o-1"));
+        Console.WriteLine($"  OrderCanceled run: {canceled}");
+
+        Result plain = await machine.ExecuteAsync(); // routes to the Otherwise chain
+        Console.WriteLine($"  Plain run: {plain}");
+
+        // Host-side buffering: feed the machine from your own queue — three lines with a Channel<T>.
+        Channel<OrderPlaced> queue = Channel.CreateUnbounded<OrderPlaced>();
+        queue.Writer.TryWrite(new OrderPlaced("o-2", 7m));
+        queue.Writer.Complete();
+        await foreach (OrderPlaced evt in queue.Reader.ReadAllAsync())
+        {
+            await machine.ExecuteAsync(evt); // one queued event = one run
+        }
+
+        RunSync(shop, orderPlaced, orderCanceled);
+    }
+
+    private static void RunSync(BlackboardSchema shop, BlackboardKey<OrderPlaced> orderPlaced,
+        BlackboardKey<OrderCanceled> orderCanceled)
+    {
+        Console.WriteLine("=== Event entry points (sync twin) ===");
+
+        // Sync-authored twin over the same schema and keys — the sync runtime needs ILogic nodes.
+        Graph graph = GraphBuilder.StartWithEvents()
+            .On(orderPlaced, e => e
+                .To(orderPlaced, (order, bb) =>
+                {
+                    Console.WriteLine($"  Reserving stock for {order.OrderId}");
+                    return Result.Success;
+                })
+                .WithOutcome(1, "Placed"))
+            .On(orderCanceled, e => e
+                .To(orderCanceled, (order, bb) =>
+                {
+                    Console.WriteLine($"  Refunding {order.OrderId}");
+                    return Result.Success;
+                })
+                .WithOutcome(2, "Canceled"))
+            .WithSchema(shop)
+            .Build();
+
+        // The sync raise arms the run and advances one tick; plain Execute() ticks continue it.
+        StateMachine machine = graph.ToStateMachine().WithBlackboard(new Blackboard(shop));
+        Result result = machine.Execute(new OrderCanceled("o-3"));
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Console.WriteLine($"  Sync OrderCanceled run: {result}, outcome: {machine.LastOutcomeName}");
+    }
+}

--- a/NxGraph.Serialization.Abstraction/BehaviorField.cs
+++ b/NxGraph.Serialization.Abstraction/BehaviorField.cs
@@ -31,6 +31,12 @@ public enum BehaviorFieldKind : byte
 
     /// <summary>A blackboard binding (<see cref="BehaviorFieldValue.Binding"/>): key name or primitive literal.</summary>
     Binding = 7,
+
+    /// <summary>
+    /// A nested behavior entry list (<see cref="BehaviorFieldValue.Entries"/>) — bounded
+    /// composition, carrying <c>Repeat</c>/<c>AsyncRepeat</c> bodies (payload version 9).
+    /// </summary>
+    Behaviors = 8,
 }
 
 /// <summary>
@@ -45,7 +51,8 @@ public sealed class BehaviorFieldValue(
     bool flag = false,
     long integer = 0,
     double number = 0,
-    BehaviorBinding? binding = null)
+    BehaviorBinding? binding = null,
+    BehaviorEntry[]? entries = null)
 {
     /// <summary>The value kind, deciding which payload slot is meaningful.</summary>
     public BehaviorFieldKind Kind { get; } = kind;
@@ -64,6 +71,25 @@ public sealed class BehaviorFieldValue(
 
     /// <summary>Binding payload; null for every other kind.</summary>
     public BehaviorBinding? Binding { get; } = binding;
+
+    /// <summary>Nested behavior entries payload (payload version 9); null for every other kind.</summary>
+    public BehaviorEntry[]? Entries { get; } = entries;
+}
+
+/// <summary>
+/// One serialized behavior entry (payload version 9 lifted this out of the serializer's
+/// internal DTOs so nested entries can ride the neutral field model): the behavior's
+/// runtime-stable CLR type name — the same rendering the blackboard payloads use — plus its
+/// fields. The recursion closure: a <see cref="BehaviorFieldKind.Behaviors"/> field carries
+/// entries, and each entry carries fields.
+/// </summary>
+public sealed class BehaviorEntry(string behaviorTypeName, BehaviorField[] fields)
+{
+    /// <summary>The behavior's runtime-stable CLR type name — the registry's lookup identity.</summary>
+    public string BehaviorTypeName { get; } = behaviorTypeName;
+
+    /// <summary>The entry's fields in write order.</summary>
+    public BehaviorField[] Fields { get; } = fields;
 }
 
 /// <summary>

--- a/NxGraph.Serialization.Abstraction/BehaviorField.cs
+++ b/NxGraph.Serialization.Abstraction/BehaviorField.cs
@@ -1,0 +1,92 @@
+namespace NxGraph.Serialization.Abstraction;
+
+/// <summary>
+/// Value kind of one serialized behavior field — the whole neutral field model (payload
+/// version 8). Deliberately small: primitives, enums (as strings), and blackboard bindings.
+/// Behaviors carrying richer literals implement their own encoding on top of these (or stay
+/// codec-serialized); widening the model is a recorded-decision follow-up.
+/// </summary>
+public enum BehaviorFieldKind : byte
+{
+    /// <summary>A string (<see cref="BehaviorFieldValue.Text"/>; may be null).</summary>
+    String = 0,
+
+    /// <summary>A boolean (<see cref="BehaviorFieldValue.Flag"/>).</summary>
+    Bool = 1,
+
+    /// <summary>A 32-bit integer (<see cref="BehaviorFieldValue.Integer"/>).</summary>
+    Int32 = 2,
+
+    /// <summary>A 64-bit integer (<see cref="BehaviorFieldValue.Integer"/>).</summary>
+    Int64 = 3,
+
+    /// <summary>A 32-bit float (<see cref="BehaviorFieldValue.Number"/>).</summary>
+    Single = 4,
+
+    /// <summary>A 64-bit float (<see cref="BehaviorFieldValue.Number"/>).</summary>
+    Double = 5,
+
+    /// <summary>An enum rendered as its member name (<see cref="BehaviorFieldValue.Text"/>).</summary>
+    Enum = 6,
+
+    /// <summary>A blackboard binding (<see cref="BehaviorFieldValue.Binding"/>): key name or primitive literal.</summary>
+    Binding = 7,
+}
+
+/// <summary>
+/// One serialized behavior field value — a codec-agnostic nested DTO, so JSON and MessagePack
+/// both carry it with no wire-type coupling (unlike <see cref="IContainerCodec{TWire}"/>,
+/// which is wire-typed by necessity). Exactly one payload slot is meaningful per
+/// <see cref="Kind"/>.
+/// </summary>
+public sealed class BehaviorFieldValue(
+    BehaviorFieldKind kind,
+    string? text = null,
+    bool flag = false,
+    long integer = 0,
+    double number = 0,
+    BehaviorBinding? binding = null)
+{
+    /// <summary>The value kind, deciding which payload slot is meaningful.</summary>
+    public BehaviorFieldKind Kind { get; } = kind;
+
+    /// <summary>String/Enum payload; a binding's key name rides on <see cref="Binding"/> instead.</summary>
+    public string? Text { get; } = text;
+
+    /// <summary>Bool payload.</summary>
+    public bool Flag { get; } = flag;
+
+    /// <summary>Int32/Int64 payload.</summary>
+    public long Integer { get; } = integer;
+
+    /// <summary>Single/Double payload.</summary>
+    public double Number { get; } = number;
+
+    /// <summary>Binding payload; null for every other kind.</summary>
+    public BehaviorBinding? Binding { get; } = binding;
+}
+
+/// <summary>
+/// A serialized blackboard binding: the key form carries only the key's registered
+/// <see cref="KeyName"/> (rebound by name against the machine's bound boards at execution);
+/// the literal form carries a primitive <see cref="Literal"/> value (whose kind is never
+/// <see cref="BehaviorFieldKind.Binding"/>).
+/// </summary>
+public sealed class BehaviorBinding(string? keyName, BehaviorFieldValue? literal)
+{
+    /// <summary>The bound key's registered name, or null for the literal form.</summary>
+    public string? KeyName { get; } = keyName;
+
+    /// <summary>The primitive literal, or null for the key form.</summary>
+    public BehaviorFieldValue? Literal { get; } = literal;
+}
+
+/// <summary>One named field of a serialized behavior.</summary>
+public sealed class BehaviorField(string name, BehaviorFieldValue value)
+{
+    /// <summary>The field name — unique per behavior, the reader's lookup identity.</summary>
+    public string Name { get; } = name;
+
+    /// <summary>The field's value.</summary>
+    public BehaviorFieldValue Value { get; } = value;
+}

--- a/NxGraph.Serialization.Abstraction/BehaviorFieldReader.cs
+++ b/NxGraph.Serialization.Abstraction/BehaviorFieldReader.cs
@@ -1,0 +1,167 @@
+using NxGraph.Behaviors;
+
+namespace NxGraph.Serialization.Abstraction;
+
+/// <summary>
+/// Reads a behavior's fields back from the neutral field model (payload version 8) — the
+/// counterpart handed to registry factories on deserialization. Lookups are by name; a
+/// missing field or kind mismatch throws a targeted error, because a behavior payload that
+/// lost a field is corrupt, not evolvable (schema evolution happens in the factory, which can
+/// probe with <see cref="Has"/>).
+/// </summary>
+public sealed class BehaviorFieldReader
+{
+    private readonly IReadOnlyList<BehaviorField> _fields;
+
+    /// <summary>Wraps a field list (in write order).</summary>
+    public BehaviorFieldReader(IReadOnlyList<BehaviorField> fields)
+    {
+        ArgumentNullException.ThrowIfNull(fields);
+        _fields = fields;
+    }
+
+    /// <summary><see langword="true"/> when a field named <paramref name="name"/> exists.</summary>
+    public bool Has(string name) => Find(name) is not null;
+
+    /// <summary>Reads a string field.</summary>
+    public string? ReadString(string name) => Require(name, BehaviorFieldKind.String).Text;
+
+    /// <summary>Reads a boolean field.</summary>
+    public bool ReadBool(string name) => Require(name, BehaviorFieldKind.Bool).Flag;
+
+    /// <summary>Reads a 32-bit integer field.</summary>
+    public int ReadInt32(string name) => checked((int)Require(name, BehaviorFieldKind.Int32).Integer);
+
+    /// <summary>Reads a 64-bit integer field.</summary>
+    public long ReadInt64(string name) => Require(name, BehaviorFieldKind.Int64).Integer;
+
+    /// <summary>Reads a 32-bit float field.</summary>
+    public float ReadSingle(string name) => (float)Require(name, BehaviorFieldKind.Single).Number;
+
+    /// <summary>Reads a 64-bit float field.</summary>
+    public double ReadDouble(string name) => Require(name, BehaviorFieldKind.Double).Number;
+
+    /// <summary>Reads an enum field from its member name.</summary>
+    public TEnum ReadEnum<TEnum>(string name) where TEnum : struct, Enum
+    {
+        BehaviorFieldValue value = Require(name, BehaviorFieldKind.Enum);
+        if (value.Text is not null && Enum.TryParse(value.Text, out TEnum parsed))
+        {
+            return parsed;
+        }
+
+        throw new InvalidOperationException(
+            $"Behavior field '{name}' carries enum member '{value.Text}', which is not defined on " +
+            $"'{typeof(TEnum)}'.");
+    }
+
+    /// <summary>
+    /// Reads a blackboard binding: the key form rebuilds as a name-bound
+    /// <see cref="BlackboardValue{T}"/> (resolved against the machine's bound boards per
+    /// execution); the literal form rebuilds the primitive, checked against
+    /// <typeparamref name="T"/>.
+    /// </summary>
+    public BlackboardValue<T> ReadBinding<T>(string name)
+    {
+        BehaviorFieldValue value = Require(name, BehaviorFieldKind.Binding);
+        BehaviorBinding binding = value.Binding ?? throw new InvalidOperationException(
+            $"Behavior field '{name}' is a binding but carries no binding payload.");
+
+        if (binding.KeyName is { } keyName)
+        {
+            return BlackboardValue<T>.Bound(keyName);
+        }
+
+        BehaviorFieldValue literal = binding.Literal ?? throw new InvalidOperationException(
+            $"Behavior field '{name}' is a binding but carries neither a key name nor a literal.");
+        if (literal.Kind == BehaviorFieldKind.Binding)
+        {
+            throw new InvalidOperationException(
+                $"Behavior field '{name}' nests a binding inside a binding literal — corrupt payload.");
+        }
+
+        return LiteralOf<T>(name, literal);
+    }
+
+    private static BlackboardValue<T> LiteralOf<T>(string name, BehaviorFieldValue literal)
+    {
+        if (typeof(T).IsEnum)
+        {
+            if (literal.Kind != BehaviorFieldKind.Enum || literal.Text is null)
+            {
+                throw LiteralMismatch<T>(name, literal.Kind);
+            }
+
+            try
+            {
+                return (T)Enum.Parse(typeof(T), literal.Text);
+            }
+            catch (ArgumentException)
+            {
+                throw new InvalidOperationException(
+                    $"Behavior field '{name}' carries enum member '{literal.Text}', which is not defined on " +
+                    $"'{typeof(T)}'.");
+            }
+        }
+
+        object? raw = literal.Kind switch
+        {
+            BehaviorFieldKind.String => literal.Text,
+            BehaviorFieldKind.Bool => literal.Flag,
+            BehaviorFieldKind.Int32 => (int)literal.Integer,
+            BehaviorFieldKind.Int64 => literal.Integer,
+            BehaviorFieldKind.Single => (float)literal.Number,
+            BehaviorFieldKind.Double => literal.Number,
+            _ => throw LiteralMismatch<T>(name, literal.Kind),
+        };
+
+        if (raw is null)
+        {
+            // Only the string kind writes null literals, and only for T == string.
+            return typeof(T) == typeof(string)
+                ? default(T)!
+                : throw LiteralMismatch<T>(name, literal.Kind);
+        }
+
+        if (raw is T typed)
+        {
+            return typed;
+        }
+
+        throw LiteralMismatch<T>(name, literal.Kind);
+    }
+
+    private static InvalidOperationException LiteralMismatch<T>(string name, BehaviorFieldKind kind) =>
+        new($"Behavior field '{name}' carries a {kind} binding literal, which does not match the expected " +
+            $"value type '{typeof(T)}'.");
+
+    private BehaviorFieldValue Require(string name, BehaviorFieldKind kind)
+    {
+        BehaviorFieldValue? value = Find(name);
+        if (value is null)
+        {
+            throw new InvalidOperationException($"Behavior field '{name}' is missing from the payload.");
+        }
+
+        if (value.Kind != kind)
+        {
+            throw new InvalidOperationException(
+                $"Behavior field '{name}' has kind {value.Kind}, expected {kind}.");
+        }
+
+        return value;
+    }
+
+    private BehaviorFieldValue? Find(string name)
+    {
+        foreach (BehaviorField field in _fields)
+        {
+            if (string.Equals(field.Name, name, StringComparison.Ordinal))
+            {
+                return field.Value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/NxGraph.Serialization.Abstraction/BehaviorFieldReader.cs
+++ b/NxGraph.Serialization.Abstraction/BehaviorFieldReader.cs
@@ -12,12 +12,19 @@ namespace NxGraph.Serialization.Abstraction;
 public sealed class BehaviorFieldReader
 {
     private readonly IReadOnlyList<BehaviorField> _fields;
+    private readonly IBehaviorEntryCodec? _entryCodec;
 
-    /// <summary>Wraps a field list (in write order).</summary>
+    /// <summary>Wraps a field list (in write order) — standalone, no nested-entry support (see <see cref="ReadBehaviors"/>).</summary>
     public BehaviorFieldReader(IReadOnlyList<BehaviorField> fields)
     {
         ArgumentNullException.ThrowIfNull(fields);
         _fields = fields;
+    }
+
+    internal BehaviorFieldReader(IReadOnlyList<BehaviorField> fields, IBehaviorEntryCodec? entryCodec)
+        : this(fields)
+    {
+        _entryCodec = entryCodec;
     }
 
     /// <summary><see langword="true"/> when a field named <paramref name="name"/> exists.</summary>
@@ -81,6 +88,37 @@ public sealed class BehaviorFieldReader
         }
 
         return LiteralOf<T>(name, literal);
+    }
+
+    /// <summary>
+    /// Reads a nested behavior entry list (payload version 9) back as <b>live instances</b> —
+    /// a <c>Repeat</c> body. Each entry is reconstructed recursively through the serializer's
+    /// registry-first per-entry dispatch, with the usual targeted error for unregistered
+    /// names. Only operates inside a <c>GraphSerializer</c> payload session — the serializer
+    /// wires the entry codec into the readers it creates; a standalone reader throws a
+    /// targeted error.
+    /// </summary>
+    public object[] ReadBehaviors(string name)
+    {
+        if (_entryCodec is null)
+        {
+            throw new InvalidOperationException(
+                "ReadBehaviors only operates inside a GraphSerializer payload session — nested behavior " +
+                "entries are reconstructed by the serializer's entry codec, which is not wired on a " +
+                "standalone BehaviorFieldReader.");
+        }
+
+        BehaviorFieldValue value = Require(name, BehaviorFieldKind.Behaviors);
+        BehaviorEntry[] entries = value.Entries ?? throw new InvalidOperationException(
+            $"Behavior field '{name}' is a behavior list but carries no entries payload.");
+
+        object[] live = new object[entries.Length];
+        for (int i = 0; i < entries.Length; i++)
+        {
+            live[i] = _entryCodec.ReadEntry(entries[i]);
+        }
+
+        return live;
     }
 
     private static BlackboardValue<T> LiteralOf<T>(string name, BehaviorFieldValue literal)

--- a/NxGraph.Serialization.Abstraction/BehaviorFieldWriter.cs
+++ b/NxGraph.Serialization.Abstraction/BehaviorFieldWriter.cs
@@ -10,6 +10,17 @@ namespace NxGraph.Serialization.Abstraction;
 public sealed class BehaviorFieldWriter
 {
     private readonly List<BehaviorField> _fields = [];
+    private readonly IBehaviorEntryCodec? _entryCodec;
+
+    /// <summary>Creates a standalone writer (no nested-entry support — see <see cref="WriteBehaviors"/>).</summary>
+    public BehaviorFieldWriter()
+    {
+    }
+
+    internal BehaviorFieldWriter(IBehaviorEntryCodec? entryCodec)
+    {
+        _entryCodec = entryCodec;
+    }
 
     /// <summary>Writes a string field (null allowed).</summary>
     public void WriteString(string name, string? value) =>
@@ -56,6 +67,38 @@ public sealed class BehaviorFieldWriter
 
         Add(name, new BehaviorFieldValue(BehaviorFieldKind.Binding,
             binding: new BehaviorBinding(keyName: null, LiteralValue(value.Literal))));
+    }
+
+    /// <summary>
+    /// Writes a nested behavior entry list (payload version 9) — a <c>Repeat</c> body. Each
+    /// entry is encoded recursively by the serializer's per-entry dispatch
+    /// (<see cref="ISerializableBehavior.Write"/> else the behavior registry), so nested user
+    /// behaviors serialize under exactly the top-level rules. Only operates inside a
+    /// <c>GraphSerializer</c> payload session — the serializer wires the entry codec into the
+    /// writers it creates; a standalone writer throws a targeted error.
+    /// </summary>
+    public void WriteBehaviors(string name, IReadOnlyList<object> entries)
+    {
+        if (entries is null)
+        {
+            throw new ArgumentNullException(nameof(entries));
+        }
+
+        if (_entryCodec is null)
+        {
+            throw new InvalidOperationException(
+                "WriteBehaviors only operates inside a GraphSerializer payload session — nested behavior " +
+                "entries are encoded by the serializer's entry codec, which is not wired on a standalone " +
+                "BehaviorFieldWriter.");
+        }
+
+        BehaviorEntry[] encoded = new BehaviorEntry[entries.Count];
+        for (int i = 0; i < entries.Count; i++)
+        {
+            encoded[i] = _entryCodec.WriteEntry(entries[i]);
+        }
+
+        Add(name, new BehaviorFieldValue(BehaviorFieldKind.Behaviors, entries: encoded));
     }
 
     /// <summary>Drains the collected fields in write order.</summary>

--- a/NxGraph.Serialization.Abstraction/BehaviorFieldWriter.cs
+++ b/NxGraph.Serialization.Abstraction/BehaviorFieldWriter.cs
@@ -1,0 +1,111 @@
+using NxGraph.Behaviors;
+
+namespace NxGraph.Serialization.Abstraction;
+
+/// <summary>
+/// Collects a behavior's fields into the neutral field model (payload version 8). Field
+/// names must be unique per behavior; the matching <see cref="BehaviorFieldReader"/> reads
+/// them back by name. Cold path by nature — serialization only.
+/// </summary>
+public sealed class BehaviorFieldWriter
+{
+    private readonly List<BehaviorField> _fields = [];
+
+    /// <summary>Writes a string field (null allowed).</summary>
+    public void WriteString(string name, string? value) =>
+        Add(name, new BehaviorFieldValue(BehaviorFieldKind.String, text: value));
+
+    /// <summary>Writes a boolean field.</summary>
+    public void WriteBool(string name, bool value) =>
+        Add(name, new BehaviorFieldValue(BehaviorFieldKind.Bool, flag: value));
+
+    /// <summary>Writes a 32-bit integer field.</summary>
+    public void WriteInt32(string name, int value) =>
+        Add(name, new BehaviorFieldValue(BehaviorFieldKind.Int32, integer: value));
+
+    /// <summary>Writes a 64-bit integer field.</summary>
+    public void WriteInt64(string name, long value) =>
+        Add(name, new BehaviorFieldValue(BehaviorFieldKind.Int64, integer: value));
+
+    /// <summary>Writes a 32-bit float field.</summary>
+    public void WriteSingle(string name, float value) =>
+        Add(name, new BehaviorFieldValue(BehaviorFieldKind.Single, number: value));
+
+    /// <summary>Writes a 64-bit float field.</summary>
+    public void WriteDouble(string name, double value) =>
+        Add(name, new BehaviorFieldValue(BehaviorFieldKind.Double, number: value));
+
+    /// <summary>Writes an enum field as its member name.</summary>
+    public void WriteEnum<TEnum>(string name, TEnum value) where TEnum : struct, Enum =>
+        Add(name, new BehaviorFieldValue(BehaviorFieldKind.Enum, text: value.ToString()));
+
+    /// <summary>
+    /// Writes a blackboard binding. The key form serializes only the key's registered
+    /// <b>name</b> (rebound by name at execution on the read side); the literal form requires
+    /// a primitive from the field model — string, bool, int, long, float, double, or an enum
+    /// — and throws a targeted <see cref="NotSupportedException"/> for anything richer.
+    /// </summary>
+    public void WriteBinding<T>(string name, in BlackboardValue<T> value)
+    {
+        if (value.IsBound)
+        {
+            Add(name, new BehaviorFieldValue(BehaviorFieldKind.Binding,
+                binding: new BehaviorBinding(value.KeyName, literal: null)));
+            return;
+        }
+
+        Add(name, new BehaviorFieldValue(BehaviorFieldKind.Binding,
+            binding: new BehaviorBinding(keyName: null, LiteralValue(value.Literal))));
+    }
+
+    /// <summary>Drains the collected fields in write order.</summary>
+    public BehaviorField[] ToFields() => _fields.ToArray();
+
+    private static BehaviorFieldValue LiteralValue<T>(T literal)
+    {
+        if (literal is null)
+        {
+            if (typeof(T) == typeof(string))
+            {
+                return new BehaviorFieldValue(BehaviorFieldKind.String, text: null);
+            }
+
+            throw LiteralOutsideModel(typeof(T));
+        }
+
+        return literal switch
+        {
+            string text => new BehaviorFieldValue(BehaviorFieldKind.String, text: text),
+            bool flag => new BehaviorFieldValue(BehaviorFieldKind.Bool, flag: flag),
+            int int32 => new BehaviorFieldValue(BehaviorFieldKind.Int32, integer: int32),
+            long int64 => new BehaviorFieldValue(BehaviorFieldKind.Int64, integer: int64),
+            float single => new BehaviorFieldValue(BehaviorFieldKind.Single, number: single),
+            double number => new BehaviorFieldValue(BehaviorFieldKind.Double, number: number),
+            Enum enumValue => new BehaviorFieldValue(BehaviorFieldKind.Enum, text: enumValue.ToString()),
+            _ => throw LiteralOutsideModel(typeof(T)),
+        };
+    }
+
+    private static NotSupportedException LiteralOutsideModel(Type type) =>
+        new($"Binding literal of type '{type}' is outside the behavior field model (string, bool, int, long, " +
+            "float, double, enum). Bind the field to a blackboard key instead, or keep the behavior " +
+            "codec-serialized.");
+
+    private void Add(string name, BehaviorFieldValue value)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            throw new ArgumentException("Field name cannot be null or empty.", nameof(name));
+        }
+
+        foreach (BehaviorField field in _fields)
+        {
+            if (string.Equals(field.Name, name, StringComparison.Ordinal))
+            {
+                throw new ArgumentException($"Field '{name}' has already been written.", nameof(name));
+            }
+        }
+
+        _fields.Add(new BehaviorField(name, value));
+    }
+}

--- a/NxGraph.Serialization.Abstraction/IBehaviorEntryCodec.cs
+++ b/NxGraph.Serialization.Abstraction/IBehaviorEntryCodec.cs
@@ -1,0 +1,20 @@
+namespace NxGraph.Serialization.Abstraction;
+
+/// <summary>
+/// Internal recursion hook behind <see cref="BehaviorFieldWriter.WriteBehaviors"/> /
+/// <see cref="BehaviorFieldReader.ReadBehaviors"/>: the graph serializer wires its per-entry
+/// behavior dispatch (write: <see cref="ISerializableBehavior.Write"/> else
+/// <see cref="IBehaviorRegistry.TryWrite"/>; read: registry-first
+/// <see cref="IBehaviorRegistry.TryRead"/>) into every writer/reader it creates for a payload
+/// session, so nested entry lists (<see cref="BehaviorFieldKind.Behaviors"/>) encode under
+/// exactly the top-level rules. Standalone writers/readers carry no codec — the two methods
+/// throw a targeted error there.
+/// </summary>
+internal interface IBehaviorEntryCodec
+{
+    /// <summary>Encodes one live behavior into a payload entry.</summary>
+    BehaviorEntry WriteEntry(object behavior);
+
+    /// <summary>Reconstructs one live behavior from a payload entry.</summary>
+    object ReadEntry(BehaviorEntry entry);
+}

--- a/NxGraph.Serialization.Abstraction/IBehaviorRegistry.cs
+++ b/NxGraph.Serialization.Abstraction/IBehaviorRegistry.cs
@@ -1,0 +1,27 @@
+namespace NxGraph.Serialization.Abstraction;
+
+/// <summary>
+/// Resolves behavior payload identities (payload version 8). The read side maps a behavior's
+/// runtime-stable type name plus its fields back to a live instance; the write side covers
+/// behaviors that carry no <see cref="ISerializableBehavior"/> implementation of their own —
+/// the shipped default registry (<c>NxGraph.Serialization.BehaviorRegistry</c>) handles the
+/// standard set (<c>Log</c>, closed <c>SetValue&lt;T&gt;</c>) built in, so standard-set
+/// graphs round-trip with zero options configured. Same posture as
+/// <see cref="IRegionSelectorRegistry"/>: the registry restores <i>a</i> behavior for the
+/// name; whether it behaves like the authored one is the user's contract.
+/// </summary>
+public interface IBehaviorRegistry
+{
+    /// <summary>
+    /// Reconstructs a behavior from its runtime-stable type name and serialized fields.
+    /// Returns <see langword="false"/> when the name is not known to this registry.
+    /// </summary>
+    bool TryRead(string behaviorTypeName, BehaviorFieldReader fields, out object? behavior);
+
+    /// <summary>
+    /// Writes the fields of a behavior that does not implement
+    /// <see cref="ISerializableBehavior"/> itself (the standard set). Returns
+    /// <see langword="false"/> when the instance is not recognized.
+    /// </summary>
+    bool TryWrite(object behavior, BehaviorFieldWriter fields);
+}

--- a/NxGraph.Serialization.Abstraction/ISerializableBehavior.cs
+++ b/NxGraph.Serialization.Abstraction/ISerializableBehavior.cs
@@ -1,0 +1,17 @@
+namespace NxGraph.Serialization.Abstraction;
+
+/// <summary>
+/// Opt-in serialization contract for behaviors (payload version 8): a behavior that wants to
+/// ride graph payloads writes its fields through the deliberately small neutral field model
+/// (<see cref="BehaviorFieldWriter"/>) — string, bool, integral/floating numerics, enum (as
+/// string), and blackboard bindings. Reconstruction is registry-based: register a factory
+/// under the behavior's runtime-stable type name on the
+/// <c>GraphSerializerOptions.BehaviorRegistry</c>, and it rebuilds the instance from a
+/// <see cref="BehaviorFieldReader"/> on read. The standard set (<c>Log</c>,
+/// <c>SetValue&lt;T&gt;</c>) needs neither — the default registry carries it built in.
+/// </summary>
+public interface ISerializableBehavior
+{
+    /// <summary>Writes this behavior's fields to the payload.</summary>
+    void Write(BehaviorFieldWriter writer);
+}

--- a/NxGraph.Serialization.Abstraction/NxGraph.Serialization.Abstraction.csproj
+++ b/NxGraph.Serialization.Abstraction/NxGraph.Serialization.Abstraction.csproj
@@ -25,6 +25,12 @@
         <ProjectReference Include="..\NxGraph\NxGraph.csproj"/>
     </ItemGroup>
     <ItemGroup>
+        <!-- The behavior entry-codec hook (IBehaviorEntryCodec + the internal writer/reader
+             ctors) is internal wiring for GraphSerializer's payload sessions, not public
+             surface — see BehaviorFieldWriter.WriteBehaviors. -->
+        <InternalsVisibleTo Include="NxGraph.Serialization"/>
+    </ItemGroup>
+    <ItemGroup>
         <None Include="Docs\readme.md" Pack="true" PackagePath="Docs\"/>
     </ItemGroup>
 

--- a/NxGraph.Serialization.Tests/BehaviorFieldModelTests.cs
+++ b/NxGraph.Serialization.Tests/BehaviorFieldModelTests.cs
@@ -1,0 +1,204 @@
+using NxGraph.Behaviors;
+using NxGraph.Blackboards;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// The neutral behavior field model (payload version 8): every kind the
+/// <see cref="BehaviorFieldWriter"/> can write reads back through the
+/// <see cref="BehaviorFieldReader"/>, and the deliberately small surface fails loud —
+/// duplicate names, missing fields, kind mismatches, non-primitive binding literals.
+/// </summary>
+[TestFixture]
+[Category("serialization")]
+public class BehaviorFieldModelTests
+{
+    private enum Mood
+    {
+        Calm,
+        Feisty,
+    }
+
+    private static BehaviorFieldReader RoundTrip(Action<BehaviorFieldWriter> write)
+    {
+        BehaviorFieldWriter writer = new();
+        write(writer);
+        return new BehaviorFieldReader(writer.ToFields());
+    }
+
+    [Test]
+    public void Every_primitive_kind_roundtrips()
+    {
+        BehaviorFieldReader reader = RoundTrip(w =>
+        {
+            w.WriteString("s", "text");
+            w.WriteString("sNull", null);
+            w.WriteBool("b", true);
+            w.WriteInt32("i32", -7);
+            w.WriteInt64("i64", 1L << 40);
+            w.WriteSingle("f32", 1.5f);
+            w.WriteDouble("f64", 2.25);
+            w.WriteEnum("mood", Mood.Feisty);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reader.Has("s"), Is.True);
+            Assert.That(reader.Has("missing"), Is.False);
+            Assert.That(reader.ReadString("s"), Is.EqualTo("text"));
+            Assert.That(reader.ReadString("sNull"), Is.Null);
+            Assert.That(reader.ReadBool("b"), Is.True);
+            Assert.That(reader.ReadInt32("i32"), Is.EqualTo(-7));
+            Assert.That(reader.ReadInt64("i64"), Is.EqualTo(1L << 40));
+            Assert.That(reader.ReadSingle("f32"), Is.EqualTo(1.5f));
+            Assert.That(reader.ReadDouble("f64"), Is.EqualTo(2.25));
+            Assert.That(reader.ReadEnum<Mood>("mood"), Is.EqualTo(Mood.Feisty));
+        });
+    }
+
+    [Test]
+    public void Bindings_roundtrip_in_key_and_literal_forms()
+    {
+        BlackboardSchema schema = new("model");
+        BlackboardKey<int> intKey = schema.Register("count", 0);
+
+        BehaviorFieldReader reader = RoundTrip(w =>
+        {
+            w.WriteBinding<int>("keyForm", intKey);
+            w.WriteBinding<int>("intLiteral", 9);
+            w.WriteBinding<long>("longLiteral", 10L);
+            w.WriteBinding<float>("floatLiteral", 0.5f);
+            w.WriteBinding<double>("doubleLiteral", 0.25);
+            w.WriteBinding<bool>("boolLiteral", true);
+            w.WriteBinding<string>("stringLiteral", "hello");
+            w.WriteBinding<Mood>("enumLiteral", Mood.Calm);
+        });
+
+        Assert.Multiple(() =>
+        {
+            BlackboardValue<int> keyForm = reader.ReadBinding<int>("keyForm");
+            Assert.That(keyForm.IsBound, Is.True);
+            Assert.That(keyForm.KeyName, Is.EqualTo("count"));
+
+            Assert.That(reader.ReadBinding<int>("intLiteral").Literal, Is.EqualTo(9));
+            Assert.That(reader.ReadBinding<long>("longLiteral").Literal, Is.EqualTo(10L));
+            Assert.That(reader.ReadBinding<float>("floatLiteral").Literal, Is.EqualTo(0.5f));
+            Assert.That(reader.ReadBinding<double>("doubleLiteral").Literal, Is.EqualTo(0.25));
+            Assert.That(reader.ReadBinding<bool>("boolLiteral").Literal, Is.True);
+            Assert.That(reader.ReadBinding<string>("stringLiteral").Literal, Is.EqualTo("hello"));
+            Assert.That(reader.ReadBinding<Mood>("enumLiteral").Literal, Is.EqualTo(Mood.Calm));
+        });
+    }
+
+    [Test]
+    public void Non_primitive_binding_literal_is_rejected_at_write_time()
+    {
+        BehaviorFieldWriter writer = new();
+        NotSupportedException? ex = Assert.Throws<NotSupportedException>(() =>
+            writer.WriteBinding<int[]>("bad", new[] { 1, 2 }));
+        Assert.That(ex!.Message, Does.Contain("outside the behavior field model"));
+
+        NotSupportedException? nullEx = Assert.Throws<NotSupportedException>(() =>
+            writer.WriteBinding<int[]>("badNull", default));
+        Assert.That(nullEx!.Message, Does.Contain("outside the behavior field model"));
+    }
+
+    [Test]
+    public void Duplicate_and_empty_field_names_are_rejected()
+    {
+        BehaviorFieldWriter writer = new();
+        writer.WriteBool("flag", true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentException>(() => writer.WriteBool("flag", false));
+            Assert.Throws<ArgumentException>(() => writer.WriteBool("", true));
+        });
+    }
+
+    [Test]
+    public void Missing_field_and_kind_mismatch_throw_targeted()
+    {
+        BehaviorFieldReader reader = RoundTrip(w => w.WriteInt32("i", 1));
+
+        Assert.Multiple(() =>
+        {
+            InvalidOperationException? missing =
+                Assert.Throws<InvalidOperationException>(() => reader.ReadInt32("nope"));
+            Assert.That(missing!.Message, Does.Contain("'nope'").And.Contain("missing"));
+
+            InvalidOperationException? mismatch =
+                Assert.Throws<InvalidOperationException>(() => reader.ReadBool("i"));
+            Assert.That(mismatch!.Message, Does.Contain("'i'").And.Contain("expected"));
+        });
+    }
+
+    [Test]
+    public void Binding_literal_type_mismatch_throws_targeted()
+    {
+        BehaviorFieldReader reader = RoundTrip(w => w.WriteBinding<int>("n", 3));
+
+        InvalidOperationException? ex =
+            Assert.Throws<InvalidOperationException>(() => reader.ReadBinding<string>("n"));
+        Assert.That(ex!.Message, Does.Contain("'n'").And.Contain("does not match"));
+    }
+
+    [Test]
+    public void Unknown_enum_member_throws_targeted()
+    {
+        BehaviorFieldReader reader = RoundTrip(w => w.WriteEnum("mood", Mood.Feisty));
+
+        // Read the member back under a different enum type that lacks the member.
+        InvalidOperationException? ex =
+            Assert.Throws<InvalidOperationException>(() => reader.ReadEnum<LogSeverity>("mood"));
+        Assert.That(ex!.Message, Does.Contain("Feisty").And.Contain("not defined"));
+    }
+
+    [Test]
+    public void Enum_binding_literal_with_wrong_enum_type_throws()
+    {
+        BehaviorFieldReader reader = RoundTrip(w => w.WriteBinding<Mood>("mood", Mood.Feisty));
+
+        InvalidOperationException? ex =
+            Assert.Throws<InvalidOperationException>(() => reader.ReadBinding<LogSeverity>("mood"));
+        Assert.That(ex!.Message, Does.Contain("Feisty").And.Contain("not defined"));
+    }
+
+    [Test]
+    public void Corrupt_binding_payloads_throw_targeted()
+    {
+        BehaviorFieldReader noPayload = new([
+            new BehaviorField("b", new BehaviorFieldValue(BehaviorFieldKind.Binding)),
+        ]);
+        BehaviorFieldReader neither = new([
+            new BehaviorField("b", new BehaviorFieldValue(BehaviorFieldKind.Binding,
+                binding: new BehaviorBinding(keyName: null, literal: null))),
+        ]);
+        BehaviorFieldReader nested = new([
+            new BehaviorField("b", new BehaviorFieldValue(BehaviorFieldKind.Binding,
+                binding: new BehaviorBinding(keyName: null,
+                    literal: new BehaviorFieldValue(BehaviorFieldKind.Binding)))),
+        ]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Assert.Throws<InvalidOperationException>(() => noPayload.ReadBinding<int>("b"))!
+                .Message, Does.Contain("no binding payload"));
+            Assert.That(Assert.Throws<InvalidOperationException>(() => neither.ReadBinding<int>("b"))!
+                .Message, Does.Contain("neither a key name nor a literal"));
+            Assert.That(Assert.Throws<InvalidOperationException>(() => nested.ReadBinding<int>("b"))!
+                .Message, Does.Contain("nests a binding"));
+        });
+    }
+
+    [Test]
+    public void Reader_and_bound_value_reject_invalid_arguments()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentNullException>(() => _ = new BehaviorFieldReader(null!));
+            Assert.Throws<ArgumentException>(() => BlackboardValue<int>.Bound(""));
+        });
+    }
+}

--- a/NxGraph.Serialization.Tests/BehaviorSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/BehaviorSerializationTests.cs
@@ -1,0 +1,520 @@
+using System.Text;
+using NxGraph.Authoring;
+using NxGraph.Behaviors;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// Payload version 8: behavior composites on the wire. The standard set (Log, closed
+/// SetValue&lt;T&gt;) rides with zero options via the default registry; entries serialize
+/// into the neutral field model; key bindings ride by name and rebind against the machine's
+/// bound boards at execution; AgentTypeName closes the typed composites on read (the agent
+/// itself never rides — re-attached via SetAgent).
+/// </summary>
+[TestFixture]
+[Category("serialization")]
+public class BehaviorSerializationTests
+{
+    public sealed class Hero
+    {
+        public readonly List<string> Visits = [];
+    }
+
+    private sealed class GreetHero : IBehavior<Hero>, IAsyncBehavior<Hero>, ISerializableBehavior
+    {
+        public Result Execute(Hero agent, in BehaviorContext ctx)
+        {
+            agent.Visits.Add("greeted");
+            return Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(Hero agent, BehaviorContext ctx, CancellationToken ct)
+        {
+            agent.Visits.Add("greeted");
+            return ResultHelpers.Success;
+        }
+
+        public void Write(BehaviorFieldWriter writer)
+        {
+            // No fields — the greeting is pure agent access.
+        }
+    }
+
+    private sealed class Beep(int times, BlackboardValue<string> sound)
+        : IBehavior, IAsyncBehavior, ISerializableBehavior
+    {
+        public int Times { get; } = times;
+        public BlackboardValue<string> Sound { get; } = sound;
+
+        public Result Execute(in BehaviorContext ctx) => Result.Success;
+
+        public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct) => ResultHelpers.Success;
+
+        public void Write(BehaviorFieldWriter writer)
+        {
+            writer.WriteInt32("times", Times);
+            writer.WriteBinding("sound", Sound);
+        }
+    }
+
+    /// <summary>Not ISerializableBehavior and unknown to the registry — must fail loud on write.</summary>
+    private sealed class OpaqueBehavior : IBehavior
+    {
+        public Result Execute(in BehaviorContext ctx) => Result.Success;
+    }
+
+    private sealed class DummyCodec : ILogicTextCodec
+    {
+        public string Serialize(IAsyncLogic data) => "noop";
+
+        public IAsyncLogic Deserialize(string s) => new EmptyAsyncLogic();
+    }
+
+    private sealed class LogCapturingAsyncObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+
+        public ValueTask OnLogReport(NodeId nodeId, string message, CancellationToken ct)
+        {
+            Messages.Add(message);
+            return default;
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static async Task<Graph> RoundTrip(GraphSerializer serializer, Graph graph, bool binary)
+    {
+        await using MemoryStream stream = new();
+        if (binary)
+        {
+            await serializer.ToBinaryAsync(graph, stream);
+            stream.Position = 0;
+            return await serializer.FromBinaryAsync(stream);
+        }
+
+        await serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+        return await serializer.FromJsonAsync(stream);
+    }
+
+    private static async Task<string> ToJson(GraphSerializer serializer, Graph graph)
+    {
+        await using MemoryStream stream = new();
+        await serializer.ToJsonAsync(graph, stream);
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static async Task<Graph> FromJson(GraphSerializer serializer, string json)
+    {
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        return await serializer.FromJsonAsync(source);
+    }
+
+    private static IBehaviorComposite CompositeAt(Graph graph, int index)
+    {
+        LogicNode node = (LogicNode)graph.GetNodeByIndex(index);
+        return (node.Logic as IBehaviorComposite ?? node.AsyncLogic as IBehaviorComposite)!;
+    }
+
+    private static (BlackboardSchema Schema, BlackboardKey<string> Message, BlackboardKey<int> Target) TestSchema()
+    {
+        BlackboardSchema schema = new("shop");
+        BlackboardKey<string> message = schema.Register("msg", "default-msg");
+        BlackboardKey<int> target = schema.Register("target", 0);
+        return (schema, message, target);
+    }
+
+    // ── Standard-set round trips (zero options) ──────────────────────────
+
+    [Test]
+    public async Task Standard_set_roundtrips_with_zero_options([Values] bool binary)
+    {
+        (BlackboardSchema schema, BlackboardKey<string> message, BlackboardKey<int> target) = TestSchema();
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new Log(LogSeverity.Error, message), new SetValue<int>(target, 5)) // sync node
+            .ToBehaviorsAsync(new Log("literal message")) // async node
+            .WithSchema(schema)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(new DummyCodec()), graph, binary);
+
+        IBehaviorComposite syncComposite = CompositeAt(rebuilt, 0);
+        IBehaviorComposite asyncComposite = CompositeAt(rebuilt, 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncComposite, Is.Not.Null.And.InstanceOf<BehaviorState>());
+            Assert.That(asyncComposite, Is.Not.Null.And.InstanceOf<AsyncBehaviorState>());
+
+            Log rebuiltLog = (Log)syncComposite.Entries[0];
+            Assert.That(rebuiltLog.Severity.IsBound, Is.False);
+            Assert.That(rebuiltLog.Severity.Literal, Is.EqualTo(LogSeverity.Error));
+            Assert.That(rebuiltLog.Message.IsBound, Is.True);
+            Assert.That(rebuiltLog.Message.KeyName, Is.EqualTo("msg"),
+                "The key form rides by name only.");
+
+            SetValue<int> rebuiltSet = (SetValue<int>)syncComposite.Entries[1];
+            Assert.That(rebuiltSet.KeyName, Is.EqualTo("target"));
+            Assert.That(rebuiltSet.Key.IsValid, Is.False, "Deserialized targets are name-bound.");
+            Assert.That(rebuiltSet.Value.IsBound, Is.False);
+            Assert.That(rebuiltSet.Value.Literal, Is.EqualTo(5));
+
+            Log literalLog = (Log)asyncComposite.Entries[0];
+            Assert.That(literalLog.Message.IsBound, Is.False);
+            Assert.That(literalLog.Message.Literal, Is.EqualTo("literal message"));
+        });
+    }
+
+    [Test]
+    public async Task Payload_carries_markers_section_and_version_eight_stamp()
+    {
+        (BlackboardSchema schema, BlackboardKey<string> message, BlackboardKey<int> target) = TestSchema();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new Log(message))
+            .ToBehaviorsAsync(new SetValue<int>(target, 1))
+            .WithSchema(schema)
+            .Build();
+
+        string json = await ToJson(new GraphSerializer(new DummyCodec()), graph);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(json, Does.Contain("\"version\": 8"));
+            Assert.That(json, Does.Contain("\"BehaviorState\""));
+            Assert.That(json, Does.Contain("\"AsyncBehaviorState\""));
+            Assert.That(json, Does.Contain("\"behaviors\""));
+            Assert.That(json, Does.Contain("NxGraph.Behaviors.Log"));
+            // The JSON writer escapes the generic-arity backtick as ` (default encoder);
+            // unescape it before the ordinal containment check.
+            Assert.That(json.Replace("\\u0060", "`")
+                    .Contains("NxGraph.Behaviors.SetValue`1[System.Int32]", StringComparison.Ordinal),
+                Is.True, "SetValue rides under its runtime-stable closed-generic name.");
+        });
+    }
+
+    [Test]
+    public async Task Bindings_rebind_by_name_and_execute_on_the_rebuilt_graph([Values] bool binary)
+    {
+        (BlackboardSchema schema, BlackboardKey<string> message, BlackboardKey<int> target) = TestSchema();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new Log(LogSeverity.Warning, message), new SetValue<int>(target, 42))
+            .WithSchema(schema)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(new DummyCodec()), graph, binary);
+
+        LogCapturingAsyncObserver observer = new();
+        Blackboard board = new(schema);
+        board.Set(message, "from-board");
+        Result result = await rebuilt.ToAsyncStateMachine(observer).WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(observer.Messages, Is.EqualTo(new[] { "[Warning] from-board" }),
+                "The key-form binding resolved by name against the bound board.");
+            Assert.That(board.Get(target), Is.EqualTo(42),
+                "The name-bound SetValue target resolved and wrote.");
+        });
+    }
+
+    [Test]
+    public async Task Rebind_against_a_schema_missing_the_key_throws_targeted()
+    {
+        (BlackboardSchema schema, BlackboardKey<string> message, _) = TestSchema();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new Log(message))
+            .WithSchema(schema)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(new DummyCodec()), graph, binary: false);
+
+        BlackboardSchema other = new("other");
+        other.Register<string>("differentName");
+        LogCapturingAsyncObserver observer = new(); // a wired reporter forces the binding resolve
+        AsyncStateMachine machine = rebuilt.ToAsyncStateMachine(observer)
+            .WithBlackboard(new Blackboard(other));
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync());
+        Assert.That(ex!.Message, Does.Contain("'msg'").And.Contain("does not exist"));
+    }
+
+    [Test]
+    public async Task Rebind_against_a_mismatched_value_type_throws_targeted()
+    {
+        (BlackboardSchema schema, BlackboardKey<string> message, _) = TestSchema();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new Log(message))
+            .WithSchema(schema)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(new DummyCodec()), graph, binary: false);
+
+        BlackboardSchema other = new("other");
+        other.Register<int>("msg"); // same name, different value type
+        LogCapturingAsyncObserver observer = new();
+        AsyncStateMachine machine = rebuilt.ToAsyncStateMachine(observer)
+            .WithBlackboard(new Blackboard(other));
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync());
+        Assert.That(ex!.Message, Does.Contain("'msg'").And.Contain("declared as"));
+    }
+
+    // ── Custom behaviors via registered factory ──────────────────────────
+
+    [Test]
+    public async Task Custom_behavior_roundtrips_via_registered_factory([Values] bool binary)
+    {
+        BlackboardSchema schema = new("sounds");
+        BlackboardKey<string> soundKey = schema.Register("sound", "beep");
+
+        BehaviorRegistry registry = new();
+        registry.Register(typeof(Beep).FullName!,
+            fields => new Beep(fields.ReadInt32("times"), fields.ReadBinding<string>("sound")));
+
+        GraphSerializer serializer = new(new DummyCodec(),
+            new GraphSerializerOptions { BehaviorRegistry = registry });
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new Beep(3, soundKey), new Beep(1, "literal-buzz"))
+            .WithSchema(schema)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(serializer, graph, binary);
+        IBehaviorComposite composite = CompositeAt(rebuilt, 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(composite.Entries, Has.Count.EqualTo(2));
+            Beep first = (Beep)composite.Entries[0];
+            Assert.That(first.Times, Is.EqualTo(3));
+            Assert.That(first.Sound.KeyName, Is.EqualTo("sound"));
+            Beep second = (Beep)composite.Entries[1];
+            Assert.That(second.Times, Is.EqualTo(1));
+            Assert.That(second.Sound.IsBound, Is.False);
+            Assert.That(second.Sound.Literal, Is.EqualTo("literal-buzz"));
+        });
+    }
+
+    [Test]
+    public void Unserializable_behavior_fails_write_naming_the_registry()
+    {
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new OpaqueBehavior())
+            .Build();
+
+        NotSupportedException? ex = Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await ToJson(new GraphSerializer(new DummyCodec()), graph));
+        Assert.That(ex!.Message, Does.Contain("OpaqueBehavior").And.Contain("BehaviorRegistry"));
+    }
+
+    [Test]
+    public async Task Unregistered_behavior_name_fails_read_naming_the_registry()
+    {
+        BehaviorRegistry writeRegistry = new();
+        // Registered for the write-side test graph but not on the reading serializer.
+        GraphSerializer writer = new(new DummyCodec(),
+            new GraphSerializerOptions { BehaviorRegistry = writeRegistry });
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new Beep(2, "x"))
+            .Build();
+
+        string json = await ToJson(writer, graph); // Beep is ISerializableBehavior — write needs no factory
+
+        NotSupportedException? ex = Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await FromJson(new GraphSerializer(new DummyCodec()), json));
+        Assert.That(ex!.Message, Does.Contain("Beep").And.Contain("BehaviorRegistry"));
+    }
+
+    // ── Agent-typed composites ───────────────────────────────────────────
+
+    [Test]
+    public async Task Typed_composite_roundtrips_and_reattaches_the_agent([Values] bool binary)
+    {
+        BehaviorRegistry registry = new();
+        registry.Register(typeof(GreetHero).FullName!, _ => new GreetHero());
+        GraphSerializer serializer = new(new DummyCodec(),
+            new GraphSerializerOptions { BehaviorRegistry = registry });
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync<Hero>(new Log("typed node"), new GreetHero())
+            .Build();
+
+        Graph rebuilt = await RoundTrip(serializer, graph, binary);
+        IBehaviorComposite composite = CompositeAt(rebuilt, 0);
+
+        Hero hero = new();
+        Result result = await rebuilt.ToAsyncStateMachine<Hero>().WithAgent(hero).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(composite, Is.InstanceOf<AsyncBehaviorState<Hero>>(),
+                "AgentTypeName closed the generic composite on read.");
+            Assert.That(composite.AgentType, Is.EqualTo(typeof(Hero)));
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(hero.Visits, Is.EqualTo(new[] { "greeted" }),
+                "The re-attached agent reached the typed entry.");
+        });
+    }
+
+    [Test]
+    public async Task Sync_typed_composite_roundtrips([Values] bool binary)
+    {
+        BehaviorRegistry registry = new();
+        registry.Register(typeof(GreetHero).FullName!, _ => new GreetHero());
+        GraphSerializer serializer = new(new DummyCodec(),
+            new GraphSerializerOptions { BehaviorRegistry = registry });
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors<Hero>(new GreetHero())
+            .Build();
+
+        Graph rebuilt = await RoundTrip(serializer, graph, binary);
+
+        Assert.That(CompositeAt(rebuilt, 0), Is.InstanceOf<BehaviorState<Hero>>());
+    }
+
+    // ── Version stamps, back compatibility, spoof defense ────────────────
+
+    [Test]
+    public async Task Version_seven_payload_reads_behavior_free()
+    {
+        string json = """
+            {
+              "version": 7,
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "noop" } ],
+              "transitions": [ { "destination": -1 } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        Graph rebuilt = await FromJson(new GraphSerializer(new DummyCodec()), json);
+
+        Assert.That(((LogicNode)rebuilt.StartNode).AsyncLogic, Is.Not.InstanceOf<AsyncBehaviorState>(),
+            "A pre-v8 payload rebuilds as an ordinary graph with no behavior surface.");
+    }
+
+    [Test]
+    public async Task Behavior_marker_string_in_ordinary_logic_is_not_honored()
+    {
+        // A codec that legitimately emits the marker string for ordinary logic: without a
+        // BehaviorDto claiming the index, the string must fall through to the codec.
+        Graph graph = GraphBuilder.Start().ToAsync(new EmptyAsyncLogic()).Build();
+
+        string json = (await ToJson(new GraphSerializer(new MarkerEmittingCodec()), graph))
+            .Replace("\"logic\": \"noop\"", "\"logic\": \"BehaviorState\"");
+
+        Graph rebuilt = await FromJson(new GraphSerializer(new MarkerEmittingCodec()), json);
+
+        Assert.That(((LogicNode)rebuilt.StartNode).AsyncLogic, Is.InstanceOf<EmptyAsyncLogic>());
+    }
+
+    private sealed class MarkerEmittingCodec : ILogicTextCodec
+    {
+        public string Serialize(IAsyncLogic data) => "noop";
+
+        public IAsyncLogic Deserialize(string s) => s is "noop" or "BehaviorState"
+            ? new EmptyAsyncLogic()
+            : throw new InvalidOperationException($"Unknown logic key '{s}'.");
+    }
+
+    [Test]
+    public void Behavior_claim_on_a_non_marker_node_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "noop" } ],
+              "transitions": [ { "destination": -1 } ],
+              "behaviors": [
+                {
+                  "ownerIndex": 0, "isSync": true, "agentTypeName": null,
+                  "entries": [ { "behaviorTypeName": "NxGraph.Behaviors.Log", "fields": [] } ]
+                }
+              ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(new GraphSerializer(new DummyCodec()), json));
+        Assert.That(ex!.Message, Does.Contain("does not reference a").And.Contain("behavior marker"));
+    }
+
+    [Test]
+    public void Marker_runtime_flavor_must_match_the_claim()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "AsyncBehaviorState" } ],
+              "transitions": [ { "destination": -1 } ],
+              "behaviors": [
+                {
+                  "ownerIndex": 0, "isSync": true, "agentTypeName": null,
+                  "entries": [ { "behaviorTypeName": "NxGraph.Behaviors.Log", "fields": [] } ]
+                }
+              ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(new GraphSerializer(new DummyCodec()), json));
+        Assert.That(ex!.Message, Does.Contain("sync").And.Contain("marked"));
+    }
+
+    [Test]
+    public void Cross_section_claim_overlap_with_forks_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": "BehaviorState" },
+                { "$type": "txt", "index": 1, "name": "b", "logic": "noop" }
+              ],
+              "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+              "forks": [ { "ownerIndex": 0, "branches": [ 1 ] } ],
+              "behaviors": [
+                { "ownerIndex": 0, "isSync": true, "agentTypeName": null, "entries": [] }
+              ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(new GraphSerializer(new DummyCodec()), json));
+        Assert.That(ex!.Message, Does.Contain("claimed by both"));
+    }
+
+    [Test]
+    public void Empty_entry_array_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "BehaviorState" } ],
+              "transitions": [ { "destination": -1 } ],
+              "behaviors": [
+                { "ownerIndex": 0, "isSync": true, "agentTypeName": null, "entries": [] }
+              ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(new GraphSerializer(new DummyCodec()), json));
+        Assert.That(ex!.Message, Does.Contain("at least one entry"));
+    }
+}

--- a/NxGraph.Serialization.Tests/BehaviorSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/BehaviorSerializationTests.cs
@@ -173,7 +173,7 @@ public class BehaviorSerializationTests
     }
 
     [Test]
-    public async Task Payload_carries_markers_section_and_version_eight_stamp()
+    public async Task Payload_carries_markers_section_and_current_version_stamp()
     {
         (BlackboardSchema schema, BlackboardKey<string> message, BlackboardKey<int> target) = TestSchema();
         Graph graph = GraphBuilder.Start()
@@ -186,7 +186,7 @@ public class BehaviorSerializationTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(json, Does.Contain("\"version\": 8"));
+            Assert.That(json, Does.Contain($"\"version\": {SerializationVersion.Version}"));
             Assert.That(json, Does.Contain("\"BehaviorState\""));
             Assert.That(json, Does.Contain("\"AsyncBehaviorState\""));
             Assert.That(json, Does.Contain("\"behaviors\""));

--- a/NxGraph.Serialization.Tests/EventEntrySerializationTests.cs
+++ b/NxGraph.Serialization.Tests/EventEntrySerializationTests.cs
@@ -1,0 +1,484 @@
+using System.Text;
+using System.Text.Json;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// Payload version 7: event entry dispatchers on the wire. The dispatch table
+/// (key names, runtime-stable event type names, targets, Otherwise target) is plain structure
+/// and serializes unconditionally; keys never ride (schemas do not serialize), so the read
+/// side rebuilds unbound registrations and raise resolves the delivery key by name against
+/// the machine's bound board.
+/// </summary>
+[TestFixture]
+[Category("serialization")]
+public class EventEntrySerializationTests
+{
+    private sealed record OrderPlaced(string OrderId, decimal Amount);
+
+    private readonly record struct OrderCanceled(string OrderId);
+
+    // ── Test doubles (ForkJoinSerializationTests pattern) ────────────────
+
+    private interface IKeyed
+    {
+        string Key { get; }
+    }
+
+    private sealed class KeyedBoardState(string key, Func<BlackboardContext, Result> body)
+        : ILogic, IAsyncLogic, IBlackboardSettable, IKeyed
+    {
+        private BlackboardContext _bb;
+
+        public string Key => key;
+
+        void IBlackboardSettable.SetBlackboards(in BlackboardContext context) => _bb = context;
+
+        public Result Execute() => body(_bb);
+
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => new(body(_bb));
+    }
+
+    private sealed class RegistryCodec : ILogicTextCodec
+    {
+        private readonly Dictionary<string, IAsyncLogic> _byKey = new();
+
+        public T Register<T>(string key, T logic) where T : IAsyncLogic
+        {
+            _byKey[key] = logic;
+            return logic;
+        }
+
+        public KeyedBoardState Handler(string key, Func<BlackboardContext, Result> body)
+            => Register(key, new KeyedBoardState(key, body));
+
+        public string Serialize(IAsyncLogic data) => ((IKeyed)data).Key;
+
+        public IAsyncLogic Deserialize(string s) => _byKey.TryGetValue(s, out IAsyncLogic? logic)
+            ? logic
+            : throw new InvalidOperationException($"Unknown logic key '{s}'.");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static async Task<Graph> RoundTrip(GraphSerializer serializer, Graph graph, bool binary)
+    {
+        await using MemoryStream stream = new();
+        if (binary)
+        {
+            await serializer.ToBinaryAsync(graph, stream);
+            stream.Position = 0;
+            return await serializer.FromBinaryAsync(stream);
+        }
+
+        await serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+        return await serializer.FromJsonAsync(stream);
+    }
+
+    private static async Task<Graph> FromJson(GraphSerializer serializer, string json)
+    {
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        return await serializer.FromJsonAsync(source);
+    }
+
+    private static EventEntryState DispatcherOf(Graph graph)
+    {
+        LogicNode start = (LogicNode)graph.StartNode;
+        return (start.AsyncLogic as EventEntryState ?? start.Logic as EventEntryState)!;
+    }
+
+    private sealed class ShopFixture
+    {
+        public required BlackboardSchema Schema;
+        public required BlackboardKey<OrderPlaced> Placed;
+        public required BlackboardKey<OrderCanceled> Canceled;
+        public required RegistryCodec Codec;
+        public required List<string> Log;
+        public required Graph Graph;
+    }
+
+    /// <summary>
+    /// Shop event graph with codec-serializable handlers. Node indexing: chains build first
+    /// (1=reserve, 2=charge, 3=refund, 4=otherwise); the dispatcher seeds as start (0).
+    /// </summary>
+    private static ShopFixture Shop()
+    {
+        BlackboardSchema schema = new("shop");
+        BlackboardKey<OrderPlaced> placed = schema.Register<OrderPlaced>("orderPlaced");
+        BlackboardKey<OrderCanceled> canceled = schema.Register<OrderCanceled>("orderCanceled");
+        RegistryCodec codec = new();
+        List<string> log = [];
+
+        Graph graph = GraphBuilder.StartWithEvents()
+            .On(placed, e => e
+                .To(codec.Handler("reserve", bb =>
+                {
+                    log.Add($"reserve:{bb.Get(placed).OrderId}");
+                    return Result.Success;
+                }))
+                .To(codec.Handler("charge", bb =>
+                {
+                    log.Add($"charge:{bb.Get(placed).Amount}");
+                    return Result.Success;
+                })))
+            .On(canceled, e => e
+                .To(codec.Handler("refund", bb =>
+                {
+                    log.Add($"refund:{bb.Get(canceled).OrderId}");
+                    return Result.Success;
+                })))
+            .Otherwise(e => e
+                .To(codec.Handler("otherwise", _ =>
+                {
+                    log.Add("otherwise");
+                    return Result.Success;
+                })))
+            .WithSchema(schema)
+            .Build();
+
+        return new ShopFixture
+        {
+            Schema = schema, Placed = placed, Canceled = canceled, Codec = codec, Log = log, Graph = graph,
+        };
+    }
+
+    // ── Round-trips ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Event_entry_roundtrips_with_marker_section_and_default_target([Values] bool binary)
+    {
+        ShopFixture shop = Shop();
+        EventEntryState original = DispatcherOf(shop.Graph);
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(shop.Codec), shop.Graph, binary);
+        EventEntryState dispatcher = DispatcherOf(rebuilt);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(dispatcher, Is.Not.Null, "The start node rebuilt as an event dispatcher.");
+            Assert.That(dispatcher.Registrations, Has.Count.EqualTo(2));
+            Assert.That(dispatcher.Registrations[0].KeyName, Is.EqualTo("orderPlaced"));
+            Assert.That(dispatcher.Registrations[1].KeyName, Is.EqualTo("orderCanceled"));
+            Assert.That(dispatcher.Registrations[0].EventTypeName,
+                Is.EqualTo(original.Registrations[0].EventTypeName),
+                "The runtime-stable event type name survives the trip.");
+            Assert.That(dispatcher.Registrations[0].Target.Index,
+                Is.EqualTo(original.Registrations[0].Target.Index));
+            Assert.That(dispatcher.Registrations[1].Target.Index,
+                Is.EqualTo(original.Registrations[1].Target.Index));
+            Assert.That(dispatcher.DefaultTarget.Index, Is.EqualTo(original.DefaultTarget.Index),
+                "The Otherwise target survives the trip.");
+        });
+    }
+
+    [Test]
+    public async Task Deserialized_graph_raise_resolves_event_type_and_key_by_name([Values] bool binary)
+    {
+        ShopFixture shop = Shop();
+        Graph rebuilt = await RoundTrip(new GraphSerializer(shop.Codec), shop.Graph, binary);
+
+        AsyncStateMachine machine = rebuilt.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        Result placed = await machine.ExecuteAsync(new OrderPlaced("o-1", 42m));
+        Result canceled = await machine.ExecuteAsync(new OrderCanceled("o-1"));
+        Result plain = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(placed, Is.EqualTo(Result.Success));
+            Assert.That(canceled, Is.EqualTo(Result.Success));
+            Assert.That(plain, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[]
+            {
+                "reserve:o-1", "charge:42", "refund:o-1", "otherwise",
+            }), "Both typed raises dispatched by name and the plain run took the Otherwise chain.");
+        });
+    }
+
+    [Test]
+    public async Task Deserialized_graph_raise_of_unregistered_type_throws_naming_registered_types()
+    {
+        ShopFixture shop = Shop();
+        Graph rebuilt = await RoundTrip(new GraphSerializer(shop.Codec), shop.Graph, binary: false);
+        AsyncStateMachine machine = rebuilt.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync(42));
+        Assert.That(ex!.Message, Does.Contain("No event entry is registered").And.Contain("OrderPlaced"));
+    }
+
+    [Test]
+    public async Task Deserialized_graph_raise_with_missing_key_name_throws()
+    {
+        ShopFixture shop = Shop();
+        Graph rebuilt = await RoundTrip(new GraphSerializer(shop.Codec), shop.Graph, binary: false);
+
+        BlackboardSchema other = new("other");
+        other.Register<OrderPlaced>("differentName");
+        AsyncStateMachine machine = rebuilt.ToAsyncStateMachine().WithBlackboard(new Blackboard(other));
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync(new OrderPlaced("o-2", 1m)));
+        Assert.That(ex!.Message, Does.Contain("'orderPlaced'").And.Contain("does not exist"));
+    }
+
+    [Test]
+    public async Task Deserialized_graph_raise_with_mismatched_key_type_throws()
+    {
+        ShopFixture shop = Shop();
+        Graph rebuilt = await RoundTrip(new GraphSerializer(shop.Codec), shop.Graph, binary: false);
+
+        BlackboardSchema other = new("other");
+        other.Register<int>("orderPlaced"); // same name, different value type
+        AsyncStateMachine machine = rebuilt.ToAsyncStateMachine().WithBlackboard(new Blackboard(other));
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync(new OrderPlaced("o-3", 1m)));
+        Assert.That(ex!.Message, Does.Contain("'orderPlaced'").And.Contain("declared as"));
+    }
+
+    // ── Version stamps and back compatibility ────────────────────────────
+
+    [Test]
+    public async Task Payload_carries_version_seven_stamp()
+    {
+        ShopFixture shop = Shop();
+        await using MemoryStream stream = new();
+        await new GraphSerializer(shop.Codec).ToJsonAsync(shop.Graph, stream);
+        string json = Encoding.UTF8.GetString(stream.ToArray());
+
+        Assert.That(json, Does.Contain("\"version\": 7"));
+    }
+
+    private static GraphSerializer PlainSerializer()
+    {
+        RegistryCodec codec = new();
+        codec.Register("a", new KeyedBoardState("a", _ => Result.Success));
+        codec.Register("b", new KeyedBoardState("b", _ => Result.Success));
+        return new GraphSerializer(codec);
+    }
+
+    [Test]
+    public async Task Version_six_payload_reads_event_free()
+    {
+        string json = """
+            {
+              "version": 6,
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": "a" },
+                { "$type": "txt", "index": 1, "name": "b", "logic": "b" }
+              ],
+              "transitions": [ { "destination": 1 }, { "destination": -1 } ],
+              "subGraphs": [], "composites": [],
+              "name": null, "index": -1
+            }
+            """;
+
+        Graph rebuilt = await FromJson(PlainSerializer(), json);
+        AsyncStateMachine machine = rebuilt.ToAsyncStateMachine();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(((LogicNode)rebuilt.StartNode).AsyncLogic, Is.Not.InstanceOf<EventEntryState>());
+            InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await machine.ExecuteAsync(new OrderPlaced("x", 0m)));
+            Assert.That(ex!.Message, Does.Contain("no event entries"),
+                "A pre-v7 payload rebuilds as an ordinary graph with no event surface.");
+        });
+    }
+
+    [Test]
+    public void Newer_payload_version_is_rejected()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version + 1}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "a" } ],
+              "transitions": [ { "destination": -1 } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("newer than serializer version"));
+    }
+
+    // ── Marker-spoof defense and negative fixtures ───────────────────────
+
+    [Test]
+    public async Task Event_entry_marker_string_in_ordinary_logic_is_not_honored()
+    {
+        RegistryCodec codec = new();
+        codec.Register("EventEntryState", new KeyedBoardState("EventEntryState", _ => Result.Success));
+
+        Graph graph = GraphBuilder
+            .StartWithAsync(codec.Deserialize("EventEntryState"))
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(codec), graph, binary: false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(((LogicNode)rebuilt.StartNode).AsyncLogic, Is.Not.InstanceOf<EventEntryState>());
+            Assert.That(((IKeyed)((LogicNode)rebuilt.StartNode).AsyncLogic).Key, Is.EqualTo("EventEntryState"));
+        });
+    }
+
+    [Test]
+    public void Event_entry_claim_on_a_non_marker_node_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": "a" },
+                { "$type": "txt", "index": 1, "name": "b", "logic": "b" }
+              ],
+              "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+              "eventEntries": [
+                {
+                  "ownerIndex": 0, "defaultTarget": -1,
+                  "entries": [ { "keyName": "k", "eventTypeName": "T", "targetIndex": 1 } ]
+                }
+              ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("does not reference an event-entry marker"));
+    }
+
+    [Test]
+    public void Cross_section_claim_overlap_with_forks_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": "EventEntryState" },
+                { "$type": "txt", "index": 1, "name": "b", "logic": "b" }
+              ],
+              "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+              "forks": [ { "ownerIndex": 0, "branches": [ 1 ] } ],
+              "eventEntries": [
+                {
+                  "ownerIndex": 0, "defaultTarget": -1,
+                  "entries": [ { "keyName": "k", "eventTypeName": "T", "targetIndex": 1 } ]
+                }
+              ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("claimed by both"));
+    }
+
+    [Test]
+    public void Out_of_range_entry_target_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": "EventEntryState" },
+                { "$type": "txt", "index": 1, "name": "b", "logic": "b" }
+              ],
+              "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+              "eventEntries": [
+                {
+                  "ownerIndex": 0, "defaultTarget": -1,
+                  "entries": [ { "keyName": "k", "eventTypeName": "T", "targetIndex": 9 } ]
+                }
+              ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("out of range"));
+    }
+
+    [Test]
+    public void Empty_entry_array_throws()
+    {
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": "EventEntryState" },
+                { "$type": "txt", "index": 1, "name": "b", "logic": "b" }
+              ],
+              "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+              "eventEntries": [ { "ownerIndex": 0, "defaultTarget": -1, "entries": [] } ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(PlainSerializer(), json));
+        Assert.That(ex!.Message, Does.Contain("at least one entry"));
+    }
+
+    // ── Durability: the full three-artifact loop ─────────────────────────
+
+    [Test]
+    public async Task Suspend_mid_handler_full_durability_round_trip_completes_and_reads_the_event()
+    {
+        ShopFixture shop = Shop();
+        GraphSerializer graphSerializer = new(shop.Codec);
+        BlackboardSerializer boardSerializer = new();
+
+        Blackboard board = new(shop.Schema);
+        AsyncStateMachine running = shop.Graph.ToAsyncStateMachine().WithBlackboard(board);
+
+        Result step1 = await running.StepAsync(new OrderPlaced("o-9", 30m)); // dispatcher
+        Result step2 = await running.StepAsync(); // reserve
+        Assert.Multiple(() =>
+        {
+            Assert.That(step1, Is.EqualTo(Result.InProgress));
+            Assert.That(step2, Is.EqualTo(Result.InProgress));
+        });
+
+        // The three durability artifacts: graph payload, machine snapshot, board payload.
+        await using MemoryStream graphStream = new();
+        await graphSerializer.ToJsonAsync(shop.Graph, graphStream);
+        string snapshotJson = JsonSerializer.Serialize(running.Suspend());
+        await using MemoryStream boardStream = new();
+        await boardSerializer.ToJsonAsync(board, boardStream);
+
+        // "Process boundary": rebuild everything fresh.
+        graphStream.Position = 0;
+        Graph rebuiltGraph = await graphSerializer.FromJsonAsync(graphStream);
+        Blackboard restoredBoard = new(shop.Schema);
+        boardStream.Position = 0;
+        await boardSerializer.RestoreFromJsonAsync(restoredBoard, boardStream);
+
+        AsyncStateMachine resumed = rebuiltGraph.ToAsyncStateMachine().WithBlackboard(restoredBoard);
+        resumed.Resume(JsonSerializer.Deserialize<StateMachineSnapshot>(snapshotJson)!);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await resumed.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Does.Contain("charge:30"),
+                "The handler's later step read the event payload from the restored board — no event replay.");
+        });
+    }
+}

--- a/NxGraph.Serialization.Tests/EventEntrySerializationTests.cs
+++ b/NxGraph.Serialization.Tests/EventEntrySerializationTests.cs
@@ -246,14 +246,14 @@ public class EventEntrySerializationTests
     // ── Version stamps and back compatibility ────────────────────────────
 
     [Test]
-    public async Task Payload_carries_version_seven_stamp()
+    public async Task Payload_carries_current_version_stamp()
     {
         ShopFixture shop = Shop();
         await using MemoryStream stream = new();
         await new GraphSerializer(shop.Codec).ToJsonAsync(shop.Graph, stream);
         string json = Encoding.UTF8.GetString(stream.ToArray());
 
-        Assert.That(json, Does.Contain("\"version\": 7"));
+        Assert.That(json, Does.Contain($"\"version\": {SerializationVersion.Version}"));
     }
 
     private static GraphSerializer PlainSerializer()

--- a/NxGraph.Serialization.Tests/ForkJoinSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/ForkJoinSerializationTests.cs
@@ -509,6 +509,7 @@ public class ForkJoinSerializationTests
             NodeId.JoinStateMarker.Name,
             NodeId.DynamicParallelStateMarker.Name,
             NodeId.SyncDynamicParallelStateMarker.Name,
+            NodeId.EventEntryStateMarker.Name,
         ];
 
         Assert.That(markers, Is.Unique, "Every wire marker string must be distinct.");

--- a/NxGraph.Serialization.Tests/RepeatSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/RepeatSerializationTests.cs
@@ -1,0 +1,447 @@
+using System.Text;
+using NxGraph.Authoring;
+using NxGraph.Behaviors;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization.Tests;
+
+/// <summary>
+/// Payload version 9: nested behavior entries on the wire (spec 015). All four repeat forms
+/// (<c>Repeat</c>/<c>AsyncRepeat</c> plus the <c>&lt;TAgent&gt;</c> twins) ride with zero
+/// options via the default registry; bodies encode recursively through the serializer's entry
+/// codec (so nested user behaviors follow the top-level rules); key-bound counts and index
+/// keys rebind by name; read-side nesting is capped; a wrong-family body entry fails with a
+/// targeted error instead of a cast exception; pre-v9 payloads read unchanged.
+/// </summary>
+[TestFixture]
+[Category("serialization")]
+public class RepeatSerializationTests
+{
+    public sealed class Hero
+    {
+        public readonly List<string> Visits = [];
+    }
+
+    private sealed class GreetHero : IBehavior<Hero>, IAsyncBehavior<Hero>, ISerializableBehavior
+    {
+        public Result Execute(Hero agent, in BehaviorContext ctx)
+        {
+            agent.Visits.Add("greeted");
+            return Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(Hero agent, BehaviorContext ctx, CancellationToken ct)
+        {
+            agent.Visits.Add("greeted");
+            return ResultHelpers.Success;
+        }
+
+        public void Write(BehaviorFieldWriter writer)
+        {
+            // No fields — the greeting is pure agent access.
+        }
+    }
+
+    private sealed class Beep(int times, BlackboardValue<string> sound)
+        : IBehavior, IAsyncBehavior, ISerializableBehavior
+    {
+        public int Times { get; } = times;
+        public BlackboardValue<string> Sound { get; } = sound;
+
+        public Result Execute(in BehaviorContext ctx) => Result.Success;
+
+        public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct) => ResultHelpers.Success;
+
+        public void Write(BehaviorFieldWriter writer)
+        {
+            writer.WriteInt32("times", Times);
+            writer.WriteBinding("sound", Sound);
+        }
+    }
+
+    /// <summary>Sync-only — the wrong-family probe for a crafted AsyncRepeat body.</summary>
+    private sealed class SyncOnlyBeep : IBehavior, ISerializableBehavior
+    {
+        public Result Execute(in BehaviorContext ctx) => Result.Success;
+
+        public void Write(BehaviorFieldWriter writer)
+        {
+        }
+    }
+
+    private sealed class DummyCodec : ILogicTextCodec
+    {
+        public string Serialize(IAsyncLogic data) => "noop";
+
+        public IAsyncLogic Deserialize(string s) => new EmptyAsyncLogic();
+    }
+
+    private sealed class LogCapturingAsyncObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+
+        public ValueTask OnLogReport(NodeId nodeId, string message, CancellationToken ct)
+        {
+            Messages.Add(message);
+            return default;
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static async Task<Graph> RoundTrip(GraphSerializer serializer, Graph graph, bool binary)
+    {
+        await using MemoryStream stream = new();
+        if (binary)
+        {
+            await serializer.ToBinaryAsync(graph, stream);
+            stream.Position = 0;
+            return await serializer.FromBinaryAsync(stream);
+        }
+
+        await serializer.ToJsonAsync(graph, stream);
+        stream.Position = 0;
+        return await serializer.FromJsonAsync(stream);
+    }
+
+    private static async Task<string> ToJson(GraphSerializer serializer, Graph graph)
+    {
+        await using MemoryStream stream = new();
+        await serializer.ToJsonAsync(graph, stream);
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static async Task<Graph> FromJson(GraphSerializer serializer, string json)
+    {
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        return await serializer.FromJsonAsync(source);
+    }
+
+    private static IBehaviorComposite CompositeAt(Graph graph, int index)
+    {
+        LogicNode node = (LogicNode)graph.GetNodeByIndex(index);
+        return (node.Logic as IBehaviorComposite ?? node.AsyncLogic as IBehaviorComposite)!;
+    }
+
+    private static (BlackboardSchema Schema, BlackboardKey<int> Trips, BlackboardKey<int> Index,
+        BlackboardKey<int> Target) LoopSchema()
+    {
+        BlackboardSchema schema = new("loops");
+        BlackboardKey<int> trips = schema.Register("trips", 2);
+        BlackboardKey<int> index = schema.Register("i", -1);
+        BlackboardKey<int> target = schema.Register("target", 0);
+        return (schema, trips, index, target);
+    }
+
+    // ── Untyped forms round-trip with zero options ───────────────────────
+
+    [Test]
+    public async Task Untyped_repeat_forms_roundtrip_with_zero_options([Values] bool binary)
+    {
+        (BlackboardSchema schema, BlackboardKey<int> trips, BlackboardKey<int> index,
+            BlackboardKey<int> target) = LoopSchema();
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new Repeat(trips, index, new Log("sync tick"), new SetValue<int>(target, 5)))
+            .ToBehaviorsAsync(new AsyncRepeat(3, new Log("async tick")))
+            .WithSchema(schema)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(new DummyCodec()), graph, binary);
+
+        Repeat syncRepeat = (Repeat)CompositeAt(rebuilt, 0).Entries[0];
+        AsyncRepeat asyncRepeat = (AsyncRepeat)CompositeAt(rebuilt, 1).Entries[0];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncRepeat.Count.IsBound, Is.True);
+            Assert.That(syncRepeat.Count.KeyName, Is.EqualTo("trips"), "The count key rides by name only.");
+            Assert.That(syncRepeat.IndexKeyName, Is.EqualTo("i"));
+            Assert.That(syncRepeat.Body, Has.Count.EqualTo(2));
+            Assert.That(syncRepeat.Body[0], Is.InstanceOf<Log>());
+            Assert.That(syncRepeat.Body[1], Is.InstanceOf<SetValue<int>>(),
+                "Nested standard entries reconstruct through the same registry dispatch.");
+
+            Assert.That(asyncRepeat.Count.IsBound, Is.False);
+            Assert.That(asyncRepeat.Count.Literal, Is.EqualTo(3));
+            Assert.That(asyncRepeat.IndexKeyName, Is.Null, "No index key rides as a null name.");
+            Assert.That(asyncRepeat.Body, Has.Count.EqualTo(1));
+            Assert.That(asyncRepeat.Body[0], Is.InstanceOf<Log>());
+        });
+    }
+
+    [Test]
+    public async Task Rebound_count_and_index_key_execute_on_the_rebuilt_graph([Values] bool binary)
+    {
+        (BlackboardSchema schema, BlackboardKey<int> trips, BlackboardKey<int> index,
+            BlackboardKey<int> target) = LoopSchema();
+
+        // The body copies the live index into the target key — after the trips resolved from
+        // the board, the target holds the last 0-based index.
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new AsyncRepeat(trips, index, new Log("tick"), new SetValue<int>(target, index)))
+            .WithSchema(schema)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(new GraphSerializer(new DummyCodec()), graph, binary);
+
+        LogCapturingAsyncObserver observer = new();
+        Blackboard board = new(schema);
+        board.Set(trips, 3);
+        Result result = await rebuilt.ToAsyncStateMachine(observer).WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(observer.Messages, Has.Count.EqualTo(3),
+                "The name-bound count resolved against the bound board.");
+            Assert.That(board.Get(target), Is.EqualTo(2),
+                "The name-bound index key was written 0-based before each iteration.");
+        });
+    }
+
+    // ── Typed forms close the generic and re-attach the agent ────────────
+
+    [Test]
+    public async Task Typed_repeat_roundtrips_closing_the_generic_and_reattaching_the_agent([Values] bool binary)
+    {
+        BehaviorRegistry registry = new();
+        registry.Register(typeof(GreetHero).FullName!, _ => new GreetHero());
+        GraphSerializer serializer = new(new DummyCodec(),
+            new GraphSerializerOptions { BehaviorRegistry = registry });
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync<Hero>(new AsyncRepeat<Hero>(2, new Log("typed"), new GreetHero()))
+            .Build();
+
+        Graph rebuilt = await RoundTrip(serializer, graph, binary);
+        IBehaviorComposite composite = CompositeAt(rebuilt, 0);
+
+        Hero hero = new();
+        Result result = await rebuilt.ToAsyncStateMachine<Hero>().WithAgent(hero).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(composite, Is.InstanceOf<AsyncBehaviorState<Hero>>());
+            Assert.That(composite.Entries[0], Is.InstanceOf<AsyncRepeat<Hero>>(),
+                "The stable-name prefix closed AsyncRepeat<TAgent> on read.");
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(hero.Visits, Is.EqualTo(new[] { "greeted", "greeted" }),
+                "The re-attached agent reached the typed body entry every iteration.");
+        });
+    }
+
+    [Test]
+    public async Task Sync_typed_repeat_roundtrips([Values] bool binary)
+    {
+        BehaviorRegistry registry = new();
+        registry.Register(typeof(GreetHero).FullName!, _ => new GreetHero());
+        GraphSerializer serializer = new(new DummyCodec(),
+            new GraphSerializerOptions { BehaviorRegistry = registry });
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors<Hero>(new Repeat<Hero>(2, new GreetHero()))
+            .Build();
+
+        Graph rebuilt = await RoundTrip(serializer, graph, binary);
+        IBehaviorComposite composite = CompositeAt(rebuilt, 0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(composite, Is.InstanceOf<BehaviorState<Hero>>());
+            Assert.That(composite.Entries[0], Is.InstanceOf<Repeat<Hero>>());
+        });
+    }
+
+    // ── User behaviors inside a body ─────────────────────────────────────
+
+    [Test]
+    public async Task User_behavior_in_a_body_roundtrips_via_registered_factory([Values] bool binary)
+    {
+        BlackboardSchema schema = new("sounds");
+        BlackboardKey<string> soundKey = schema.Register("sound", "beep");
+
+        BehaviorRegistry registry = new();
+        registry.Register(typeof(Beep).FullName!,
+            fields => new Beep(fields.ReadInt32("times"), fields.ReadBinding<string>("sound")));
+
+        GraphSerializer serializer = new(new DummyCodec(),
+            new GraphSerializerOptions { BehaviorRegistry = registry });
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new AsyncRepeat(2, new Beep(3, soundKey)))
+            .WithSchema(schema)
+            .Build();
+
+        Graph rebuilt = await RoundTrip(serializer, graph, binary);
+        AsyncRepeat repeat = (AsyncRepeat)CompositeAt(rebuilt, 0).Entries[0];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(repeat.Body, Has.Count.EqualTo(1));
+            Beep beep = (Beep)repeat.Body[0];
+            Assert.That(beep.Times, Is.EqualTo(3), "The nested entry wrote itself via ISerializableBehavior.");
+            Assert.That(beep.Sound.KeyName, Is.EqualTo("sound"),
+                "Nested bindings ride by name, exactly like top-level entries.");
+        });
+    }
+
+    [Test]
+    public async Task Unregistered_user_behavior_in_a_body_fails_read_naming_the_registry()
+    {
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new AsyncRepeat(2, new Beep(1, "x")))
+            .Build();
+
+        // Beep is ISerializableBehavior — the write needs no factory; the zero-options reader does.
+        string json = await ToJson(new GraphSerializer(new DummyCodec()), graph);
+
+        NotSupportedException? ex = Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await FromJson(new GraphSerializer(new DummyCodec()), json));
+        Assert.That(ex!.Message, Does.Contain("Beep").And.Contain("BehaviorRegistry"));
+    }
+
+    // ── Crafted payloads ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task Nesting_beyond_the_depth_cap_is_rejected_on_read()
+    {
+        // Construction is bottom-up and legal at any depth; the write side is uncapped. The
+        // read side treats 40 nested bodies as a crafted payload and stops at the cap.
+        Repeat deep = new(1, new Log("leaf"));
+        for (int i = 0; i < 40; i++)
+        {
+            deep = new Repeat(1, deep);
+        }
+
+        Graph graph = GraphBuilder.Start().ToBehaviors(deep).Build();
+        GraphSerializer serializer = new(new DummyCodec());
+
+        await using MemoryStream stream = new();
+        await serializer.ToBinaryAsync(graph, stream);
+        stream.Position = 0;
+
+        // MessagePack wraps formatter errors — the targeted message rides the innermost exception.
+        Exception? ex = Assert.CatchAsync(async () => await serializer.FromBinaryAsync(stream));
+        while (ex!.InnerException is not null)
+        {
+            ex = ex.InnerException;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex, Is.InstanceOf<InvalidOperationException>());
+            Assert.That(ex!.Message, Does.Contain("nesting depth"));
+        });
+    }
+
+    [Test]
+    public void Wrong_family_body_entry_fails_with_the_targeted_error()
+    {
+        // A crafted payload smuggles a registered sync-only behavior into an AsyncRepeat body
+        // — the reconstruction must fail naming the offender, never as a cast exception.
+        BehaviorRegistry registry = new();
+        registry.Register(typeof(SyncOnlyBeep).FullName!, _ => new SyncOnlyBeep());
+        GraphSerializer serializer = new(new DummyCodec(),
+            new GraphSerializerOptions { BehaviorRegistry = registry });
+
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "AsyncBehaviorState" } ],
+              "transitions": [ { "destination": -1 } ],
+              "behaviors": [
+                {
+                  "ownerIndex": 0, "isSync": false, "agentTypeName": null,
+                  "entries": [
+                    {
+                      "behaviorTypeName": "NxGraph.Behaviors.AsyncRepeat",
+                      "fields": [
+                        { "name": "count",
+                          "value": { "kind": 7, "binding": { "keyName": null, "literal": { "kind": 2, "integer": 1 } } } },
+                        { "name": "indexKey", "value": { "kind": 0, "text": null } },
+                        { "name": "body",
+                          "value": { "kind": 8, "entries": [
+                            { "behaviorTypeName": "{{typeof(SyncOnlyBeep).FullName}}", "fields": [] }
+                          ] } }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "name": null, "index": -1
+            }
+            """;
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await FromJson(serializer, json));
+        Assert.That(ex!.Message, Does.Contain("SyncOnlyBeep").And.Contain("IAsyncBehavior"));
+    }
+
+    // ── Version stamps and back compatibility ────────────────────────────
+
+    [Test]
+    public async Task Payload_carries_the_version_nine_stamp_and_stable_repeat_names()
+    {
+        (BlackboardSchema schema, BlackboardKey<int> trips, BlackboardKey<int> index, _) = LoopSchema();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new Repeat(trips, index, new Log("tick")))
+            .WithSchema(schema)
+            .Build();
+
+        string json = await ToJson(new GraphSerializer(new DummyCodec()), graph);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(SerializationVersion.Version, Is.EqualTo(9));
+            Assert.That(json, Does.Contain("\"version\": 9"));
+            Assert.That(json, Does.Contain("NxGraph.Behaviors.Repeat"));
+            Assert.That(json, Does.Contain("NxGraph.Behaviors.Log"),
+                "The nested body entry rides under its own stable name.");
+        });
+    }
+
+    [Test]
+    public async Task Version_eight_payload_reads_unchanged()
+    {
+        // A v8-era payload: behavior field values carry no entries slot. It must rebuild
+        // exactly as before — the v9 change lives entirely inside the field model.
+        string json = """
+            {
+              "version": 8,
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": "BehaviorState" } ],
+              "transitions": [ { "destination": -1 } ],
+              "behaviors": [
+                {
+                  "ownerIndex": 0, "isSync": true, "agentTypeName": null,
+                  "entries": [
+                    {
+                      "behaviorTypeName": "NxGraph.Behaviors.Log",
+                      "fields": [
+                        { "name": "severity",
+                          "value": { "kind": 7, "binding": { "keyName": null, "literal": { "kind": 6, "text": "Warning" } } } },
+                        { "name": "message",
+                          "value": { "kind": 7, "binding": { "keyName": null, "literal": { "kind": 0, "text": "old payload" } } } }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "name": null, "index": -1
+            }
+            """;
+
+        Graph rebuilt = await FromJson(new GraphSerializer(new DummyCodec()), json);
+        Log log = (Log)CompositeAt(rebuilt, 0).Entries[0];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(log.Severity.Literal, Is.EqualTo(LogSeverity.Warning));
+            Assert.That(log.Message.Literal, Is.EqualTo("old payload"));
+        });
+    }
+}

--- a/NxGraph.Serialization/BehaviorDto.cs
+++ b/NxGraph.Serialization/BehaviorDto.cs
@@ -4,53 +4,62 @@ using NxGraph.Serialization.Abstraction;
 namespace NxGraph.Serialization;
 
 /// <summary>
-/// One entry of a serialized behavior composite (payload version 8): the behavior's
-/// runtime-stable CLR type name (the same rendering the blackboard payloads use) plus its
-/// fields in the neutral field model.
-/// </summary>
-internal sealed record BehaviorEntryDto(string BehaviorTypeName, BehaviorField[] Fields);
-
-/// <summary>
 /// Payload entry for a behavior composite node (payload version 8). <paramref name="IsSync"/>
 /// discriminates the runtime (wire markers "BehaviorState"/"AsyncBehaviorState" must match);
 /// <paramref name="AgentTypeName"/> is the runtime-stable name closing
 /// <c>BehaviorState&lt;TAgent&gt;</c> on read, or null for the untyped composites — the agent
-/// itself never rides (it is runtime context, re-attached via <c>SetAgent</c>).
+/// itself never rides (it is runtime context, re-attached via <c>SetAgent</c>). Entries ride
+/// as the abstraction's <see cref="BehaviorEntry"/> since payload version 9, which lifted the
+/// entry shape out of this file so nested bodies (<see cref="BehaviorFieldKind.Behaviors"/>)
+/// reuse it recursively.
 /// </summary>
-internal sealed record BehaviorDto(int OwnerIndex, bool IsSync, string? AgentTypeName, BehaviorEntryDto[] Entries);
+internal sealed record BehaviorDto(int OwnerIndex, bool IsSync, string? AgentTypeName, BehaviorEntry[] Entries);
 
 internal sealed class BehaviorDtoFormatter : GraphEntityFormatter<BehaviorDto>
 {
     public static readonly BehaviorDtoFormatter Instance = new();
 
+    // Read-side cap on Behaviors-field recursion (payload version 9): a deeper nesting is a
+    // crafted or corrupt payload, not a real graph — without the cap an attacker can
+    // stack-overflow the reader (the deep-suspend depth-cap precedent). Bindings keep their
+    // own nest-one rule.
+    internal const int MaxBehaviorNestingDepth = 32;
+
     public override void Serialize(ref MessagePackWriter writer, BehaviorDto value,
         MessagePackSerializerOptions options)
     {
         // [OwnerIndex, IsSync, AgentTypeName?, [[typeName, [[name, value], ...]], ...]] —
-        // hand-rolled to pin the payload shape; field values nest one level for bindings.
+        // hand-rolled to pin the payload shape; field values nest one level for bindings and
+        // recursively (write side; the read side caps) for nested behavior entries.
         writer.WriteArrayHeader(4);
         writer.Write(value.OwnerIndex);
         writer.Write(value.IsSync);
         writer.Write(value.AgentTypeName);
         writer.WriteArrayHeader(value.Entries.Length);
-        foreach (BehaviorEntryDto entry in value.Entries)
+        foreach (BehaviorEntry entry in value.Entries)
+        {
+            WriteEntry(ref writer, entry);
+        }
+    }
+
+    private static void WriteEntry(ref MessagePackWriter writer, BehaviorEntry entry)
+    {
+        writer.WriteArrayHeader(2);
+        writer.Write(entry.BehaviorTypeName);
+        writer.WriteArrayHeader(entry.Fields.Length);
+        foreach (BehaviorField field in entry.Fields)
         {
             writer.WriteArrayHeader(2);
-            writer.Write(entry.BehaviorTypeName);
-            writer.WriteArrayHeader(entry.Fields.Length);
-            foreach (BehaviorField field in entry.Fields)
-            {
-                writer.WriteArrayHeader(2);
-                writer.Write(field.Name);
-                WriteValue(ref writer, field.Value);
-            }
+            writer.Write(field.Name);
+            WriteValue(ref writer, field.Value);
         }
     }
 
     private static void WriteValue(ref MessagePackWriter writer, BehaviorFieldValue value)
     {
-        // [Kind, Text?, Flag, Integer, Number, Binding?]
-        writer.WriteArrayHeader(6);
+        // [Kind, Text?, Flag, Integer, Number, Binding?, Entries?] — the Entries slot arrived
+        // with payload version 9 (pre-v9 payloads wrote 6 elements; both shapes read).
+        writer.WriteArrayHeader(7);
         writer.Write((byte)value.Kind);
         writer.Write(value.Text);
         writer.Write(value.Flag);
@@ -74,6 +83,19 @@ internal sealed class BehaviorDtoFormatter : GraphEntityFormatter<BehaviorDto>
         {
             writer.WriteNil();
         }
+
+        if (value.Entries is { } entries)
+        {
+            writer.WriteArrayHeader(entries.Length);
+            foreach (BehaviorEntry entry in entries)
+            {
+                WriteEntry(ref writer, entry);
+            }
+        }
+        else
+        {
+            writer.WriteNil();
+        }
     }
 
     public override BehaviorDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
@@ -85,49 +107,55 @@ internal sealed class BehaviorDtoFormatter : GraphEntityFormatter<BehaviorDto>
         bool isSync = reader.ReadBoolean();
         string? agentTypeName = reader.ReadString();
         int entryCount = reader.ReadArrayHeader();
-        BehaviorEntryDto[] entries = new BehaviorEntryDto[entryCount];
+        BehaviorEntry[] entries = new BehaviorEntry[entryCount];
         for (int i = 0; i < entryCount; i++)
         {
-            int entryLength = reader.ReadArrayHeader();
-            if (entryLength != 2)
-                throw new InvalidOperationException(
-                    $"BehaviorDto: entry {i} has {entryLength} elements, expected 2");
-
-            string typeName = reader.ReadString() ??
-                              throw new InvalidOperationException(
-                                  "BehaviorDto: behavior type name cannot be null.");
-            int fieldCount = reader.ReadArrayHeader();
-            BehaviorField[] fields = new BehaviorField[fieldCount];
-            for (int f = 0; f < fieldCount; f++)
-            {
-                int fieldLength = reader.ReadArrayHeader();
-                if (fieldLength != 2)
-                    throw new InvalidOperationException(
-                        $"BehaviorDto: field {f} has {fieldLength} elements, expected 2");
-
-                string name = reader.ReadString() ??
-                              throw new InvalidOperationException("BehaviorDto: field name cannot be null.");
-                fields[f] = new BehaviorField(name, ReadValue(ref reader, depth: 0));
-            }
-
-            entries[i] = new BehaviorEntryDto(typeName, fields);
+            entries[i] = ReadEntry(ref reader, behaviorDepth: 0);
         }
 
         return new BehaviorDto(owner, isSync, agentTypeName, entries);
     }
 
-    private static BehaviorFieldValue ReadValue(ref MessagePackReader reader, int depth)
+    private static BehaviorEntry ReadEntry(ref MessagePackReader reader, int behaviorDepth)
+    {
+        int entryLength = reader.ReadArrayHeader();
+        if (entryLength != 2)
+            throw new InvalidOperationException(
+                $"BehaviorDto: entry has {entryLength} elements, expected 2");
+
+        string typeName = reader.ReadString() ??
+                          throw new InvalidOperationException(
+                              "BehaviorDto: behavior type name cannot be null.");
+        int fieldCount = reader.ReadArrayHeader();
+        BehaviorField[] fields = new BehaviorField[fieldCount];
+        for (int f = 0; f < fieldCount; f++)
+        {
+            int fieldLength = reader.ReadArrayHeader();
+            if (fieldLength != 2)
+                throw new InvalidOperationException(
+                    $"BehaviorDto: field {f} has {fieldLength} elements, expected 2");
+
+            string name = reader.ReadString() ??
+                          throw new InvalidOperationException("BehaviorDto: field name cannot be null.");
+            fields[f] = new BehaviorField(name, ReadValue(ref reader, bindingDepth: 0, behaviorDepth));
+        }
+
+        return new BehaviorEntry(typeName, fields);
+    }
+
+    private static BehaviorFieldValue ReadValue(ref MessagePackReader reader, int bindingDepth, int behaviorDepth)
     {
         // Bindings nest exactly one literal value; anything deeper is a crafted payload.
-        if (depth > 1)
+        if (bindingDepth > 1)
             throw new InvalidOperationException("BehaviorDto: field value nesting exceeds the binding model.");
 
         int length = reader.ReadArrayHeader();
-        if (length != 6)
-            throw new InvalidOperationException($"BehaviorDto: field value has {length} elements, expected 6");
+        if (length != 6 && length != 7)
+            throw new InvalidOperationException(
+                $"BehaviorDto: field value has {length} elements, expected 6 (pre-v9) or 7");
 
         byte kind = reader.ReadByte();
-        if (kind > (byte)BehaviorFieldKind.Binding)
+        if (kind > (byte)BehaviorFieldKind.Behaviors)
             throw new InvalidOperationException($"BehaviorDto: unknown field kind {kind}.");
 
         string? text = reader.ReadString();
@@ -151,13 +179,30 @@ internal sealed class BehaviorDtoFormatter : GraphEntityFormatter<BehaviorDto>
             BehaviorFieldValue? literal = null;
             if (!reader.TryReadNil())
             {
-                literal = ReadValue(ref reader, depth + 1);
+                literal = ReadValue(ref reader, bindingDepth + 1, behaviorDepth);
             }
 
             binding = new BehaviorBinding(keyName, literal);
         }
 
-        return new BehaviorFieldValue((BehaviorFieldKind)kind, text, flag, integer, number, binding);
+        // The Entries slot (payload version 9): pre-v9 values end after the binding.
+        BehaviorEntry[]? entries = null;
+        if (length == 7 && !reader.TryReadNil())
+        {
+            if (behaviorDepth >= MaxBehaviorNestingDepth)
+                throw new InvalidOperationException(
+                    $"BehaviorDto: nested behavior entries exceed the maximum nesting depth " +
+                    $"({MaxBehaviorNestingDepth}).");
+
+            int nestedCount = reader.ReadArrayHeader();
+            entries = new BehaviorEntry[nestedCount];
+            for (int i = 0; i < nestedCount; i++)
+            {
+                entries[i] = ReadEntry(ref reader, behaviorDepth + 1);
+            }
+        }
+
+        return new BehaviorFieldValue((BehaviorFieldKind)kind, text, flag, integer, number, binding, entries);
     }
 }
 

--- a/NxGraph.Serialization/BehaviorDto.cs
+++ b/NxGraph.Serialization/BehaviorDto.cs
@@ -1,0 +1,184 @@
+using MessagePack;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// One entry of a serialized behavior composite (payload version 8): the behavior's
+/// runtime-stable CLR type name (the same rendering the blackboard payloads use) plus its
+/// fields in the neutral field model.
+/// </summary>
+internal sealed record BehaviorEntryDto(string BehaviorTypeName, BehaviorField[] Fields);
+
+/// <summary>
+/// Payload entry for a behavior composite node (payload version 8). <paramref name="IsSync"/>
+/// discriminates the runtime (wire markers "BehaviorState"/"AsyncBehaviorState" must match);
+/// <paramref name="AgentTypeName"/> is the runtime-stable name closing
+/// <c>BehaviorState&lt;TAgent&gt;</c> on read, or null for the untyped composites — the agent
+/// itself never rides (it is runtime context, re-attached via <c>SetAgent</c>).
+/// </summary>
+internal sealed record BehaviorDto(int OwnerIndex, bool IsSync, string? AgentTypeName, BehaviorEntryDto[] Entries);
+
+internal sealed class BehaviorDtoFormatter : GraphEntityFormatter<BehaviorDto>
+{
+    public static readonly BehaviorDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, BehaviorDto value,
+        MessagePackSerializerOptions options)
+    {
+        // [OwnerIndex, IsSync, AgentTypeName?, [[typeName, [[name, value], ...]], ...]] —
+        // hand-rolled to pin the payload shape; field values nest one level for bindings.
+        writer.WriteArrayHeader(4);
+        writer.Write(value.OwnerIndex);
+        writer.Write(value.IsSync);
+        writer.Write(value.AgentTypeName);
+        writer.WriteArrayHeader(value.Entries.Length);
+        foreach (BehaviorEntryDto entry in value.Entries)
+        {
+            writer.WriteArrayHeader(2);
+            writer.Write(entry.BehaviorTypeName);
+            writer.WriteArrayHeader(entry.Fields.Length);
+            foreach (BehaviorField field in entry.Fields)
+            {
+                writer.WriteArrayHeader(2);
+                writer.Write(field.Name);
+                WriteValue(ref writer, field.Value);
+            }
+        }
+    }
+
+    private static void WriteValue(ref MessagePackWriter writer, BehaviorFieldValue value)
+    {
+        // [Kind, Text?, Flag, Integer, Number, Binding?]
+        writer.WriteArrayHeader(6);
+        writer.Write((byte)value.Kind);
+        writer.Write(value.Text);
+        writer.Write(value.Flag);
+        writer.Write(value.Integer);
+        writer.Write(value.Number);
+        if (value.Binding is { } binding)
+        {
+            // [KeyName?, Literal?]
+            writer.WriteArrayHeader(2);
+            writer.Write(binding.KeyName);
+            if (binding.Literal is { } literal)
+            {
+                WriteValue(ref writer, literal);
+            }
+            else
+            {
+                writer.WriteNil();
+            }
+        }
+        else
+        {
+            writer.WriteNil();
+        }
+    }
+
+    public override BehaviorDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        if (count != 4) throw new InvalidOperationException($"BehaviorDto: expected 4 elements, got {count}");
+
+        int owner = reader.ReadInt32();
+        bool isSync = reader.ReadBoolean();
+        string? agentTypeName = reader.ReadString();
+        int entryCount = reader.ReadArrayHeader();
+        BehaviorEntryDto[] entries = new BehaviorEntryDto[entryCount];
+        for (int i = 0; i < entryCount; i++)
+        {
+            int entryLength = reader.ReadArrayHeader();
+            if (entryLength != 2)
+                throw new InvalidOperationException(
+                    $"BehaviorDto: entry {i} has {entryLength} elements, expected 2");
+
+            string typeName = reader.ReadString() ??
+                              throw new InvalidOperationException(
+                                  "BehaviorDto: behavior type name cannot be null.");
+            int fieldCount = reader.ReadArrayHeader();
+            BehaviorField[] fields = new BehaviorField[fieldCount];
+            for (int f = 0; f < fieldCount; f++)
+            {
+                int fieldLength = reader.ReadArrayHeader();
+                if (fieldLength != 2)
+                    throw new InvalidOperationException(
+                        $"BehaviorDto: field {f} has {fieldLength} elements, expected 2");
+
+                string name = reader.ReadString() ??
+                              throw new InvalidOperationException("BehaviorDto: field name cannot be null.");
+                fields[f] = new BehaviorField(name, ReadValue(ref reader, depth: 0));
+            }
+
+            entries[i] = new BehaviorEntryDto(typeName, fields);
+        }
+
+        return new BehaviorDto(owner, isSync, agentTypeName, entries);
+    }
+
+    private static BehaviorFieldValue ReadValue(ref MessagePackReader reader, int depth)
+    {
+        // Bindings nest exactly one literal value; anything deeper is a crafted payload.
+        if (depth > 1)
+            throw new InvalidOperationException("BehaviorDto: field value nesting exceeds the binding model.");
+
+        int length = reader.ReadArrayHeader();
+        if (length != 6)
+            throw new InvalidOperationException($"BehaviorDto: field value has {length} elements, expected 6");
+
+        byte kind = reader.ReadByte();
+        if (kind > (byte)BehaviorFieldKind.Binding)
+            throw new InvalidOperationException($"BehaviorDto: unknown field kind {kind}.");
+
+        string? text = reader.ReadString();
+        bool flag = reader.ReadBoolean();
+        long integer = reader.ReadInt64();
+        double number = reader.ReadDouble();
+
+        BehaviorBinding? binding = null;
+        if (reader.TryReadNil())
+        {
+            // no binding payload
+        }
+        else
+        {
+            int bindingLength = reader.ReadArrayHeader();
+            if (bindingLength != 2)
+                throw new InvalidOperationException(
+                    $"BehaviorDto: binding has {bindingLength} elements, expected 2");
+
+            string? keyName = reader.ReadString();
+            BehaviorFieldValue? literal = null;
+            if (!reader.TryReadNil())
+            {
+                literal = ReadValue(ref reader, depth + 1);
+            }
+
+            binding = new BehaviorBinding(keyName, literal);
+        }
+
+        return new BehaviorFieldValue((BehaviorFieldKind)kind, text, flag, integer, number, binding);
+    }
+}
+
+internal sealed class BehaviorArrayDtoFormatter : GraphEntityFormatter<BehaviorDto[]>
+{
+    public static readonly BehaviorArrayDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, BehaviorDto[] value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(value.Length);
+        for (int i = 0; i < value.Length; i++)
+            BehaviorDtoFormatter.Instance.Serialize(ref writer, value[i], options);
+    }
+
+    public override BehaviorDto[] Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        BehaviorDto[] arr = new BehaviorDto[count];
+        for (int i = 0; i < count; i++)
+            arr[i] = BehaviorDtoFormatter.Instance.Deserialize(ref reader, options);
+        return arr;
+    }
+}

--- a/NxGraph.Serialization/BehaviorRegistry.cs
+++ b/NxGraph.Serialization/BehaviorRegistry.cs
@@ -1,0 +1,121 @@
+using System.Reflection;
+using NxGraph.Behaviors;
+using NxGraph.Serialization.Abstraction;
+
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// Default <see cref="IBehaviorRegistry"/>: user factories keyed by runtime-stable behavior
+/// type name, with the standard set (<c>Log</c> and every closed <c>SetValue&lt;T&gt;</c>)
+/// built in — so standard-set graphs round-trip with <b>zero options configured</b>
+/// (<see cref="GraphSerializer"/> falls back to a fresh instance of this class when no
+/// <see cref="GraphSerializerOptions.BehaviorRegistry"/> is given). <c>SetValue&lt;T&gt;</c>
+/// closes its generic on read via cold-path reflection over the stable type name
+/// (<c>BlackboardSerializer</c> precedent). User factories are consulted first, so a factory
+/// registered under a standard name overrides the built-in handling.
+/// </summary>
+public sealed class BehaviorRegistry : IBehaviorRegistry
+{
+    private static readonly string LogTypeName = BlackboardSerializer.StableTypeName(typeof(Log));
+    private static readonly string SetValuePrefix = typeof(SetValue<>).FullName + "[";
+
+    private readonly Dictionary<string, Func<BehaviorFieldReader, object>> _factories = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Registers a reconstruction factory under <paramref name="behaviorTypeName"/> — the
+    /// behavior's runtime-stable type name, the identity its payload entries carry. The
+    /// factory receives the entry's fields and returns the live behavior instance. Duplicate
+    /// names fail here, at setup, rather than at load time.
+    /// </summary>
+    public void Register(string behaviorTypeName, Func<BehaviorFieldReader, object> factory)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(behaviorTypeName);
+        ArgumentNullException.ThrowIfNull(factory);
+        if (!_factories.TryAdd(behaviorTypeName, factory))
+        {
+            throw new ArgumentException(
+                $"A behavior factory is already registered under '{behaviorTypeName}'.",
+                nameof(behaviorTypeName));
+        }
+    }
+
+    /// <inheritdoc />
+    public bool TryRead(string behaviorTypeName, BehaviorFieldReader fields, out object? behavior)
+    {
+        if (_factories.TryGetValue(behaviorTypeName, out Func<BehaviorFieldReader, object>? factory))
+        {
+            behavior = factory(fields) ?? throw new InvalidOperationException(
+                $"The behavior factory registered under '{behaviorTypeName}' returned null.");
+            return true;
+        }
+
+        if (string.Equals(behaviorTypeName, LogTypeName, StringComparison.Ordinal))
+        {
+            behavior = new Log(fields.ReadBinding<LogSeverity>("severity"), fields.ReadBinding<string>("message"));
+            return true;
+        }
+
+        if (behaviorTypeName.StartsWith(SetValuePrefix, StringComparison.Ordinal) &&
+            behaviorTypeName.EndsWith("]", StringComparison.Ordinal))
+        {
+            behavior = ReadSetValue(behaviorTypeName, fields);
+            return true;
+        }
+
+        behavior = null;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryWrite(object behavior, BehaviorFieldWriter fields)
+    {
+        if (behavior is Log log)
+        {
+            fields.WriteBinding("severity", log.Severity);
+            fields.WriteBinding("message", log.Message);
+            return true;
+        }
+
+        Type type = behavior.GetType();
+        if (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(SetValue<>))
+        {
+            MethodInfo writer = typeof(BehaviorRegistry)
+                .GetMethod(nameof(WriteSetValue), BindingFlags.NonPublic | BindingFlags.Static)!
+                .MakeGenericMethod(type.GetGenericArguments()[0]);
+            writer.Invoke(null, [behavior, fields]);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static object ReadSetValue(string behaviorTypeName, BehaviorFieldReader fields)
+    {
+        string valueTypeName =
+            behaviorTypeName.Substring(SetValuePrefix.Length, behaviorTypeName.Length - SetValuePrefix.Length - 1);
+        if (!StableTypeResolver.TryResolve(valueTypeName, out Type valueType))
+        {
+            throw new InvalidOperationException(
+                $"Behavior payload names '{behaviorTypeName}', but value type '{valueTypeName}' cannot be " +
+                "resolved — ensure the assembly declaring it is loaded.");
+        }
+
+        MethodInfo reader = typeof(BehaviorRegistry)
+            .GetMethod(nameof(ReadSetValueGeneric), BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(valueType);
+        return reader.Invoke(null, [fields])!;
+    }
+
+    private static SetValue<T> ReadSetValueGeneric<T>(BehaviorFieldReader fields)
+    {
+        string keyName = fields.ReadString("key") ?? throw new InvalidOperationException(
+            "SetValue payload carries a null key name.");
+        return SetValue<T>.Unbound(keyName, fields.ReadBinding<T>("value"));
+    }
+
+    private static void WriteSetValue<T>(SetValue<T> behavior, BehaviorFieldWriter fields)
+    {
+        fields.WriteString("key", behavior.KeyName);
+        fields.WriteBinding("value", behavior.Value);
+    }
+}

--- a/NxGraph.Serialization/BehaviorRegistry.cs
+++ b/NxGraph.Serialization/BehaviorRegistry.cs
@@ -6,18 +6,26 @@ namespace NxGraph.Serialization;
 
 /// <summary>
 /// Default <see cref="IBehaviorRegistry"/>: user factories keyed by runtime-stable behavior
-/// type name, with the standard set (<c>Log</c> and every closed <c>SetValue&lt;T&gt;</c>)
-/// built in — so standard-set graphs round-trip with <b>zero options configured</b>
+/// type name, with the standard set (<c>Log</c>, every closed <c>SetValue&lt;T&gt;</c>, and
+/// all four repeat forms — <c>Repeat</c>/<c>AsyncRepeat</c> plus the <c>&lt;TAgent&gt;</c>
+/// twins) built in — so standard-set graphs round-trip with <b>zero options configured</b>
 /// (<see cref="GraphSerializer"/> falls back to a fresh instance of this class when no
-/// <see cref="GraphSerializerOptions.BehaviorRegistry"/> is given). <c>SetValue&lt;T&gt;</c>
-/// closes its generic on read via cold-path reflection over the stable type name
-/// (<c>BlackboardSerializer</c> precedent). User factories are consulted first, so a factory
-/// registered under a standard name overrides the built-in handling.
+/// <see cref="GraphSerializerOptions.BehaviorRegistry"/> is given). Generic forms close on
+/// read via cold-path reflection over the stable type name (<c>BlackboardSerializer</c>
+/// precedent). Repeat bodies ride as nested entry lists (payload version 9) encoded through
+/// the serializer's entry codec, and reconstruct through the <c>Unbound</c> forms with a
+/// targeted error naming the offending entry when a body mixes runtime families. User
+/// factories are consulted first, so a factory registered under a standard name overrides
+/// the built-in handling.
 /// </summary>
 public sealed class BehaviorRegistry : IBehaviorRegistry
 {
     private static readonly string LogTypeName = BlackboardSerializer.StableTypeName(typeof(Log));
     private static readonly string SetValuePrefix = typeof(SetValue<>).FullName + "[";
+    private static readonly string RepeatTypeName = BlackboardSerializer.StableTypeName(typeof(Repeat));
+    private static readonly string AsyncRepeatTypeName = BlackboardSerializer.StableTypeName(typeof(AsyncRepeat));
+    private static readonly string RepeatPrefix = typeof(Repeat<>).FullName + "[";
+    private static readonly string AsyncRepeatPrefix = typeof(AsyncRepeat<>).FullName + "[";
 
     private readonly Dictionary<string, Func<BehaviorFieldReader, object>> _factories = new(StringComparer.Ordinal);
 
@@ -62,6 +70,34 @@ public sealed class BehaviorRegistry : IBehaviorRegistry
             return true;
         }
 
+        if (string.Equals(behaviorTypeName, RepeatTypeName, StringComparison.Ordinal))
+        {
+            behavior = Repeat.Unbound(fields.ReadBinding<int>("count"), fields.ReadString("indexKey"),
+                RepeatBody<IBehavior>(fields, "Repeat"));
+            return true;
+        }
+
+        if (string.Equals(behaviorTypeName, AsyncRepeatTypeName, StringComparison.Ordinal))
+        {
+            behavior = AsyncRepeat.Unbound(fields.ReadBinding<int>("count"), fields.ReadString("indexKey"),
+                RepeatBody<IAsyncBehavior>(fields, "AsyncRepeat"));
+            return true;
+        }
+
+        if (behaviorTypeName.StartsWith(RepeatPrefix, StringComparison.Ordinal) &&
+            behaviorTypeName.EndsWith("]", StringComparison.Ordinal))
+        {
+            behavior = ReadTypedRepeat(behaviorTypeName, RepeatPrefix, nameof(ReadRepeatGeneric), fields);
+            return true;
+        }
+
+        if (behaviorTypeName.StartsWith(AsyncRepeatPrefix, StringComparison.Ordinal) &&
+            behaviorTypeName.EndsWith("]", StringComparison.Ordinal))
+        {
+            behavior = ReadTypedRepeat(behaviorTypeName, AsyncRepeatPrefix, nameof(ReadAsyncRepeatGeneric), fields);
+            return true;
+        }
+
         behavior = null;
         return false;
     }
@@ -76,11 +112,43 @@ public sealed class BehaviorRegistry : IBehaviorRegistry
             return true;
         }
 
+        if (behavior is Repeat repeat)
+        {
+            WriteRepeatFields(fields, repeat.Count, repeat.IndexKeyName, repeat.Body);
+            return true;
+        }
+
+        if (behavior is AsyncRepeat asyncRepeat)
+        {
+            WriteRepeatFields(fields, asyncRepeat.Count, asyncRepeat.IndexKeyName, asyncRepeat.Body);
+            return true;
+        }
+
         Type type = behavior.GetType();
-        if (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(SetValue<>))
+        if (!type.IsConstructedGenericType)
+        {
+            return false;
+        }
+
+        Type definition = type.GetGenericTypeDefinition();
+        if (definition == typeof(SetValue<>))
         {
             MethodInfo writer = typeof(BehaviorRegistry)
                 .GetMethod(nameof(WriteSetValue), BindingFlags.NonPublic | BindingFlags.Static)!
+                .MakeGenericMethod(type.GetGenericArguments()[0]);
+            writer.Invoke(null, [behavior, fields]);
+            return true;
+        }
+
+        if (definition == typeof(Repeat<>) || definition == typeof(AsyncRepeat<>))
+        {
+            // Cold path: reflection only reaches the typed twin's identical field shape —
+            // the agent type parameter never affects the payload beyond the type name.
+            string writerName = definition == typeof(Repeat<>)
+                ? nameof(WriteRepeatGeneric)
+                : nameof(WriteAsyncRepeatGeneric);
+            MethodInfo writer = typeof(BehaviorRegistry)
+                .GetMethod(writerName, BindingFlags.NonPublic | BindingFlags.Static)!
                 .MakeGenericMethod(type.GetGenericArguments()[0]);
             writer.Invoke(null, [behavior, fields]);
             return true;
@@ -117,5 +185,69 @@ public sealed class BehaviorRegistry : IBehaviorRegistry
     {
         fields.WriteString("key", behavior.KeyName);
         fields.WriteBinding("value", behavior.Value);
+    }
+
+    // ── Repeat (payload version 9) ──────────────────────────────────────
+    // All four forms share one field shape: `count` (binding), `indexKey` (string, null when
+    // absent), `body` (nested behavior entries via the serializer's entry codec).
+
+    private static void WriteRepeatFields(BehaviorFieldWriter fields, BlackboardValue<int> count,
+        string? indexKeyName, IReadOnlyList<object> body)
+    {
+        fields.WriteBinding("count", count);
+        fields.WriteString("indexKey", indexKeyName);
+        fields.WriteBehaviors("body", body);
+    }
+
+    private static void WriteRepeatGeneric<TAgent>(Repeat<TAgent> behavior, BehaviorFieldWriter fields) =>
+        WriteRepeatFields(fields, behavior.Count, behavior.IndexKeyName, behavior.Body);
+
+    private static void WriteAsyncRepeatGeneric<TAgent>(AsyncRepeat<TAgent> behavior, BehaviorFieldWriter fields) =>
+        WriteRepeatFields(fields, behavior.Count, behavior.IndexKeyName, behavior.Body);
+
+    private static object ReadTypedRepeat(string behaviorTypeName, string prefix, string readerName,
+        BehaviorFieldReader fields)
+    {
+        string agentTypeName =
+            behaviorTypeName.Substring(prefix.Length, behaviorTypeName.Length - prefix.Length - 1);
+        if (!StableTypeResolver.TryResolve(agentTypeName, out Type agentType))
+        {
+            throw new InvalidOperationException(
+                $"Behavior payload names '{behaviorTypeName}', but agent type '{agentTypeName}' cannot be " +
+                "resolved — ensure the assembly declaring it is loaded.");
+        }
+
+        MethodInfo reader = typeof(BehaviorRegistry)
+            .GetMethod(readerName, BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(agentType);
+        return reader.Invoke(null, [fields])!;
+    }
+
+    private static Repeat<TAgent> ReadRepeatGeneric<TAgent>(BehaviorFieldReader fields) =>
+        Repeat<TAgent>.Unbound(fields.ReadBinding<int>("count"), fields.ReadString("indexKey"),
+            RepeatBody<IBehavior>(fields, $"Repeat<{typeof(TAgent).Name}>"));
+
+    private static AsyncRepeat<TAgent> ReadAsyncRepeatGeneric<TAgent>(BehaviorFieldReader fields) =>
+        AsyncRepeat<TAgent>.Unbound(fields.ReadBinding<int>("count"), fields.ReadString("indexKey"),
+            RepeatBody<IAsyncBehavior>(fields, $"AsyncRepeat<{typeof(TAgent).Name}>"));
+
+    /// <summary>
+    /// Reads a repeat body and casts each reconstructed entry to the family's entry
+    /// interface, with a targeted error naming the offender on mismatch — a crafted payload
+    /// putting a sync-only entry in an async repeat body must not surface as a cast
+    /// exception.
+    /// </summary>
+    private static TEntry[] RepeatBody<TEntry>(BehaviorFieldReader fields, string family) where TEntry : class
+    {
+        object[] body = fields.ReadBehaviors("body");
+        TEntry[] typed = new TEntry[body.Length];
+        for (int i = 0; i < body.Length; i++)
+        {
+            typed[i] = body[i] as TEntry ?? throw new InvalidOperationException(
+                $"{family} body entry {i} ('{body[i].GetType().Name}') does not implement " +
+                $"{typeof(TEntry).Name}, required by the {family} family.");
+        }
+
+        return typed;
     }
 }

--- a/NxGraph.Serialization/EventEntryDto.cs
+++ b/NxGraph.Serialization/EventEntryDto.cs
@@ -1,0 +1,93 @@
+using MessagePack;
+
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// One entry of an event dispatcher's dispatch table on the wire (payload version 7):
+/// the delivery key's registered name, the event's runtime-stable CLR type name (the same
+/// rendering the blackboard payloads use), and the entry chain's head node index. Keys never
+/// ride the payload (schemas do not serialize), so the read side rebuilds unbound
+/// registrations resolved by name at raise time.
+/// </summary>
+internal sealed record EventRegistrationDto(string KeyName, string EventTypeName, int TargetIndex);
+
+/// <summary>
+/// Payload entry for an <c>EventEntryState</c> dispatcher node (payload version 7).
+/// <paramref name="DefaultTarget"/> is the <c>Otherwise</c> chain's head node index, or -1
+/// when the graph has no plain-run entry.
+/// </summary>
+internal sealed record EventEntryDto(int OwnerIndex, int DefaultTarget, EventRegistrationDto[] Entries);
+
+internal sealed class EventEntryDtoFormatter : GraphEntityFormatter<EventEntryDto>
+{
+    public static readonly EventEntryDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, EventEntryDto value,
+        MessagePackSerializerOptions options)
+    {
+        // [OwnerIndex, DefaultTarget, [[keyName, eventTypeName, targetIndex], ...]] —
+        // hand-rolled to pin the payload shape.
+        writer.WriteArrayHeader(3);
+        writer.Write(value.OwnerIndex);
+        writer.Write(value.DefaultTarget);
+        writer.WriteArrayHeader(value.Entries.Length);
+        for (int i = 0; i < value.Entries.Length; i++)
+        {
+            EventRegistrationDto entry = value.Entries[i];
+            writer.WriteArrayHeader(3);
+            writer.Write(entry.KeyName);
+            writer.Write(entry.EventTypeName);
+            writer.Write(entry.TargetIndex);
+        }
+    }
+
+    public override EventEntryDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        if (count != 3) throw new InvalidOperationException($"EventEntryDto: expected 3 elements, got {count}");
+
+        int owner = reader.ReadInt32();
+        int defaultTarget = reader.ReadInt32();
+        int entryCount = reader.ReadArrayHeader();
+        EventRegistrationDto[] entries = new EventRegistrationDto[entryCount];
+        for (int i = 0; i < entryCount; i++)
+        {
+            int entryLength = reader.ReadArrayHeader();
+            if (entryLength != 3)
+                throw new InvalidOperationException(
+                    $"EventEntryDto: entry {i} has {entryLength} elements, expected 3");
+
+            string keyName = reader.ReadString() ??
+                             throw new InvalidOperationException("EventEntryDto: key name cannot be null.");
+            string eventTypeName = reader.ReadString() ??
+                                   throw new InvalidOperationException(
+                                       "EventEntryDto: event type name cannot be null.");
+            int targetIndex = reader.ReadInt32();
+            entries[i] = new EventRegistrationDto(keyName, eventTypeName, targetIndex);
+        }
+
+        return new EventEntryDto(owner, defaultTarget, entries);
+    }
+}
+
+internal sealed class EventEntryArrayDtoFormatter : GraphEntityFormatter<EventEntryDto[]>
+{
+    public static readonly EventEntryArrayDtoFormatter Instance = new();
+
+    public override void Serialize(ref MessagePackWriter writer, EventEntryDto[] value,
+        MessagePackSerializerOptions options)
+    {
+        writer.WriteArrayHeader(value.Length);
+        for (int i = 0; i < value.Length; i++)
+            EventEntryDtoFormatter.Instance.Serialize(ref writer, value[i], options);
+    }
+
+    public override EventEntryDto[] Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        int count = reader.ReadArrayHeader();
+        EventEntryDto[] arr = new EventEntryDto[count];
+        for (int i = 0; i < count; i++)
+            arr[i] = EventEntryDtoFormatter.Instance.Deserialize(ref reader, options);
+        return arr;
+    }
+}

--- a/NxGraph.Serialization/GraphDto.cs
+++ b/NxGraph.Serialization/GraphDto.cs
@@ -13,7 +13,8 @@ internal sealed class GraphDto
     public GraphDto(INodeDto[] nodes, TransitionDto[] transitions, SubGraphDto[]? subGraphs = null, int index = -1,
         string? name = null, RetryPolicyDto[]? retryPolicies = null, OutcomeCodeDto[]? outcomeCodes = null,
         OutcomeNameDto[]? outcomeNames = null, CompositeDto[]? composites = null, UidDto[]? uids = null,
-        ForkDto[]? forks = null, JoinDto[]? joins = null, ContainerDto[]? containers = null)
+        ForkDto[]? forks = null, JoinDto[]? joins = null, ContainerDto[]? containers = null,
+        EventEntryDto[]? eventEntries = null)
     {
         if (nodes.Length != transitions.Length)
             throw new ArgumentException("Nodes and transitions must have the same length.", nameof(transitions));
@@ -30,6 +31,7 @@ internal sealed class GraphDto
         Forks = forks ?? [];
         Joins = joins ?? [];
         Containers = containers ?? [];
+        EventEntries = eventEntries ?? [];
     }
 
     /// <summary>
@@ -53,5 +55,6 @@ internal sealed class GraphDto
     public ForkDto[] Forks { get; set; }
     public JoinDto[] Joins { get; set; }
     public ContainerDto[] Containers { get; set; }
+    public EventEntryDto[] EventEntries { get; set; }
 
 }

--- a/NxGraph.Serialization/GraphDto.cs
+++ b/NxGraph.Serialization/GraphDto.cs
@@ -14,7 +14,7 @@ internal sealed class GraphDto
         string? name = null, RetryPolicyDto[]? retryPolicies = null, OutcomeCodeDto[]? outcomeCodes = null,
         OutcomeNameDto[]? outcomeNames = null, CompositeDto[]? composites = null, UidDto[]? uids = null,
         ForkDto[]? forks = null, JoinDto[]? joins = null, ContainerDto[]? containers = null,
-        EventEntryDto[]? eventEntries = null)
+        EventEntryDto[]? eventEntries = null, BehaviorDto[]? behaviors = null)
     {
         if (nodes.Length != transitions.Length)
             throw new ArgumentException("Nodes and transitions must have the same length.", nameof(transitions));
@@ -32,6 +32,7 @@ internal sealed class GraphDto
         Joins = joins ?? [];
         Containers = containers ?? [];
         EventEntries = eventEntries ?? [];
+        Behaviors = behaviors ?? [];
     }
 
     /// <summary>
@@ -56,5 +57,6 @@ internal sealed class GraphDto
     public JoinDto[] Joins { get; set; }
     public ContainerDto[] Containers { get; set; }
     public EventEntryDto[] EventEntries { get; set; }
+    public BehaviorDto[] Behaviors { get; set; }
 
 }

--- a/NxGraph.Serialization/GraphDtoFormatter.cs
+++ b/NxGraph.Serialization/GraphDtoFormatter.cs
@@ -13,13 +13,14 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
     private const int VersionFiveHeaderCount = 11;
     private const int VersionSixHeaderCount = 14;
     private const int VersionSevenHeaderCount = 15;
+    private const int VersionEightHeaderCount = 16;
 
     public override void Serialize(ref MessagePackWriter writer, GraphDto value, MessagePackSerializerOptions options)
     {
         // [0.Version 1.Index, 2.Name, 3.Nodes[], 4.Transitions[], 5.SubGraphs[],
         //  6.RetryPolicies[], 7.OutcomeCodes[], 8.OutcomeNames[], 9.Composites[], 10.Uids[],
-        //  11.Forks[], 12.Joins[], 13.Containers[], 14.EventEntries[]]
-        writer.WriteArrayHeader(VersionSevenHeaderCount);
+        //  11.Forks[], 12.Joins[], 13.Containers[], 14.EventEntries[], 15.Behaviors[]]
+        writer.WriteArrayHeader(VersionEightHeaderCount);
         writer.Write(value.Version);
         writer.Write(value.Index);
         writer.Write(value.Name);
@@ -44,6 +45,8 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
             .Serialize(ref writer, value.Containers, options);
         options.Resolver.GetFormatterWithVerify<EventEntryDto[]>()
             .Serialize(ref writer, value.EventEntries, options);
+        options.Resolver.GetFormatterWithVerify<BehaviorDto[]>()
+            .Serialize(ref writer, value.Behaviors, options);
     }
 
     public override GraphDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
@@ -79,6 +82,9 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
             case 7 when count < VersionSevenHeaderCount:
                 throw new InvalidOperationException(
                     $"GraphDto: expected at least {VersionSevenHeaderCount} elements, got {count}");
+            case 8 when count < VersionEightHeaderCount:
+                throw new InvalidOperationException(
+                    $"GraphDto: expected at least {VersionEightHeaderCount} elements, got {count}");
         }
 
         int index = reader.ReadInt32();
@@ -141,9 +147,17 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
                 .Deserialize(ref reader, options);
         }
 
+        // Pre-v8 payloads end after EventEntries; the behavior section arrived with version 8.
+        BehaviorDto[] behaviors = [];
+        if (count >= VersionEightHeaderCount)
+        {
+            behaviors = options.Resolver.GetFormatterWithVerify<BehaviorDto[]>()
+                .Deserialize(ref reader, options);
+        }
+
         reader.Depth--;
 
         return new GraphDto(nodes, transitions, subGraphs, index, name, retryPolicies, outcomeCodes, outcomeNames,
-            composites, uids, forks, joins, containers, eventEntries) { Version = version };
+            composites, uids, forks, joins, containers, eventEntries, behaviors) { Version = version };
     }
 }

--- a/NxGraph.Serialization/GraphDtoFormatter.cs
+++ b/NxGraph.Serialization/GraphDtoFormatter.cs
@@ -82,7 +82,8 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
             case 7 when count < VersionSevenHeaderCount:
                 throw new InvalidOperationException(
                     $"GraphDto: expected at least {VersionSevenHeaderCount} elements, got {count}");
-            case 8 when count < VersionEightHeaderCount:
+            // v9 changed only the behavior field model (nested entries), not the header shape.
+            case 8 or 9 when count < VersionEightHeaderCount:
                 throw new InvalidOperationException(
                     $"GraphDto: expected at least {VersionEightHeaderCount} elements, got {count}");
         }

--- a/NxGraph.Serialization/GraphDtoFormatter.cs
+++ b/NxGraph.Serialization/GraphDtoFormatter.cs
@@ -12,13 +12,14 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
     private const int VersionFourHeaderCount = 10;
     private const int VersionFiveHeaderCount = 11;
     private const int VersionSixHeaderCount = 14;
+    private const int VersionSevenHeaderCount = 15;
 
     public override void Serialize(ref MessagePackWriter writer, GraphDto value, MessagePackSerializerOptions options)
     {
         // [0.Version 1.Index, 2.Name, 3.Nodes[], 4.Transitions[], 5.SubGraphs[],
         //  6.RetryPolicies[], 7.OutcomeCodes[], 8.OutcomeNames[], 9.Composites[], 10.Uids[],
-        //  11.Forks[], 12.Joins[], 13.Containers[]]
-        writer.WriteArrayHeader(VersionSixHeaderCount);
+        //  11.Forks[], 12.Joins[], 13.Containers[], 14.EventEntries[]]
+        writer.WriteArrayHeader(VersionSevenHeaderCount);
         writer.Write(value.Version);
         writer.Write(value.Index);
         writer.Write(value.Name);
@@ -41,6 +42,8 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
             .Serialize(ref writer, value.Joins, options);
         options.Resolver.GetFormatterWithVerify<ContainerDto[]>()
             .Serialize(ref writer, value.Containers, options);
+        options.Resolver.GetFormatterWithVerify<EventEntryDto[]>()
+            .Serialize(ref writer, value.EventEntries, options);
     }
 
     public override GraphDto Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
@@ -73,6 +76,9 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
             case 6 when count < VersionSixHeaderCount:
                 throw new InvalidOperationException(
                     $"GraphDto: expected at least {VersionSixHeaderCount} elements, got {count}");
+            case 7 when count < VersionSevenHeaderCount:
+                throw new InvalidOperationException(
+                    $"GraphDto: expected at least {VersionSevenHeaderCount} elements, got {count}");
         }
 
         int index = reader.ReadInt32();
@@ -127,9 +133,17 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
                 .Deserialize(ref reader, options);
         }
 
+        // Pre-v7 payloads end after Containers; the event entry section arrived with version 7.
+        EventEntryDto[] eventEntries = [];
+        if (count >= VersionSevenHeaderCount)
+        {
+            eventEntries = options.Resolver.GetFormatterWithVerify<EventEntryDto[]>()
+                .Deserialize(ref reader, options);
+        }
+
         reader.Depth--;
 
         return new GraphDto(nodes, transitions, subGraphs, index, name, retryPolicies, outcomeCodes, outcomeNames,
-            composites, uids, forks, joins, containers) { Version = version };
+            composites, uids, forks, joins, containers, eventEntries) { Version = version };
     }
 }

--- a/NxGraph.Serialization/GraphFormatterResolver.cs
+++ b/NxGraph.Serialization/GraphFormatterResolver.cs
@@ -169,6 +169,18 @@ internal sealed class GraphFormatterResolver : IFormatterResolver
                 return;
             }
 
+            if (typeof(T) == typeof(BehaviorDto))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)BehaviorDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(BehaviorDto[]))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)BehaviorArrayDtoFormatter.Instance;
+                return;
+            }
+
             Formatter = null;
         }
     }

--- a/NxGraph.Serialization/GraphFormatterResolver.cs
+++ b/NxGraph.Serialization/GraphFormatterResolver.cs
@@ -157,6 +157,18 @@ internal sealed class GraphFormatterResolver : IFormatterResolver
                 return;
             }
 
+            if (typeof(T) == typeof(EventEntryDto))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)EventEntryDtoFormatter.Instance;
+                return;
+            }
+
+            if (typeof(T) == typeof(EventEntryDto[]))
+            {
+                Formatter = (IMessagePackFormatter<T>)(object)EventEntryArrayDtoFormatter.Instance;
+                return;
+            }
+
             Formatter = null;
         }
     }

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using MessagePack;
 using MessagePack.Resolvers;
+using NxGraph.Behaviors;
 using NxGraph.Blackboards;
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
@@ -26,6 +27,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
     private readonly ILogicCodec _codec;
     private readonly IRegionSelectorRegistry? _selectorRegistry;
     private readonly IContainerCodec? _containerCodec;
+    private readonly IBehaviorRegistry _behaviorRegistry;
     private readonly MessagePackSerializerOptions _options;
 
     private readonly JsonSerializerOptions _jsonOptions;
@@ -40,6 +42,9 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         ArgumentNullException.ThrowIfNull(codec);
         _selectorRegistry = options?.SelectorRegistry;
         _containerCodec = options?.ContainerCodec;
+        // The default registry carries the standard behavior set built in, so standard-set
+        // graphs round-trip with zero options configured (payload version 8).
+        _behaviorRegistry = options?.BehaviorRegistry ?? new BehaviorRegistry();
 
         // Wire-type coherence: the container codec's payload rides in the same node DTO slot
         // as the logic codec's, so their wire types must match. Fail at setup, not save time.
@@ -194,6 +199,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         List<JoinDto> joins = [];
         List<ContainerDto> containers = [];
         List<EventEntryDto> eventEntries = [];
+        List<BehaviorDto> behaviors = [];
         INodeDto[] nodes = new INodeDto[nodeCount];
         for (int index = 0; index < nodeCount; index++)
         {
@@ -246,6 +252,22 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                         eventEntries.Add(new EventEntryDto(index, defaultTarget, entries));
                         nodes[index] = new NodeTextDto(index, node.Id.Name,
                             LogicNode.EventEntryStateMarker.Id.Name);
+                        break;
+                    }
+
+                    // Behavior composites (payload version 8): entries serialize into the
+                    // neutral field model — through their own ISerializableBehavior.Write or
+                    // the registry's built-in standard-set handling — and the composite's
+                    // shape (runtime, agent type) is structure. Detected via the non-generic
+                    // IBehaviorComposite surface so closed BehaviorState<TAgent> types need
+                    // no reflection here.
+                    if ((logicNode.Logic as IBehaviorComposite ??
+                         logicNode.AsyncLogic as IBehaviorComposite) is { } behaviorComposite)
+                    {
+                        behaviors.Add(BuildBehaviorDto(index, node.Id, behaviorComposite));
+                        nodes[index] = new NodeTextDto(index, node.Id.Name, behaviorComposite.IsSync
+                            ? LogicNode.BehaviorStateMarker.Id.Name
+                            : LogicNode.AsyncBehaviorStateMarker.Id.Name);
                         break;
                     }
 
@@ -472,7 +494,43 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
 
         return new GraphDto(nodes, transitions, subGraphs.ToArray(), graph.Id.Index, graph.Id.Name, retryPolicies,
             outcomeCodes, outcomeNames, composites.ToArray(), uids, forks.ToArray(), joins.ToArray(),
-            containers.ToArray(), eventEntries.ToArray());
+            containers.ToArray(), eventEntries.ToArray(), behaviors.ToArray());
+    }
+
+    /// <summary>
+    /// Serializes one behavior composite's entries into the neutral field model. Entries
+    /// implementing <see cref="ISerializableBehavior"/> write themselves; the registry covers
+    /// the standard set; anything else fails with the targeted error naming the unlocking
+    /// option (the dynamic-parallel/container precedent).
+    /// </summary>
+    private BehaviorDto BuildBehaviorDto(int index, NodeId nodeId, IBehaviorComposite composite)
+    {
+        IReadOnlyList<object> entries = composite.Entries;
+        BehaviorEntryDto[] entryDtos = new BehaviorEntryDto[entries.Count];
+        for (int i = 0; i < entries.Count; i++)
+        {
+            object entry = entries[i];
+            BehaviorFieldWriter writer = new();
+            if (entry is ISerializableBehavior serializable)
+            {
+                serializable.Write(writer);
+            }
+            else if (!_behaviorRegistry.TryWrite(entry, writer))
+            {
+                throw new NotSupportedException(
+                    $"Node '{nodeId}' contains behavior '{entry.GetType().Name}', which is neither an " +
+                    "ISerializableBehavior nor known to the behavior registry. Implement ISerializableBehavior " +
+                    "on it and register a reconstruction factory on GraphSerializerOptions.BehaviorRegistry.");
+            }
+
+            entryDtos[i] = new BehaviorEntryDto(BlackboardSerializer.StableTypeName(entry.GetType()),
+                writer.ToFields());
+        }
+
+        string? agentTypeName = composite.AgentType is { } agentType
+            ? BlackboardSerializer.StableTypeName(agentType)
+            : null;
+        return new BehaviorDto(index, composite.IsSync, agentTypeName, entryDtos);
     }
 
     /// <summary>
@@ -586,6 +644,17 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     $"Event entry DTO owner index {eventEntryDto.OwnerIndex} is duplicated in the payload.");
         }
 
+        // Claim-first for the v8 behavior section: the "BehaviorState"/"AsyncBehaviorState"
+        // markers are only honored when a BehaviorDto claims the node index.
+        Dictionary<int, BehaviorDto>? behaviorOwners = null;
+        foreach (BehaviorDto behaviorDto in dto.Behaviors)
+        {
+            behaviorOwners ??= new Dictionary<int, BehaviorDto>();
+            if (!behaviorOwners.TryAdd(behaviorDto.OwnerIndex, behaviorDto))
+                throw new InvalidOperationException(
+                    $"Behavior DTO owner index {behaviorDto.OwnerIndex} is duplicated in the payload.");
+        }
+
         // A node index may be claimed by at most one section. Before markerless container
         // claims this was implicit via marker matching; now it must be explicit — an
         // overlapping claim is a corrupt or crafted payload, not something to route by luck.
@@ -597,6 +666,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             AddClaims(ref claimedBy, joinOwners?.Keys, "Joins");
             AddClaims(ref claimedBy, containerOwners?.Keys, "Containers");
             AddClaims(ref claimedBy, eventEntryOwners?.Keys, "EventEntries");
+            AddClaims(ref claimedBy, behaviorOwners?.Keys, "Behaviors");
         }
 
         INode[] nodes = new INode[nodesLength];
@@ -672,6 +742,25 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                         eventEntryOwners is not null && eventEntryOwners.ContainsKey(nodeDto.Index))
                     {
                         nodes[nodeDto.Index] = LogicNode.EventEntryStateMarker;
+                        break;
+                    }
+
+                    // Behavior markers (v8): honored only when a BehaviorDto claims this node
+                    // index. The runtime flavor must match the claim's IsSync — a mismatched
+                    // pair is a corrupt or crafted payload.
+                    if ((textDto.Logic == LogicNode.BehaviorStateMarker.Id.Name ||
+                         textDto.Logic == LogicNode.AsyncBehaviorStateMarker.Id.Name) &&
+                        behaviorOwners is not null &&
+                        behaviorOwners.TryGetValue(nodeDto.Index, out BehaviorDto? behaviorClaim))
+                    {
+                        LogicNode expectedMarker = behaviorClaim.IsSync
+                            ? LogicNode.BehaviorStateMarker
+                            : LogicNode.AsyncBehaviorStateMarker;
+                        if (textDto.Logic != expectedMarker.Id.Name)
+                            throw new InvalidOperationException(
+                                $"Behavior DTO for node {nodeDto.Index} is {(behaviorClaim.IsSync ? "sync" : "async")} " +
+                                $"but the node is marked '{textDto.Logic}'.");
+                        nodes[nodeDto.Index] = expectedMarker;
                         break;
                     }
 
@@ -987,6 +1076,60 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     (IAsyncLogic)new EventEntryState(registrations, defaultTarget));
         }
 
+        // Rebuild behavior composites (v8) through the public constructors so entry
+        // validation (non-empty, agent-type checks) re-runs. Entries reconstruct through the
+        // behavior registry; key bindings rebuild name-bound and resolve against the
+        // machine's bound boards at execution. A typed composite's AgentTypeName closes
+        // BehaviorState<TAgent> via cold-path reflection — the agent itself never rides and
+        // is re-attached via SetAgent.
+        foreach (BehaviorDto behaviorDto in dto.Behaviors)
+        {
+            if (behaviorDto.OwnerIndex < 0 || behaviorDto.OwnerIndex >= nodesLength)
+                throw new InvalidOperationException(
+                    $"Behavior DTO owner index {behaviorDto.OwnerIndex} is out of range (0..{nodesLength - 1}).");
+
+            LogicNode expectedMarker = behaviorDto.IsSync
+                ? LogicNode.BehaviorStateMarker
+                : LogicNode.AsyncBehaviorStateMarker;
+            if (!ReferenceEquals(nodes[behaviorDto.OwnerIndex], expectedMarker))
+                throw new InvalidOperationException(
+                    $"Behavior DTO owner index {behaviorDto.OwnerIndex} does not reference a " +
+                    $"'{expectedMarker.Id.Name}' behavior marker node.");
+            if (behaviorDto.Entries.Length == 0)
+                throw new InvalidOperationException(
+                    $"Behavior DTO for node {behaviorDto.OwnerIndex} must carry at least one entry.");
+
+            object[] entries = new object[behaviorDto.Entries.Length];
+            for (int e = 0; e < entries.Length; e++)
+            {
+                BehaviorEntryDto entry = behaviorDto.Entries[e];
+                if (string.IsNullOrEmpty(entry.BehaviorTypeName))
+                    throw new InvalidOperationException(
+                        $"Behavior DTO for node {behaviorDto.OwnerIndex} has an entry with a missing behavior " +
+                        "type name.");
+
+                BehaviorFieldReader reader = new(entry.Fields);
+                if (!_behaviorRegistry.TryRead(entry.BehaviorTypeName, reader, out object? behavior) ||
+                    behavior is null)
+                    throw new NotSupportedException(
+                        $"Behavior DTO for node {behaviorDto.OwnerIndex} names behavior type " +
+                        $"'{entry.BehaviorTypeName}', which the behavior registry cannot reconstruct. Register " +
+                        "a factory for it on GraphSerializerOptions.BehaviorRegistry.");
+
+                entries[e] = behavior;
+            }
+
+            string behaviorNodeName = dto.Nodes[behaviorDto.OwnerIndex] switch
+            {
+                NodeTextDto nt => nt.Name,
+                NodeBinaryDto nb => nb.Name,
+                _ => $"Node_{behaviorDto.OwnerIndex}"
+            };
+
+            nodes[behaviorDto.OwnerIndex] = new LogicNode(
+                new NodeId(behaviorDto.OwnerIndex, behaviorNodeName), BuildBehaviorComposite(behaviorDto, entries));
+        }
+
         // Rebuild container-codec nodes (v6): children first (in wire order = SubGraphs
         // enumeration order), then the node's ordinary logic payload routes to the container
         // codec, which owns the reconstruction recipe.
@@ -1147,6 +1290,57 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         }
 
         return selector;
+    }
+
+    /// <summary>
+    /// Rebuilds one behavior composite from its reconstructed entries, closing the typed
+    /// variants over the payload's runtime-stable agent type name. Sync composites re-wrap
+    /// in the sync-logic adapter so the node stays runnable on both runtimes, mirroring the
+    /// nested-machine and composite installs above.
+    /// </summary>
+    private static IAsyncLogic BuildBehaviorComposite(BehaviorDto behaviorDto, object[] entries)
+    {
+        if (behaviorDto.IsSync)
+        {
+            IBehavior[] syncEntries = CastBehaviorEntries<IBehavior>(behaviorDto, entries);
+            ILogic composite = behaviorDto.AgentTypeName is null
+                ? new BehaviorState(syncEntries)
+                : (ILogic)CreateTypedComposite(behaviorDto, typeof(BehaviorState<>), syncEntries);
+            return new SyncLogicAdapter(composite);
+        }
+
+        IAsyncBehavior[] asyncEntries = CastBehaviorEntries<IAsyncBehavior>(behaviorDto, entries);
+        return behaviorDto.AgentTypeName is null
+            ? new AsyncBehaviorState(asyncEntries)
+            : (IAsyncLogic)CreateTypedComposite(behaviorDto, typeof(AsyncBehaviorState<>), asyncEntries);
+    }
+
+    private static object CreateTypedComposite(BehaviorDto behaviorDto, Type openComposite, object entriesArray)
+    {
+        if (!StableTypeResolver.TryResolve(behaviorDto.AgentTypeName!, out Type agentType))
+            throw new InvalidOperationException(
+                $"Behavior DTO for node {behaviorDto.OwnerIndex} names agent type " +
+                $"'{behaviorDto.AgentTypeName}', which cannot be resolved — ensure the assembly declaring it " +
+                "is loaded.");
+
+        // The params ctor's real signature is (IBehavior[]/IAsyncBehavior[]), so the array
+        // rides as the single constructor argument; ctor validation re-runs on load.
+        return Activator.CreateInstance(openComposite.MakeGenericType(agentType), [entriesArray])!;
+    }
+
+    private static TEntry[] CastBehaviorEntries<TEntry>(BehaviorDto behaviorDto, object[] entries)
+        where TEntry : class
+    {
+        TEntry[] typed = new TEntry[entries.Length];
+        for (int i = 0; i < entries.Length; i++)
+        {
+            typed[i] = entries[i] as TEntry ?? throw new InvalidOperationException(
+                $"Behavior DTO for node {behaviorDto.OwnerIndex}: reconstructed behavior " +
+                $"'{entries[i].GetType().Name}' does not implement {typeof(TEntry).Name}, required by the " +
+                $"{(behaviorDto.IsSync ? "sync" : "async")} composite.");
+        }
+
+        return typed;
     }
 
     /// <summary>

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -193,6 +193,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         List<ForkDto> forks = [];
         List<JoinDto> joins = [];
         List<ContainerDto> containers = [];
+        List<EventEntryDto> eventEntries = [];
         INodeDto[] nodes = new INodeDto[nodeCount];
         for (int index = 0; index < nodeCount; index++)
         {
@@ -219,6 +220,32 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     {
                         joins.Add(new JoinDto(index, (byte)join.Policy.Kind, join.Policy.Count));
                         nodes[index] = new NodeTextDto(index, node.Id.Name, LogicNode.JoinStateMarker.Id.Name);
+                        break;
+                    }
+
+                    // Event dispatchers (payload version 7): the dispatch table is plain
+                    // structure — key names, runtime-stable event type names, target indexes,
+                    // and the Otherwise target. Keys never ride (schemas do not serialize);
+                    // the read side rebuilds unbound registrations resolved by name at raise
+                    // time. One marker for both runtimes, like fork/join.
+                    if ((logicNode.AsyncLogic as EventEntryState ??
+                         logicNode.Logic as EventEntryState) is { } eventEntry)
+                    {
+                        EventRegistrationDto[] entries =
+                            new EventRegistrationDto[eventEntry.Registrations.Count];
+                        for (int e = 0; e < entries.Length; e++)
+                        {
+                            EventRegistration registration = eventEntry.Registrations[e];
+                            entries[e] = new EventRegistrationDto(registration.KeyName,
+                                registration.EventTypeName, registration.Target.Index);
+                        }
+
+                        int defaultTarget = eventEntry.DefaultTarget == NodeId.Default
+                            ? -1
+                            : eventEntry.DefaultTarget.Index;
+                        eventEntries.Add(new EventEntryDto(index, defaultTarget, entries));
+                        nodes[index] = new NodeTextDto(index, node.Id.Name,
+                            LogicNode.EventEntryStateMarker.Id.Name);
                         break;
                     }
 
@@ -445,7 +472,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
 
         return new GraphDto(nodes, transitions, subGraphs.ToArray(), graph.Id.Index, graph.Id.Name, retryPolicies,
             outcomeCodes, outcomeNames, composites.ToArray(), uids, forks.ToArray(), joins.ToArray(),
-            containers.ToArray());
+            containers.ToArray(), eventEntries.ToArray());
     }
 
     /// <summary>
@@ -548,6 +575,17 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     $"Container DTO owner index {containerDto.OwnerIndex} is duplicated in the payload.");
         }
 
+        // Claim-first for the v7 event entry section: the "EventEntryState" marker is only
+        // honored when an EventEntryDto claims the node index.
+        Dictionary<int, EventEntryDto>? eventEntryOwners = null;
+        foreach (EventEntryDto eventEntryDto in dto.EventEntries)
+        {
+            eventEntryOwners ??= new Dictionary<int, EventEntryDto>();
+            if (!eventEntryOwners.TryAdd(eventEntryDto.OwnerIndex, eventEntryDto))
+                throw new InvalidOperationException(
+                    $"Event entry DTO owner index {eventEntryDto.OwnerIndex} is duplicated in the payload.");
+        }
+
         // A node index may be claimed by at most one section. Before markerless container
         // claims this was implicit via marker matching; now it must be explicit — an
         // overlapping claim is a corrupt or crafted payload, not something to route by luck.
@@ -558,6 +596,7 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             AddClaims(ref claimedBy, forkOwners?.Keys, "Forks");
             AddClaims(ref claimedBy, joinOwners?.Keys, "Joins");
             AddClaims(ref claimedBy, containerOwners?.Keys, "Containers");
+            AddClaims(ref claimedBy, eventEntryOwners?.Keys, "EventEntries");
         }
 
         INode[] nodes = new INode[nodesLength];
@@ -624,6 +663,15 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                         joinOwners is not null && joinOwners.ContainsKey(nodeDto.Index))
                     {
                         nodes[nodeDto.Index] = LogicNode.JoinStateMarker;
+                        break;
+                    }
+
+                    // Event entry marker (v7): honored only when an EventEntryDto claims this
+                    // node index — an unclaimed marker string is ordinary codec payload.
+                    if (textDto.Logic == LogicNode.EventEntryStateMarker.Id.Name &&
+                        eventEntryOwners is not null && eventEntryOwners.ContainsKey(nodeDto.Index))
+                    {
+                        nodes[nodeDto.Index] = LogicNode.EventEntryStateMarker;
                         break;
                     }
 
@@ -882,6 +930,61 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
 
             nodes[joinDto.OwnerIndex] = new LogicNode(new NodeId(joinDto.OwnerIndex, joinNodeName),
                 new JoinState(policy));
+        }
+
+        // Rebuild event dispatchers (v7) through the public constructor so duplicate-type-name
+        // validation re-runs. Registrations rebuild unbound — keys never ride the payload
+        // (schemas do not serialize), so raise on the rebuilt graph resolves the event type by
+        // its runtime-stable name and the delivery key by name against the machine's bound
+        // Graph board schema. Target ids rebuild as bare indexes, like fork branches.
+        foreach (EventEntryDto eventEntryDto in dto.EventEntries)
+        {
+            if (eventEntryDto.OwnerIndex < 0 || eventEntryDto.OwnerIndex >= nodesLength)
+                throw new InvalidOperationException(
+                    $"Event entry DTO owner index {eventEntryDto.OwnerIndex} is out of range (0..{nodesLength - 1}).");
+            if (!ReferenceEquals(nodes[eventEntryDto.OwnerIndex], LogicNode.EventEntryStateMarker))
+                throw new InvalidOperationException(
+                    $"Event entry DTO owner index {eventEntryDto.OwnerIndex} does not reference an event-entry " +
+                    "marker node.");
+            if (eventEntryDto.Entries.Length == 0)
+                throw new InvalidOperationException(
+                    $"Event entry DTO for node {eventEntryDto.OwnerIndex} must carry at least one entry.");
+            if (eventEntryDto.DefaultTarget < -1 || eventEntryDto.DefaultTarget >= nodesLength)
+                throw new InvalidOperationException(
+                    $"Event entry DTO for node {eventEntryDto.OwnerIndex} has default target " +
+                    $"{eventEntryDto.DefaultTarget} out of range (-1..{nodesLength - 1}).");
+
+            EventRegistration[] registrations = new EventRegistration[eventEntryDto.Entries.Length];
+            for (int e = 0; e < registrations.Length; e++)
+            {
+                EventRegistrationDto entry = eventEntryDto.Entries[e];
+                if (string.IsNullOrEmpty(entry.KeyName) || string.IsNullOrEmpty(entry.EventTypeName))
+                    throw new InvalidOperationException(
+                        $"Event entry DTO for node {eventEntryDto.OwnerIndex} has an entry with a missing key " +
+                        "or event type name.");
+                if (entry.TargetIndex < 0 || entry.TargetIndex >= nodesLength)
+                    throw new InvalidOperationException(
+                        $"Event entry DTO for node {eventEntryDto.OwnerIndex} has entry target index " +
+                        $"{entry.TargetIndex} out of range (0..{nodesLength - 1}).");
+
+                registrations[e] = EventRegistration.Unbound(entry.KeyName, entry.EventTypeName,
+                    new NodeId(entry.TargetIndex));
+            }
+
+            NodeId defaultTarget = eventEntryDto.DefaultTarget == -1
+                ? NodeId.Default
+                : new NodeId(eventEntryDto.DefaultTarget);
+
+            string eventEntryNodeName = dto.Nodes[eventEntryDto.OwnerIndex] switch
+            {
+                NodeTextDto nt => nt.Name,
+                NodeBinaryDto nb => nb.Name,
+                _ => $"Node_{eventEntryDto.OwnerIndex}"
+            };
+
+            nodes[eventEntryDto.OwnerIndex] =
+                new LogicNode(new NodeId(eventEntryDto.OwnerIndex, eventEntryNodeName),
+                    (IAsyncLogic)new EventEntryState(registrations, defaultTarget));
         }
 
         // Rebuild container-codec nodes (v6): children first (in wire order = SubGraphs

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -498,39 +498,88 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
     }
 
     /// <summary>
-    /// Serializes one behavior composite's entries into the neutral field model. Entries
-    /// implementing <see cref="ISerializableBehavior"/> write themselves; the registry covers
-    /// the standard set; anything else fails with the targeted error naming the unlocking
-    /// option (the dynamic-parallel/container precedent).
+    /// Serializes one behavior composite's entries into the neutral field model through the
+    /// per-session entry codec. Entries implementing <see cref="ISerializableBehavior"/>
+    /// write themselves; the registry covers the standard set; anything else fails with the
+    /// targeted error naming the unlocking option (the dynamic-parallel/container precedent).
+    /// The same dispatch applies recursively to nested bodies
+    /// (<see cref="BehaviorFieldKind.Behaviors"/> fields, payload version 9).
     /// </summary>
     private BehaviorDto BuildBehaviorDto(int index, NodeId nodeId, IBehaviorComposite composite)
     {
         IReadOnlyList<object> entries = composite.Entries;
-        BehaviorEntryDto[] entryDtos = new BehaviorEntryDto[entries.Count];
+        BehaviorEntryCodec codec = new(_behaviorRegistry, $"Node '{nodeId}'");
+        BehaviorEntry[] entryDtos = new BehaviorEntry[entries.Count];
         for (int i = 0; i < entries.Count; i++)
         {
-            object entry = entries[i];
-            BehaviorFieldWriter writer = new();
-            if (entry is ISerializableBehavior serializable)
-            {
-                serializable.Write(writer);
-            }
-            else if (!_behaviorRegistry.TryWrite(entry, writer))
-            {
-                throw new NotSupportedException(
-                    $"Node '{nodeId}' contains behavior '{entry.GetType().Name}', which is neither an " +
-                    "ISerializableBehavior nor known to the behavior registry. Implement ISerializableBehavior " +
-                    "on it and register a reconstruction factory on GraphSerializerOptions.BehaviorRegistry.");
-            }
-
-            entryDtos[i] = new BehaviorEntryDto(BlackboardSerializer.StableTypeName(entry.GetType()),
-                writer.ToFields());
+            entryDtos[i] = codec.WriteEntry(entries[i]);
         }
 
         string? agentTypeName = composite.AgentType is { } agentType
             ? BlackboardSerializer.StableTypeName(agentType)
             : null;
         return new BehaviorDto(index, composite.IsSync, agentTypeName, entryDtos);
+    }
+
+    /// <summary>
+    /// Per-payload-session behavior entry codec (payload version 9): the serializer's
+    /// per-entry dispatch — write: <see cref="ISerializableBehavior.Write"/> else
+    /// <see cref="IBehaviorRegistry.TryWrite"/>; read: registry-first
+    /// <see cref="IBehaviorRegistry.TryRead"/> — wired into every
+    /// <see cref="BehaviorFieldWriter"/>/<see cref="BehaviorFieldReader"/> the serializer
+    /// creates, so nested entry lists encode under exactly the top-level rules. The read side
+    /// caps entry nesting (crafted-payload guard, matching the MessagePack formatter's cap —
+    /// the codec-neutral backstop for the JSON path).
+    /// </summary>
+    private sealed class BehaviorEntryCodec(IBehaviorRegistry registry, string owner) : IBehaviorEntryCodec
+    {
+        private int _readDepth;
+
+        public BehaviorEntry WriteEntry(object behavior)
+        {
+            BehaviorFieldWriter writer = new(this);
+            if (behavior is ISerializableBehavior serializable)
+            {
+                serializable.Write(writer);
+            }
+            else if (!registry.TryWrite(behavior, writer))
+            {
+                throw new NotSupportedException(
+                    $"{owner} contains behavior '{behavior.GetType().Name}', which is neither an " +
+                    "ISerializableBehavior nor known to the behavior registry. Implement ISerializableBehavior " +
+                    "on it and register a reconstruction factory on GraphSerializerOptions.BehaviorRegistry.");
+            }
+
+            return new BehaviorEntry(BlackboardSerializer.StableTypeName(behavior.GetType()), writer.ToFields());
+        }
+
+        public object ReadEntry(BehaviorEntry entry)
+        {
+            if (string.IsNullOrEmpty(entry.BehaviorTypeName))
+                throw new InvalidOperationException(
+                    $"{owner} has an entry with a missing behavior type name.");
+            if (_readDepth >= BehaviorDtoFormatter.MaxBehaviorNestingDepth)
+                throw new InvalidOperationException(
+                    $"{owner}: nested behavior entries exceed the maximum nesting depth " +
+                    $"({BehaviorDtoFormatter.MaxBehaviorNestingDepth}).");
+
+            _readDepth++;
+            try
+            {
+                BehaviorFieldReader reader = new(entry.Fields, this);
+                if (!registry.TryRead(entry.BehaviorTypeName, reader, out object? behavior) || behavior is null)
+                    throw new NotSupportedException(
+                        $"{owner} names behavior type '{entry.BehaviorTypeName}', which the behavior registry " +
+                        "cannot reconstruct. Register a factory for it on " +
+                        "GraphSerializerOptions.BehaviorRegistry.");
+
+                return behavior;
+            }
+            finally
+            {
+                _readDepth--;
+            }
+        }
     }
 
     /// <summary>
@@ -1099,24 +1148,14 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                 throw new InvalidOperationException(
                     $"Behavior DTO for node {behaviorDto.OwnerIndex} must carry at least one entry.");
 
+            // Entries reconstruct through the per-session entry codec — the same registry-first
+            // dispatch applied recursively to nested bodies (payload version 9).
+            BehaviorEntryCodec entryCodec = new(_behaviorRegistry,
+                $"Behavior DTO for node {behaviorDto.OwnerIndex}");
             object[] entries = new object[behaviorDto.Entries.Length];
             for (int e = 0; e < entries.Length; e++)
             {
-                BehaviorEntryDto entry = behaviorDto.Entries[e];
-                if (string.IsNullOrEmpty(entry.BehaviorTypeName))
-                    throw new InvalidOperationException(
-                        $"Behavior DTO for node {behaviorDto.OwnerIndex} has an entry with a missing behavior " +
-                        "type name.");
-
-                BehaviorFieldReader reader = new(entry.Fields);
-                if (!_behaviorRegistry.TryRead(entry.BehaviorTypeName, reader, out object? behavior) ||
-                    behavior is null)
-                    throw new NotSupportedException(
-                        $"Behavior DTO for node {behaviorDto.OwnerIndex} names behavior type " +
-                        $"'{entry.BehaviorTypeName}', which the behavior registry cannot reconstruct. Register " +
-                        "a factory for it on GraphSerializerOptions.BehaviorRegistry.");
-
-                entries[e] = behavior;
+                entries[e] = entryCodec.ReadEntry(behaviorDto.Entries[e]);
             }
 
             string behaviorNodeName = dto.Nodes[behaviorDto.OwnerIndex] switch

--- a/NxGraph.Serialization/GraphSerializerOptions.cs
+++ b/NxGraph.Serialization/GraphSerializerOptions.cs
@@ -24,4 +24,13 @@ public sealed class GraphSerializerOptions
     /// logic codec's — the container payload rides in the same node DTO slot.
     /// </summary>
     public IContainerCodec? ContainerCodec { get; init; }
+
+    /// <summary>
+    /// Resolves behavior payload identities (payload version 8). When left null the
+    /// serializer uses a fresh default <see cref="BehaviorRegistry"/>, which carries the
+    /// standard set (<c>Log</c>, closed <c>SetValue&lt;T&gt;</c>) built in — standard-set
+    /// graphs round-trip with zero options. Configure one to register reconstruction
+    /// factories for user <c>ISerializableBehavior</c> implementations.
+    /// </summary>
+    public IBehaviorRegistry? BehaviorRegistry { get; init; }
 }

--- a/NxGraph.Serialization/SerializationVersion.cs
+++ b/NxGraph.Serialization/SerializationVersion.cs
@@ -17,6 +17,12 @@ public static class SerializationVersion
     //     other sections) — dispatch table as (KeyName, EventTypeName, TargetIndex) entries
     //     plus the Otherwise target; keys never ride, so the read side rebuilds unbound
     //     registrations resolved by name against the machine's bound board at raise time.
-    public const int Version = 7;
+    // v8: behavior composite section ("BehaviorState"/"AsyncBehaviorState" markers, sparse
+    //     BehaviorDto beside the other sections) — entries as (BehaviorTypeName, Fields[])
+    //     in the neutral field model, bindings by key name (rebound against the machine's
+    //     bound boards at execution), AgentTypeName closing BehaviorState<TAgent> on read;
+    //     the standard set (Log, SetValue<T>) rides with zero options via the default
+    //     BehaviorRegistry.
+    public const int Version = 8;
 }
 

--- a/NxGraph.Serialization/SerializationVersion.cs
+++ b/NxGraph.Serialization/SerializationVersion.cs
@@ -13,6 +13,10 @@ public static class SerializationVersion
     //     composite kinds + SelectorKey ("DynamicParallelState"/"SyncDynamicParallelState"
     //     markers, selector resolved via IRegionSelectorRegistry), container section
     //     (markerless claims routed to the configured IContainerCodec).
-    public const int Version = 6;
+    // v7: event entry section ("EventEntryState" marker, sparse EventEntryDto beside the
+    //     other sections) — dispatch table as (KeyName, EventTypeName, TargetIndex) entries
+    //     plus the Otherwise target; keys never ride, so the read side rebuilds unbound
+    //     registrations resolved by name against the machine's bound board at raise time.
+    public const int Version = 7;
 }
 

--- a/NxGraph.Serialization/SerializationVersion.cs
+++ b/NxGraph.Serialization/SerializationVersion.cs
@@ -23,6 +23,12 @@ public static class SerializationVersion
     //     bound boards at execution), AgentTypeName closing BehaviorState<TAgent> on read;
     //     the standard set (Log, SetValue<T>) rides with zero options via the default
     //     BehaviorRegistry.
-    public const int Version = 8;
+    // v9: nested behavior entries (BehaviorFieldKind.Behaviors) — field values gain an
+    //     Entries slot carrying BehaviorEntry lists, encoded recursively through the
+    //     serializer's entry codec, so Repeat/AsyncRepeat bodies (and user behaviors nested
+    //     inside them) ride under the top-level entry rules; read-side nesting is capped at
+    //     32. No new section — the change lives entirely inside the field model, and pre-v9
+    //     payloads never contain the new kind, so they read unchanged.
+    public const int Version = 9;
 }
 

--- a/NxGraph.Serialization/StableTypeResolver.cs
+++ b/NxGraph.Serialization/StableTypeResolver.cs
@@ -1,0 +1,170 @@
+using System.Reflection;
+
+namespace NxGraph.Serialization;
+
+/// <summary>
+/// Resolves the runtime-stable type names the payloads carry (see
+/// <see cref="BlackboardSerializer.StableTypeName"/> for the rendering) back to live
+/// <see cref="Type"/>s — cold read-side reflection, the <c>BlackboardSerializer</c>
+/// precedent. Simple names probe <see cref="Type.GetType(string)"/> and then every loaded
+/// assembly; constructed generics and arrays are parsed recursively, because stable names
+/// deliberately omit assembly qualification.
+/// </summary>
+internal static class StableTypeResolver
+{
+    internal static bool TryResolve(string stableName, out Type type)
+    {
+        Type? resolved = Resolve(stableName.Trim());
+        type = resolved!;
+        return resolved is not null;
+    }
+
+    private static Type? Resolve(string name)
+    {
+        if (name.Length == 0)
+        {
+            return null;
+        }
+
+        if (!name.EndsWith("]", StringComparison.Ordinal))
+        {
+            return ResolveSimple(name);
+        }
+
+        int open = FindMatchingOpen(name);
+        if (open <= 0)
+        {
+            return null;
+        }
+
+        string inner = name.Substring(open + 1, name.Length - open - 2);
+        if (IsArraySuffix(inner))
+        {
+            Type? element = Resolve(name.Substring(0, open));
+            if (element is null)
+            {
+                return null;
+            }
+
+            int rank = inner.Length + 1; // "" → 1, "," → 2, ...
+            return rank == 1 ? element.MakeArrayType() : element.MakeArrayType(rank);
+        }
+
+        Type? definition = ResolveSimple(name.Substring(0, open));
+        if (definition is null || !definition.IsGenericTypeDefinition)
+        {
+            return null;
+        }
+
+        string[] parts = SplitTopLevel(inner);
+        if (definition.GetGenericArguments().Length != parts.Length)
+        {
+            return null;
+        }
+
+        Type[] arguments = new Type[parts.Length];
+        for (int i = 0; i < parts.Length; i++)
+        {
+            Type? argument = Resolve(parts[i].Trim());
+            if (argument is null)
+            {
+                return null;
+            }
+
+            arguments[i] = argument;
+        }
+
+        try
+        {
+            return definition.MakeGenericType(arguments);
+        }
+        catch (ArgumentException)
+        {
+            return null; // constraint violation — treat as unresolvable, callers throw targeted errors
+        }
+    }
+
+    private static Type? ResolveSimple(string name)
+    {
+        Type? type = Type.GetType(name);
+        if (type is not null)
+        {
+            return type;
+        }
+
+        foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            type = assembly.GetType(name);
+            if (type is not null)
+            {
+                return type;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsArraySuffix(string inner)
+    {
+        foreach (char c in inner)
+        {
+            if (c != ',')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Index of the '[' matching the final ']' of <paramref name="name"/>, or -1.</summary>
+    private static int FindMatchingOpen(string name)
+    {
+        int depth = 0;
+        for (int i = name.Length - 1; i >= 0; i--)
+        {
+            switch (name[i])
+            {
+                case ']':
+                    depth++;
+                    break;
+                case '[':
+                    depth--;
+                    if (depth == 0)
+                    {
+                        return i;
+                    }
+
+                    break;
+            }
+        }
+
+        return -1;
+    }
+
+    private static string[] SplitTopLevel(string inner)
+    {
+        List<string> parts = [];
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < inner.Length; i++)
+        {
+            switch (inner[i])
+            {
+                case '[':
+                    depth++;
+                    break;
+                case ']':
+                    depth--;
+                    break;
+                case ',' when depth == 0:
+                    parts.Add(inner.Substring(start, i - start));
+                    start = i + 1;
+                    break;
+            }
+        }
+
+        parts.Add(inner.Substring(start));
+        return parts.ToArray();
+    }
+}

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -729,6 +729,85 @@ public class AllocationGateTests
         AssertZeroAlloc(token.ToStateMachine(new NoopSyncObserver()));
     }
 
+    // ── Event entry points (spec 013): typed raise + run ────────────────
+
+    private readonly record struct GatePing(int Value);
+
+    private static (Graph graph, Blackboard board, BlackboardKey<GatePing> ping) EventGraph(bool sync)
+    {
+        BlackboardSchema schema = new("gate-events");
+        BlackboardKey<GatePing> ping = schema.Register<GatePing>("ping");
+
+        Graph graph = sync
+            ? GraphBuilder.StartWithEvents()
+                .On(ping, e => e
+                    .To(bb => bb.Get(ping).Value >= 0 ? Result.Success : Result.Failure)
+                    .To(ping, (evt, _) => evt.Value >= 0 ? Result.Success : Result.Failure))
+                .WithSchema(schema)
+                .Build()
+            : GraphBuilder.StartWithEvents()
+                .On(ping, e => e
+                    .ToAsync((bb, _) => bb.Get(ping).Value >= 0 ? ResultHelpers.Success : ResultHelpers.Failure)
+                    .ToAsync(ping, (evt, _, _) => evt.Value >= 0 ? ResultHelpers.Success : ResultHelpers.Failure))
+                .WithSchema(schema)
+                .Build();
+
+        return (graph, new Blackboard(schema), ping);
+    }
+
+    [Test]
+    public async Task async_typed_event_raise_and_run_is_allocation_free()
+    {
+        (Graph graph, Blackboard board, BlackboardKey<GatePing> _) = EventGraph(sync: false);
+        AsyncStateMachine machine = graph.ToAsyncStateMachine().WithBlackboard(board);
+
+        for (int i = 0; i < 50; i++)
+        {
+            await machine.ExecuteAsync(new GatePing(i));
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < Iterations; i++)
+        {
+            await machine.ExecuteAsync(new GatePing(i));
+        }
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.That(allocated, Is.Zero,
+            $"Typed event raise allocated {allocated} B over {Iterations} runs.");
+    }
+
+    [Test]
+    public void sync_typed_event_raise_and_run_is_allocation_free()
+    {
+        (Graph graph, Blackboard board, BlackboardKey<GatePing> _) = EventGraph(sync: true);
+        StateMachine machine = graph.ToStateMachine().WithBlackboard(board);
+
+        for (int i = 0; i < 50; i++)
+        {
+            RaiseToCompletion(machine, new GatePing(i));
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < Iterations; i++)
+        {
+            RaiseToCompletion(machine, new GatePing(i));
+        }
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.That(allocated, Is.Zero,
+            $"Sync typed event raise allocated {allocated} B over {Iterations} runs.");
+    }
+
+    private static void RaiseToCompletion<TEvent>(StateMachine machine, TEvent evt)
+    {
+        Result result = machine.Execute(evt);
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+    }
+
     // ── Token runtime (spec 007): pooled tokens, fork/join, per-token scratch ──
 
     private static void AssertZeroAllocTokens(NxGraph.Tokens.TokenMachine machine)

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -929,6 +929,46 @@ public class AllocationGateTests
         await AssertZeroAllocTokensAsync(TokenDiamond().ToAsyncTokenMachine(new NoopAsyncTokenObserver()));
     }
 
+    // ── Behaviors: sequence run loop + binding resolution (spec 014) ────
+    //
+    // A behavior node with a key-bound Log (observer-less, so no string is ever formatted)
+    // and a SetValue must execute at 0 B steady-state: the run loop is an array walk over
+    // one stack context, and binding resolution is a branch plus a typed Get.
+
+    private static (Behaviors.Log log, Behaviors.SetValue<int> set, Blackboard board) BehaviorFixture()
+    {
+        BlackboardSchema schema = new("behaviors");
+        BlackboardKey<string> message = schema.Register("message", "steady");
+        BlackboardKey<int> source = schema.Register("source", 7);
+        BlackboardKey<int> target = schema.Register<int>("target");
+
+        Behaviors.Log log = new(Behaviors.LogSeverity.Info, message);
+        Behaviors.SetValue<int> set = new(target, source);
+        return (log, set, new Blackboard(schema));
+    }
+
+    [Test]
+    public async Task async_behavior_node_is_allocation_free()
+    {
+        (Behaviors.Log log, Behaviors.SetValue<int> set, Blackboard board) = BehaviorFixture();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(log, set)
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine().WithBlackboard(board));
+    }
+
+    [Test]
+    public void sync_behavior_node_is_allocation_free()
+    {
+        (Behaviors.Log log, Behaviors.SetValue<int> set, Blackboard board) = BehaviorFixture();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(log, set)
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine().WithBlackboard(board));
+    }
+
     private sealed class NoopAsyncTokenObserver : NxGraph.Tokens.IAsyncTokenMachineObserver
     {
         public ValueTask OnStateEntered(int tokenId, NodeId id, CancellationToken ct = default) =>

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -969,6 +969,46 @@ public class AllocationGateTests
         AssertZeroAlloc(graph.ToStateMachine().WithBlackboard(board));
     }
 
+    // ── Repeat: bounded sub-node iteration (spec 015) ───────────────────
+    //
+    // A Repeat with a key-bound count and an index key over a SetValue body must execute at
+    // 0 B steady-state: count resolution is a branch plus a typed Get (once at entry), the
+    // index write is a typed Set, and iteration is an array walk.
+
+    private static (Behaviors.Repeat repeat, Blackboard board) RepeatFixture()
+    {
+        BlackboardSchema schema = new("repeat");
+        BlackboardKey<int> trips = schema.Register("trips", 3);
+        BlackboardKey<int> index = schema.Register("i", 0);
+        BlackboardKey<int> source = schema.Register("source", 7);
+        BlackboardKey<int> target = schema.Register<int>("target");
+
+        Behaviors.Repeat repeat = new(trips, index, new Behaviors.SetValue<int>(target, source));
+        return (repeat, new Blackboard(schema));
+    }
+
+    [Test]
+    public async Task async_repeat_behavior_node_is_allocation_free()
+    {
+        (Behaviors.Repeat repeat, Blackboard board) = RepeatFixture();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(repeat)
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine().WithBlackboard(board));
+    }
+
+    [Test]
+    public void sync_repeat_behavior_node_is_allocation_free()
+    {
+        (Behaviors.Repeat repeat, Blackboard board) = RepeatFixture();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(repeat)
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine().WithBlackboard(board));
+    }
+
     private sealed class NoopAsyncTokenObserver : NxGraph.Tokens.IAsyncTokenMachineObserver
     {
         public ValueTask OnStateEntered(int tokenId, NodeId id, CancellationToken ct = default) =>

--- a/NxGraph.Tests/BehaviorTests.cs
+++ b/NxGraph.Tests/BehaviorTests.cs
@@ -1,0 +1,666 @@
+using NxGraph.Authoring;
+using NxGraph.Behaviors;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Behavior composition (spec 014): declarative, reusable, blackboard-bound sequences inside
+/// one node. Codifies the contract: in-order fail-fast execution under the node's fault
+/// model, the binding primitive across all scopes, the report channel, runtime parity of the
+/// dual-interface standard set, and the agent-typed channel (agent as call parameter, never
+/// stamped onto behaviors).
+/// </summary>
+[TestFixture]
+[Category("behaviors")]
+public class BehaviorTests
+{
+    // ── Test doubles ─────────────────────────────────────────────────────
+
+    /// <summary>Dual-interface probe: appends its id to a shared trace, returns a fixed result.</summary>
+    private sealed class TraceBehavior(string id, List<string> trace, Func<Result>? result = null)
+        : IBehavior, IAsyncBehavior
+    {
+        public Result Execute(in BehaviorContext ctx)
+        {
+            trace.Add(id);
+            return result?.Invoke() ?? Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct)
+        {
+            trace.Add(id);
+            return new ValueTask<Result>(result?.Invoke() ?? Result.Success);
+        }
+    }
+
+    /// <summary>Dual-interface probe: resolves a binding and records the value.</summary>
+    private sealed class CaptureBehavior<T>(BlackboardValue<T> value, List<T?> captured)
+        : IBehavior, IAsyncBehavior
+    {
+        public Result Execute(in BehaviorContext ctx)
+        {
+            captured.Add(ctx.Resolve(value));
+            return Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct)
+        {
+            captured.Add(ctx.Resolve(value));
+            return ResultHelpers.Success;
+        }
+    }
+
+    private sealed class ThrowingBehavior : IBehavior, IAsyncBehavior
+    {
+        public Result Execute(in BehaviorContext ctx) => throw new InvalidOperationException("boom");
+
+        public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct) =>
+            throw new InvalidOperationException("boom");
+    }
+
+    private sealed class Hero
+    {
+        public required string Name;
+        public List<string> Visits = [];
+    }
+
+    private sealed class Villain;
+
+    /// <summary>Agent-typed dual-interface probe: records which agent instance it received.</summary>
+    private sealed class GreetHero : IBehavior<Hero>, IAsyncBehavior<Hero>
+    {
+        public Result Execute(Hero agent, in BehaviorContext ctx)
+        {
+            agent.Visits.Add($"greet:{agent.Name}");
+            return Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(Hero agent, BehaviorContext ctx, CancellationToken ct)
+        {
+            agent.Visits.Add($"greet:{agent.Name}");
+            return ResultHelpers.Success;
+        }
+    }
+
+    private sealed class VillainOnly : IBehavior<Villain>
+    {
+        public Result Execute(Villain agent, in BehaviorContext ctx) => Result.Success;
+    }
+
+    private sealed class LogCapturingAsyncObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+
+        public ValueTask OnLogReport(NodeId nodeId, string message, CancellationToken ct)
+        {
+            Messages.Add(message);
+            return default;
+        }
+    }
+
+    private sealed class LogCapturingSyncObserver : IStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+
+        void IStateMachineObserver.OnLogReport(NodeId nodeId, string message) => Messages.Add(message);
+    }
+
+    private static Result RunToEnd(StateMachine machine)
+    {
+        Result result = machine.Execute();
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+
+    // ── Sequence semantics ───────────────────────────────────────────────
+
+    [Test]
+    public async Task Async_sequence_runs_in_order()
+    {
+        List<string> trace = [];
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(
+                new TraceBehavior("a", trace),
+                new TraceBehavior("b", trace),
+                new TraceBehavior("c", trace))
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "a", "b", "c" }));
+        });
+    }
+
+    [Test]
+    public void Sync_sequence_runs_in_order()
+    {
+        List<string> trace = [];
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(
+                new TraceBehavior("a", trace),
+                new TraceBehavior("b", trace),
+                new TraceBehavior("c", trace))
+            .Build();
+
+        Result result = RunToEnd(graph.ToStateMachine());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "a", "b", "c" }));
+        });
+    }
+
+    [Test]
+    public async Task Fail_fast_stops_the_sequence_and_fails_the_node([Values] bool sync)
+    {
+        List<string> trace = [];
+        TraceBehavior[] behaviors =
+        [
+            new("a", trace),
+            new("fail", trace, () => Result.Failure),
+            new("never", trace),
+        ];
+
+        Graph graph = sync
+            ? GraphBuilder.Start().ToBehaviors(behaviors).Build()
+            : GraphBuilder.Start().ToBehaviorsAsync(behaviors).Build();
+
+        Result result = sync
+            ? RunToEnd(graph.ToStateMachine())
+            : await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(trace, Is.EqualTo(new[] { "a", "fail" }),
+                "Entries after the first failure must not run — fail-fast, the opposite of AllState.");
+        });
+    }
+
+    [Test]
+    public async Task Node_retry_reruns_the_whole_list()
+    {
+        List<string> trace = [];
+        int failuresLeft = 1;
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(
+                new TraceBehavior("a", trace),
+                new TraceBehavior("flaky", trace, () => failuresLeft-- > 0 ? Result.Failure : Result.Success),
+                new TraceBehavior("b", trace))
+            .Retry(maxAttempts: 2)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "a", "flaky", "a", "flaky", "b" }),
+                "The retry re-runs the whole sequence in place, not just the failed entry.");
+        });
+    }
+
+    [Test]
+    public async Task OnError_reroutes_a_failed_behavior_node()
+    {
+        List<string> trace = [];
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new TraceBehavior("fail", trace, () => Result.Failure))
+            .OnErrorAsync(_ =>
+            {
+                trace.Add("handler");
+                return ResultHelpers.Success;
+            })
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "fail", "handler" }));
+        });
+    }
+
+    [Test]
+    public async Task WithOutcome_codes_a_terminal_behavior_node()
+    {
+        List<string> trace = [];
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new TraceBehavior("done", trace))
+            .WithOutcome(7, "Done")
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+        Result result = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(machine.LastOutcome, Is.EqualTo(7));
+            Assert.That(machine.LastOutcomeName, Is.EqualTo("Done"));
+        });
+    }
+
+    [Test]
+    public void Behavior_exceptions_propagate_as_from_any_node_logic([Values] bool sync)
+    {
+        Graph graph = sync
+            ? GraphBuilder.Start().ToBehaviors(new ThrowingBehavior()).Build()
+            : GraphBuilder.Start().ToBehaviorsAsync(new ThrowingBehavior()).Build();
+
+        if (sync)
+        {
+            InvalidOperationException? ex =
+                Assert.Throws<InvalidOperationException>(() => graph.ToStateMachine().Execute());
+            Assert.That(ex!.Message, Is.EqualTo("boom"));
+        }
+        else
+        {
+            InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await graph.ToAsyncStateMachine().ExecuteAsync());
+            Assert.That(ex!.Message, Is.EqualTo("boom"));
+        }
+    }
+
+    // ── BlackboardValue bindings across scopes ───────────────────────────
+
+    [Test]
+    public async Task Literal_and_key_bindings_resolve_across_all_three_scopes()
+    {
+        BlackboardSchema globalSchema = new("world", BlackboardScope.Global);
+        BlackboardKey<string> globalKey = globalSchema.Register("motd", "hello-global");
+        BlackboardSchema graphSchema = new("entity");
+        BlackboardKey<int> graphKey = graphSchema.Register("score", 41);
+        BlackboardSchema nodeSchema = new("scratch", BlackboardScope.Node);
+        BlackboardKey<double> nodeKey = nodeSchema.Register("temp", 0d);
+
+        List<string?> strings = [];
+        List<int> ints = [];
+        List<double> doubles = [];
+
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(
+                new SetValue<int>(graphKey, 42),
+                new SetValue<double>(nodeKey, 1.5), // Node scratch: written and read within one visit
+                new CaptureBehavior<string>(globalKey, strings),
+                new CaptureBehavior<int>(graphKey, ints),
+                new CaptureBehavior<double>(nodeKey, doubles),
+                new CaptureBehavior<string>("a literal", strings))
+            .WithSchema(globalSchema)
+            .WithSchema(graphSchema)
+            .WithSchema(nodeSchema)
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine()
+            .WithBlackboard(new Blackboard(globalSchema))
+            .WithBlackboard(new Blackboard(graphSchema));
+
+        Result result = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(strings, Is.EqualTo(new[] { "hello-global", "a literal" }));
+            Assert.That(ints, Is.EqualTo(new[] { 42 }), "Key binding reads the same-visit write.");
+            Assert.That(doubles, Is.EqualTo(new[] { 1.5 }),
+                "Node-scoped bindings are legal — behavior bindings resolve within one visit.");
+        });
+    }
+
+    [Test]
+    public void Default_blackboard_value_is_a_literal_default()
+    {
+        BlackboardValue<int> value = default;
+        Assert.Multiple(() =>
+        {
+            Assert.That(value.IsBound, Is.False);
+            Assert.That(value.Literal, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void Invalid_key_is_rejected_at_wiring_time()
+    {
+        Assert.Throws<ArgumentException>(() => _ = (BlackboardValue<int>)default(BlackboardKey<int>));
+    }
+
+    // ── Log and the report channel ───────────────────────────────────────
+
+    [Test]
+    public async Task Log_reaches_the_async_observer_with_the_severity_prefix()
+    {
+        BlackboardSchema schema = new("logs");
+        BlackboardKey<string> messageKey = schema.Register("msg", "from-key");
+
+        LogCapturingAsyncObserver observer = new();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(
+                new Log("plain info"),
+                new Log(LogSeverity.Error, "bad thing"),
+                new Log(LogSeverity.Warning, messageKey))
+            .WithSchema(schema)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine(observer)
+            .WithBlackboard(new Blackboard(schema))
+            .ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(observer.Messages, Is.EqualTo(new[]
+            {
+                "[Info] plain info", "[Error] bad thing", "[Warning] from-key",
+            }));
+        });
+    }
+
+    [Test]
+    public void Log_reaches_the_sync_observer_with_the_severity_prefix()
+    {
+        LogCapturingSyncObserver observer = new();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new Log("hello"), new Log(LogSeverity.Trace, "detail"))
+            .Build();
+
+        Result result = RunToEnd(graph.ToStateMachine(observer));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(observer.Messages, Is.EqualTo(new[] { "[Info] hello", "[Trace] detail" }));
+        });
+    }
+
+    [Test]
+    public async Task Observer_less_log_runs_clean([Values] bool sync)
+    {
+        Graph graph = sync
+            ? GraphBuilder.Start().ToBehaviors(new Log("nobody listens")).Build()
+            : GraphBuilder.Start().ToBehaviorsAsync(new Log("nobody listens")).Build();
+
+        Result result = sync
+            ? RunToEnd(graph.ToStateMachine())
+            : await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
+
+    // ── SetValue ─────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task SetValue_writes_value_and_reference_types([Values] bool sync)
+    {
+        BlackboardSchema schema = new("data");
+        BlackboardKey<int> countKey = schema.Register("count", 0);
+        BlackboardKey<string> nameKey = schema.Register<string>("name");
+        BlackboardKey<int> sourceKey = schema.Register("source", 9);
+
+        SetValue<int> setCount = new(countKey, sourceKey); // key-to-key copy
+        SetValue<string> setName = new(nameKey, "renamed");
+
+        Graph graph = sync
+            ? GraphBuilder.Start().ToBehaviors(setCount, setName).WithSchema(schema).Build()
+            : GraphBuilder.Start().ToBehaviorsAsync(setCount, setName).WithSchema(schema).Build();
+
+        Blackboard board = new(schema);
+        Result result = sync
+            ? RunToEnd(graph.ToStateMachine().WithBlackboard(board))
+            : await graph.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(board.Get(countKey), Is.EqualTo(9));
+            Assert.That(board.Get(nameKey), Is.EqualTo("renamed"));
+        });
+    }
+
+    // ── Runtime parity ───────────────────────────────────────────────────
+
+    [Test]
+    public async Task Dual_interface_standard_set_behaves_identically_under_both_runtimes()
+    {
+        BlackboardSchema schema = new("parity");
+        BlackboardKey<int> key = schema.Register("value", 0);
+
+        // The very same behavior instances author both graphs.
+        SetValue<int> set = new(key, 5);
+        Log log = new(LogSeverity.Info, "parity");
+
+        Graph syncGraph = GraphBuilder.Start().ToBehaviors(set, log).WithSchema(schema).Build();
+        Graph asyncGraph = GraphBuilder.Start().ToBehaviorsAsync(set, log).WithSchema(schema).Build();
+
+        LogCapturingSyncObserver syncObserver = new();
+        Blackboard syncBoard = new(schema);
+        Result syncResult = RunToEnd(syncGraph.ToStateMachine(syncObserver).WithBlackboard(syncBoard));
+
+        LogCapturingAsyncObserver asyncObserver = new();
+        Blackboard asyncBoard = new(schema);
+        Result asyncResult = await asyncGraph.ToAsyncStateMachine(asyncObserver)
+            .WithBlackboard(asyncBoard).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncResult, Is.EqualTo(asyncResult));
+            Assert.That(syncBoard.Get(key), Is.EqualTo(asyncBoard.Get(key)));
+            Assert.That(syncObserver.Messages, Is.EqualTo(asyncObserver.Messages));
+        });
+    }
+
+    [Test]
+    public async Task Sync_behavior_state_runs_under_the_async_machine_via_the_adapter()
+    {
+        List<string> trace = [];
+        LogCapturingAsyncObserver observer = new();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new TraceBehavior("sync-under-async", trace), new Log("adapted"))
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine(observer).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "sync-under-async" }));
+            Assert.That(observer.Messages, Is.EqualTo(new[] { "[Info] adapted" }),
+                "Reports from a sync composite behind the adapter reach the async observer.");
+        });
+    }
+
+    // ── Wiring-time rejections ───────────────────────────────────────────
+
+    [Test]
+    public void Empty_and_null_entries_are_rejected()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentException>(() => _ = new BehaviorState());
+            Assert.Throws<ArgumentException>(() => _ = new AsyncBehaviorState());
+            Assert.Throws<ArgumentException>(() => _ = new BehaviorState(new Log("a"), null!));
+            Assert.Throws<ArgumentException>(() => _ = new AsyncBehaviorState(new Log("a"), null!));
+            Assert.Throws<ArgumentException>(() => _ = new BehaviorState<Hero>());
+            Assert.Throws<ArgumentException>(() => _ = new AsyncBehaviorState<Hero>());
+        });
+    }
+
+    [Test]
+    public void Untyped_composites_reject_agent_typed_entries_pointing_at_the_typed_dsl()
+    {
+        ArgumentException? syncEx =
+            Assert.Throws<ArgumentException>(() => _ = new BehaviorState(new GreetHero()));
+        ArgumentException? asyncEx =
+            Assert.Throws<ArgumentException>(() => _ = new AsyncBehaviorState(new GreetHero()));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncEx!.Message, Does.Contain("ToBehaviors<TAgent>").And.Contain("GreetHero"));
+            Assert.That(asyncEx!.Message, Does.Contain("ToBehaviorsAsync<TAgent>").And.Contain("GreetHero"));
+        });
+    }
+
+    [Test]
+    public void Typed_composite_rejects_wrong_agent_type_naming_both_types()
+    {
+        ArgumentException? ex =
+            Assert.Throws<ArgumentException>(() => _ = new BehaviorState<Hero>(new VillainOnly()));
+
+        Assert.That(ex!.Message, Does.Contain("Villain").And.Contain("Hero"));
+    }
+
+    [Test]
+    public void Dim_guard_throws_when_the_untyped_execute_of_a_typed_behavior_is_invoked()
+    {
+        IBehavior behavior = new GreetHero();
+        BehaviorContext ctx = default;
+
+        NotSupportedException? ex = Assert.Throws<NotSupportedException>(() => behavior.Execute(in ctx));
+        Assert.That(ex!.Message, Does.Contain("GreetHero").And.Contain("agent-typed"));
+    }
+
+    // ── DSL surface matrix ───────────────────────────────────────────────
+
+    [Test]
+    public void Sync_dsl_matrix_covers_all_four_surfaces()
+    {
+        List<string> trace = [];
+        bool takeThen = true;
+        // ReSharper disable once AccessToModifiedClosure
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new TraceBehavior("start", trace)) // StartToken
+            .ToBehaviors(new TraceBehavior("chain", trace)) // StateToken
+            .If(() => takeThen)
+            .Then(new EmptyLogic())
+            .ToBehaviors(new TraceBehavior("then", trace)) // BranchBuilder
+            .Else(new EmptyLogic())
+            .ToBehaviors(new TraceBehavior("else", trace)) // BranchEnd (chains after the else tip)
+            .Build();
+
+        StateMachine machine = graph.ToStateMachine();
+        Result thenResult = RunToEnd(machine);
+        takeThen = false;
+        Result elseResult = RunToEnd(machine);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thenResult, Is.EqualTo(Result.Success));
+            Assert.That(elseResult, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "start", "chain", "then", "start", "chain", "else" }));
+        });
+    }
+
+    [Test]
+    public async Task Async_dsl_matrix_covers_all_four_surfaces()
+    {
+        List<string> trace = [];
+        bool takeThen = true;
+        // ReSharper disable once AccessToModifiedClosure
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new TraceBehavior("start", trace))
+            .ToBehaviorsAsync(new TraceBehavior("chain", trace))
+            .If(() => takeThen)
+            .Then(new EmptyLogic())
+            .ToBehaviorsAsync(new TraceBehavior("then", trace))
+            .Else(new EmptyLogic())
+            .ToBehaviorsAsync(new TraceBehavior("else", trace))
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+        Result thenResult = await machine.ExecuteAsync();
+        takeThen = false;
+        Result elseResult = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(thenResult, Is.EqualTo(Result.Success));
+            Assert.That(elseResult, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "start", "chain", "then", "start", "chain", "else" }));
+        });
+    }
+
+    // ── Agent-typed channel ──────────────────────────────────────────────
+
+    [Test]
+    public async Task Mixed_sequence_delivers_the_machine_bound_agent_per_execution([Values] bool sync)
+    {
+        List<string> trace = [];
+        Hero hero = new() { Name = "Asta" };
+
+        Graph graph = sync
+            ? GraphBuilder.Start()
+                .ToBehaviors<Hero>(new TraceBehavior("plain", trace), new GreetHero())
+                .Build()
+            : GraphBuilder.Start()
+                .ToBehaviorsAsync<Hero>(new TraceBehavior("plain", trace), new GreetHero())
+                .Build();
+
+        Result result;
+        if (sync)
+        {
+            StateMachine<Hero> machine = graph.ToStateMachine<Hero>().WithAgent(hero);
+            result = RunToEnd(machine);
+        }
+        else
+        {
+            result = await graph.ToAsyncStateMachine<Hero>().WithAgent(hero).ExecuteAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "plain" }), "Plain entries run agent-blind in the mix.");
+            Assert.That(hero.Visits, Is.EqualTo(new[] { "greet:Asta" }));
+        });
+    }
+
+    [Test]
+    public async Task Two_machines_sharing_one_graph_each_deliver_their_own_agent()
+    {
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync<Hero>(new GreetHero())
+            .Build();
+
+        Hero first = new() { Name = "Asta" };
+        Hero second = new() { Name = "Yuno" };
+        AsyncStateMachine<Hero> machineA = graph.ToAsyncStateMachine<Hero>().WithAgent(first);
+        AsyncStateMachine<Hero> machineB = graph.ToAsyncStateMachine<Hero>().WithAgent(second);
+
+        // Non-overlapping runs — the standard shared-graph contract. The agent re-stamps at
+        // every run start, so interleaved sequential runs deliver each machine's own agent.
+        await machineA.ExecuteAsync();
+        await machineB.ExecuteAsync();
+        await machineA.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Visits, Is.EqualTo(new[] { "greet:Asta", "greet:Asta" }));
+            Assert.That(second.Visits, Is.EqualTo(new[] { "greet:Yuno" }));
+        });
+    }
+
+    [Test]
+    public void Graph_set_agent_counts_the_typed_composite_as_an_acceptor()
+    {
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors<Hero>(new GreetHero())
+            .Build();
+
+        // Would throw InvalidOperationException if no node accepted the agent type.
+        Assert.DoesNotThrow(() => graph.SetAgent(new Hero { Name = "Asta" }));
+        Assert.Throws<InvalidOperationException>(() => graph.SetAgent(new Villain()),
+            "A graph whose only acceptor is Hero-typed must reject a Villain agent.");
+    }
+}

--- a/NxGraph.Tests/EventEntryTests.cs
+++ b/NxGraph.Tests/EventEntryTests.cs
@@ -1,0 +1,829 @@
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Diagnostics.Export;
+using NxGraph.Diagnostics.Validations;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Behavior spec for event entry points (spec 013): typed multi-entry dispatch through
+/// <see cref="EventEntryState"/> and the machines' typed raise overloads. An event is a run
+/// trigger — one event, one run; delivery goes through the registration's Graph-scoped
+/// blackboard key, so payload access, sharing, and durability are the blackboard's existing
+/// machinery.
+/// </summary>
+[TestFixture]
+public class EventEntryTests
+{
+    private sealed record OrderPlaced(string OrderId, decimal Amount);
+
+    private readonly record struct OrderCanceled(string OrderId);
+
+    private sealed record UnregisteredEvent;
+
+    private sealed class ShopSetup
+    {
+        public required BlackboardSchema Schema;
+        public required BlackboardKey<OrderPlaced> Placed;
+        public required BlackboardKey<OrderCanceled> Canceled;
+        public required Graph Graph;
+        public required List<string> Log;
+    }
+
+    /// <summary>Async shop graph: two typed entries (class + struct payload) and an optional Otherwise chain.</summary>
+    private static ShopSetup AsyncShop(bool withOtherwise = true)
+    {
+        BlackboardSchema schema = new("shop");
+        BlackboardKey<OrderPlaced> placed = schema.Register<OrderPlaced>("orderPlaced");
+        BlackboardKey<OrderCanceled> canceled = schema.Register<OrderCanceled>("orderCanceled");
+        List<string> log = [];
+
+        EventsToken token = GraphBuilder.StartWithEvents()
+            .On(placed, e => e
+                .ToAsync((bb, _) =>
+                {
+                    log.Add($"reserve:{bb.Get(placed).OrderId}"); // payload via Bb.Get
+                    return ResultHelpers.Success;
+                })
+                .ToAsync(placed, (order, _, _) =>
+                {
+                    log.Add($"charge:{order.Amount}"); // payload via the spec-010 consumer sugar
+                    return ResultHelpers.Success;
+                })
+                .WithOutcome(1, "Placed"))
+            .On(canceled, e => e
+                .ToAsync(canceled, (order, _, _) =>
+                {
+                    log.Add($"refund:{order.OrderId}");
+                    return ResultHelpers.Success;
+                })
+                .WithOutcome(2, "Canceled"));
+
+        if (withOtherwise)
+        {
+            token = token.Otherwise(e => e.ToAsync((_, _) =>
+            {
+                log.Add("otherwise");
+                return ResultHelpers.Success;
+            }));
+        }
+
+        Graph graph = token.WithSchema(schema).Build();
+        return new ShopSetup { Schema = schema, Placed = placed, Canceled = canceled, Graph = graph, Log = log };
+    }
+
+    /// <summary>Sync twin of <see cref="AsyncShop"/>.</summary>
+    private static ShopSetup SyncShop(bool withOtherwise = true)
+    {
+        BlackboardSchema schema = new("shop");
+        BlackboardKey<OrderPlaced> placed = schema.Register<OrderPlaced>("orderPlaced");
+        BlackboardKey<OrderCanceled> canceled = schema.Register<OrderCanceled>("orderCanceled");
+        List<string> log = [];
+
+        EventsToken token = GraphBuilder.StartWithEvents()
+            .On(placed, e => e
+                .To(bb =>
+                {
+                    log.Add($"reserve:{bb.Get(placed).OrderId}");
+                    return Result.Success;
+                })
+                .To(placed, (order, _) =>
+                {
+                    log.Add($"charge:{order.Amount}");
+                    return Result.Success;
+                })
+                .WithOutcome(1, "Placed"))
+            .On(canceled, e => e
+                .To(canceled, (order, _) =>
+                {
+                    log.Add($"refund:{order.OrderId}");
+                    return Result.Success;
+                })
+                .WithOutcome(2, "Canceled"));
+
+        if (withOtherwise)
+        {
+            token = token.Otherwise(e => e.To(_ =>
+            {
+                log.Add("otherwise");
+                return Result.Success;
+            }));
+        }
+
+        Graph graph = token.WithSchema(schema).Build();
+        return new ShopSetup { Schema = schema, Placed = placed, Canceled = canceled, Graph = graph, Log = log };
+    }
+
+    private static Result RunToCompletion(StateMachine machine)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+
+    private static Result RaiseToCompletion<TEvent>(StateMachine machine, TEvent evt)
+    {
+        Result result = machine.Execute(evt);
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+
+    // ── Dispatch ─────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task async_raise_dispatches_class_payload_to_its_chain()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        Result result = await machine.ExecuteAsync(new OrderPlaced("o-1", 42m));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[] { "reserve:o-1", "charge:42" }));
+        });
+    }
+
+    [Test]
+    public async Task async_raise_dispatches_struct_payload_to_its_chain()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        Result result = await machine.ExecuteAsync(new OrderCanceled("o-2"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[] { "refund:o-2" }));
+        });
+    }
+
+    [Test]
+    public void sync_raise_dispatches_both_payload_kinds()
+    {
+        ShopSetup shop = SyncShop();
+        StateMachine machine = shop.Graph.ToStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        Result placed = RaiseToCompletion(machine, new OrderPlaced("o-3", 7m));
+        Result canceled = RaiseToCompletion(machine, new OrderCanceled("o-3"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(placed, Is.EqualTo(Result.Success));
+            Assert.That(canceled, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[] { "reserve:o-3", "charge:7", "refund:o-3" }));
+        });
+    }
+
+    [Test]
+    public async Task async_last_outcome_reports_the_entry_taken()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+        machine.SetRestartPolicy(RestartPolicy.Manual);
+
+        await machine.ExecuteAsync(new OrderPlaced("o-4", 1m));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(machine.LastOutcome, Is.EqualTo(1));
+            Assert.That(machine.LastOutcomeName, Is.EqualTo("Placed"));
+        });
+    }
+
+    [Test]
+    public void sync_last_outcome_reports_the_entry_taken()
+    {
+        ShopSetup shop = SyncShop();
+        StateMachine machine = shop.Graph.ToStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+        machine.SetRestartPolicy(RestartPolicy.Manual);
+
+        RaiseToCompletion(machine, new OrderCanceled("o-5"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(machine.LastOutcome, Is.EqualTo(2));
+            Assert.That(machine.LastOutcomeName, Is.EqualTo("Canceled"));
+        });
+    }
+
+    // ── Misses, Otherwise, staleness ─────────────────────────────────────
+
+    [Test]
+    public void async_unregistered_event_type_throws_naming_registered_types()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync(new UnregisteredEvent()));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Message, Does.Contain("No event entry is registered"));
+            Assert.That(ex.Message, Does.Contain("OrderPlaced"));
+            Assert.That(ex.Message, Does.Contain("OrderCanceled"));
+        });
+    }
+
+    [Test]
+    public void sync_unregistered_event_type_throws_naming_registered_types()
+    {
+        ShopSetup shop = SyncShop();
+        StateMachine machine = shop.Graph.ToStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => machine.Execute(new UnregisteredEvent()));
+        Assert.That(ex!.Message, Does.Contain("OrderPlaced").And.Contain("OrderCanceled"));
+    }
+
+    [Test]
+    public async Task async_plain_execute_routes_to_otherwise()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        Result result = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[] { "otherwise" }));
+        });
+    }
+
+    [Test]
+    public void async_plain_execute_without_otherwise_throws_pointing_at_the_raise_api()
+    {
+        ShopSetup shop = AsyncShop(withOtherwise: false);
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync());
+        Assert.That(ex!.Message, Does.Contain("ExecuteAsync<TEvent>"));
+    }
+
+    [Test]
+    public void sync_plain_execute_without_otherwise_throws_pointing_at_the_raise_api()
+    {
+        ShopSetup shop = SyncShop(withOtherwise: false);
+        StateMachine machine = shop.Graph.ToStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(() => machine.Execute());
+        Assert.That(ex!.Message, Does.Contain("Execute<TEvent>"));
+    }
+
+    [Test]
+    public void sync_plain_execute_routes_to_otherwise()
+    {
+        ShopSetup shop = SyncShop();
+        StateMachine machine = shop.Graph.ToStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        Result result = RunToCompletion(machine);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[] { "otherwise" }));
+        });
+    }
+
+    [Test]
+    public async Task async_stale_entry_never_leaks_into_a_later_plain_run()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        await machine.ExecuteAsync(new OrderPlaced("o-6", 5m));
+        await machine.ExecuteAsync(); // plain run: must route to Otherwise, not the placed chain
+
+        Assert.That(shop.Log, Is.EqualTo(new[] { "reserve:o-6", "charge:5", "otherwise" }));
+    }
+
+    [Test]
+    public void sync_stale_entry_never_leaks_into_a_later_plain_run()
+    {
+        ShopSetup shop = SyncShop();
+        StateMachine machine = shop.Graph.ToStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        RaiseToCompletion(machine, new OrderCanceled("o-7"));
+        RunToCompletion(machine);
+
+        Assert.That(shop.Log, Is.EqualTo(new[] { "refund:o-7", "otherwise" }));
+    }
+
+    // ── Restart policies and busy guards ─────────────────────────────────
+
+    [Test]
+    public async Task async_repeated_raises_under_auto_policy_each_start_a_fresh_run()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        await machine.ExecuteAsync(new OrderPlaced("a", 1m));
+        await machine.ExecuteAsync(new OrderCanceled("a"));
+        await machine.ExecuteAsync(new OrderPlaced("b", 2m));
+
+        Assert.That(shop.Log, Is.EqualTo(new[]
+        {
+            "reserve:a", "charge:1", "refund:a", "reserve:b", "charge:2",
+        }));
+    }
+
+    [Test]
+    public async Task async_manual_policy_post_terminal_raise_throws_until_reset()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+        machine.SetRestartPolicy(RestartPolicy.Manual);
+
+        await machine.ExecuteAsync(new OrderPlaced("o-8", 3m));
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync(new OrderCanceled("o-8")));
+        Assert.That(ex!.Message, Does.Contain("Reset()"));
+
+        await machine.Reset();
+        Result result = await machine.ExecuteAsync(new OrderCanceled("o-8"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[] { "reserve:o-8", "charge:3", "refund:o-8" }));
+        });
+    }
+
+    [Test]
+    public void sync_manual_policy_post_terminal_raise_throws_until_reset()
+    {
+        ShopSetup shop = SyncShop();
+        StateMachine machine = shop.Graph.ToStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+        machine.SetRestartPolicy(RestartPolicy.Manual);
+
+        RaiseToCompletion(machine, new OrderPlaced("o-9", 4m));
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => machine.Execute(new OrderCanceled("o-9")));
+        Assert.That(ex!.Message, Does.Contain("Reset()"));
+
+        machine.Reset();
+        Result result = RaiseToCompletion(machine, new OrderCanceled("o-9"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[] { "reserve:o-9", "charge:4", "refund:o-9" }));
+        });
+    }
+
+    [Test]
+    public async Task async_raise_while_running_throws()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        Result first = await machine.StepAsync(new OrderPlaced("o-10", 6m));
+        Assert.That(first, Is.EqualTo(Result.InProgress));
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync(new OrderCanceled("o-10")));
+        Assert.That(ex!.Message, Does.Contain("Cannot raise an event while the machine is executing"));
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await machine.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[] { "reserve:o-10", "charge:6" }));
+        });
+    }
+
+    [Test]
+    public void sync_raise_mid_run_throws()
+    {
+        ShopSetup shop = SyncShop();
+        StateMachine machine = shop.Graph.ToStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        Result first = machine.Execute(new OrderPlaced("o-11", 8m));
+        Assert.That(first, Is.EqualTo(Result.InProgress));
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => machine.Execute(new OrderCanceled("o-11")));
+        Assert.That(ex!.Message, Does.Contain("Cannot raise an event while the machine is executing"));
+
+        Result result = RunToCompletion(machine);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[] { "reserve:o-11", "charge:8" }));
+        });
+    }
+
+    [Test]
+    public async Task async_typed_step_starts_a_run_and_mid_run_typed_step_throws()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop.Schema));
+
+        Result first = await machine.StepAsync(new OrderCanceled("o-12"));
+        Assert.That(first, Is.EqualTo(Result.InProgress), "First typed step executes the dispatcher.");
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.StepAsync(new OrderPlaced("o-12", 9m)));
+        Assert.That(ex!.Message, Does.Contain("stepped run is in progress"));
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await machine.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Is.EqualTo(new[] { "refund:o-12" }));
+        });
+    }
+
+    [Test]
+    public void async_raise_on_a_graph_without_event_entries_throws()
+    {
+        Graph graph = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync(new OrderPlaced("x", 0m)));
+        Assert.That(ex!.Message, Does.Contain("no event entries"));
+    }
+
+    [Test]
+    public void sync_raise_on_a_graph_without_event_entries_throws()
+    {
+        Graph graph = GraphBuilder.StartWith(() => Result.Success).Build();
+        StateMachine machine = graph.ToStateMachine();
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => machine.Execute(new OrderPlaced("x", 0m)));
+        Assert.That(ex!.Message, Does.Contain("no event entries"));
+    }
+
+    [Test]
+    public void async_raise_without_a_graph_board_hits_the_unbound_scope_routing_throw()
+    {
+        ShopSetup shop = AsyncShop();
+        AsyncStateMachine machine = shop.Graph.ToAsyncStateMachine(); // no WithBlackboard
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await machine.ExecuteAsync(new OrderPlaced("o-13", 1m)));
+        Assert.That(ex!.Message, Does.Contain("no graph blackboard bound"));
+    }
+
+    [Test]
+    public void sync_raise_without_a_graph_board_hits_the_unbound_scope_routing_throw()
+    {
+        ShopSetup shop = SyncShop();
+        StateMachine machine = shop.Graph.ToStateMachine(); // no WithBlackboard
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => machine.Execute(new OrderCanceled("o-13")));
+        Assert.That(ex!.Message, Does.Contain("no graph blackboard bound"));
+    }
+
+    // ── Sharing: one graph, several machines ─────────────────────────────
+
+    [Test]
+    public async Task two_machines_share_one_graph_with_distinct_boards_and_events()
+    {
+        BlackboardSchema schema = new("shared-shop");
+        BlackboardKey<OrderPlaced> placed = schema.Register<OrderPlaced>("orderPlaced");
+        BlackboardKey<OrderCanceled> canceled = schema.Register<OrderCanceled>("orderCanceled");
+        BlackboardKey<string> handled = schema.Register<string>("handled", string.Empty);
+
+        Graph graph = GraphBuilder.StartWithEvents()
+            .On(placed, e => e.ToAsync((bb, _) =>
+            {
+                bb.Set(handled, $"placed:{bb.Get(placed).OrderId}");
+                return ResultHelpers.Success;
+            }))
+            .On(canceled, e => e.ToAsync((bb, _) =>
+            {
+                bb.Set(handled, $"canceled:{bb.Get(canceled).OrderId}");
+                return ResultHelpers.Success;
+            }))
+            .WithSchema(schema)
+            .Build();
+
+        Blackboard boardA = new(schema);
+        Blackboard boardB = new(schema);
+        AsyncStateMachine machineA = graph.ToAsyncStateMachine().WithBlackboard(boardA);
+        AsyncStateMachine machineB = graph.ToAsyncStateMachine().WithBlackboard(boardB);
+
+        await machineA.ExecuteAsync(new OrderPlaced("a-1", 10m));
+        await machineB.ExecuteAsync(new OrderCanceled("b-1"));
+        await machineA.ExecuteAsync(new OrderCanceled("a-2"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(boardA.Get(handled), Is.EqualTo("canceled:a-2"));
+            Assert.That(boardB.Get(handled), Is.EqualTo("canceled:b-1"));
+            Assert.That(boardA.Get(placed), Is.EqualTo(new OrderPlaced("a-1", 10m)),
+                "Each machine's payload landed on its own board.");
+        });
+    }
+
+    // ── Entry chains use the full DSL vocabulary ─────────────────────────
+
+    [Test]
+    public async Task entry_chains_support_retry_onerror_and_convergent_nodes()
+    {
+        BlackboardSchema schema = new("faulty-shop");
+        BlackboardKey<OrderPlaced> placed = schema.Register<OrderPlaced>("orderPlaced");
+        BlackboardKey<OrderCanceled> canceled = schema.Register<OrderCanceled>("orderCanceled");
+        List<string> log = [];
+
+        int attempts = 0;
+        RelayState sharedFinish = new(() =>
+        {
+            log.Add("finish");
+            return Result.Success;
+        });
+
+        Graph graph = GraphBuilder.StartWithEvents()
+            .On(placed, e => e
+                .To(() =>
+                {
+                    attempts++;
+                    log.Add($"try:{attempts}");
+                    return attempts < 3 ? Result.Failure : Result.Success;
+                })
+                .Retry(3)
+                .OnError(() =>
+                {
+                    log.Add("handler");
+                    return Result.Success;
+                })
+                .To(sharedFinish))
+            .On(canceled, e => e
+                .To(() =>
+                {
+                    log.Add("cancel");
+                    return Result.Success;
+                })
+                .To(sharedFinish)) // convergence: both chains end on the same node
+            .WithSchema(schema)
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(schema));
+
+        await machine.ExecuteAsync(new OrderPlaced("o-14", 1m));
+        await machine.ExecuteAsync(new OrderCanceled("o-14"));
+
+        Assert.That(log, Is.EqualTo(new[]
+        {
+            "try:1", "try:2", "try:3", "finish", "cancel", "finish",
+        }), "The failing step retried in place, then both entries converged on the shared node.");
+    }
+
+    // ── Durability: suspend mid-handler, resume on a fresh machine ───────
+
+    [Test]
+    public async Task async_suspend_mid_handler_resumes_on_a_fresh_machine_and_reads_the_event()
+    {
+        ShopSetup shop = AsyncShop();
+        Blackboard board = new(shop.Schema);
+        AsyncStateMachine first = shop.Graph.ToAsyncStateMachine().WithBlackboard(board);
+
+        Result step1 = await first.StepAsync(new OrderPlaced("o-15", 30m)); // dispatcher
+        Result step2 = await first.StepAsync(); // reserve step
+        Assert.Multiple(() =>
+        {
+            Assert.That(step1, Is.EqualTo(Result.InProgress));
+            Assert.That(step2, Is.EqualTo(Result.InProgress));
+        });
+
+        StateMachineSnapshot snapshot = first.Suspend();
+
+        AsyncStateMachine second = shop.Graph.ToAsyncStateMachine().WithBlackboard(board);
+        second.Resume(snapshot);
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = await second.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Does.Contain("charge:30"),
+                "The handler's later step read the event payload from the restored board.");
+        });
+    }
+
+    [Test]
+    public void sync_suspend_mid_handler_resumes_on_a_fresh_machine_and_reads_the_event()
+    {
+        ShopSetup shop = SyncShop();
+        Blackboard board = new(shop.Schema);
+        StateMachine first = shop.Graph.ToStateMachine().WithBlackboard(board);
+
+        Result step1 = first.Execute(new OrderPlaced("o-16", 60m)); // dispatcher tick
+        Result step2 = first.Execute(); // reserve tick
+        Assert.Multiple(() =>
+        {
+            Assert.That(step1, Is.EqualTo(Result.InProgress));
+            Assert.That(step2, Is.EqualTo(Result.InProgress));
+        });
+
+        StateMachineSnapshot snapshot = first.Suspend();
+
+        StateMachine second = shop.Graph.ToStateMachine().WithBlackboard(board);
+        second.Resume(snapshot);
+
+        Result result = RunToCompletion(second);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(shop.Log, Does.Contain("charge:60"));
+        });
+    }
+
+    // ── Builder / wiring rejections ──────────────────────────────────────
+
+    [Test]
+    public void duplicate_clr_event_type_throws_at_wiring_time()
+    {
+        BlackboardSchema schema = new("dup-type");
+        BlackboardKey<OrderPlaced> first = schema.Register<OrderPlaced>("first");
+        BlackboardKey<OrderPlaced> second = schema.Register<OrderPlaced>("second");
+
+        ArgumentException? ex = Assert.Throws<ArgumentException>(() => GraphBuilder.StartWithEvents()
+            .On(first, e => e.To(() => Result.Success))
+            .On(second, e => e.To(() => Result.Success)));
+        Assert.That(ex!.Message, Does.Contain("one entry per type"));
+    }
+
+    [Test]
+    public void duplicate_event_key_throws_at_wiring_time()
+    {
+        BlackboardSchema schema = new("dup-key");
+        BlackboardKey<OrderPlaced> placed = schema.Register<OrderPlaced>("orderPlaced");
+
+        ArgumentException? ex = Assert.Throws<ArgumentException>(() => GraphBuilder.StartWithEvents()
+            .On(placed, e => e.To(() => Result.Success))
+            .On(placed, e => e.To(() => Result.Success)));
+        Assert.That(ex!.Message, Does.Contain("already bound to an entry"));
+    }
+
+    [Test]
+    public void node_scoped_event_key_throws_at_wiring_time()
+    {
+        BlackboardSchema schema = new("scratch", BlackboardScope.Node);
+        BlackboardKey<OrderPlaced> placed = schema.Register<OrderPlaced>("orderPlaced");
+
+        ArgumentException? ex = Assert.Throws<ArgumentException>(() => GraphBuilder.StartWithEvents()
+            .On(placed, e => e.To(() => Result.Success)));
+        Assert.That(ex!.Message, Does.Contain("Node-scoped"));
+    }
+
+    [Test]
+    public void schema_less_event_key_throws_at_wiring_time()
+    {
+        ArgumentException? ex = Assert.Throws<ArgumentException>(() => GraphBuilder.StartWithEvents()
+            .On(default(BlackboardKey<OrderPlaced>), e => e.To(() => Result.Success)));
+        Assert.That(ex!.Message, Does.Contain("obtain keys via BlackboardSchema.Register"));
+    }
+
+    [Test]
+    public void build_with_zero_registrations_throws()
+    {
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(
+            () => GraphBuilder.StartWithEvents().Build());
+        Assert.That(ex!.Message, Does.Contain("at least one event entry"));
+    }
+
+    [Test]
+    public void second_otherwise_chain_throws()
+    {
+        BlackboardSchema schema = new("dup-otherwise");
+        BlackboardKey<OrderPlaced> placed = schema.Register<OrderPlaced>("orderPlaced");
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(() => GraphBuilder
+            .StartWithEvents()
+            .On(placed, e => e.To(() => Result.Success))
+            .Otherwise(e => e.To(() => Result.Success))
+            .Otherwise(e => e.To(() => Result.Success)));
+        Assert.That(ex!.Message, Does.Contain("Otherwise chain has already been declared"));
+    }
+
+    // ── Validator lints ──────────────────────────────────────────────────
+
+    [Test]
+    public void validator_reports_event_entry_info_and_reaches_all_chains()
+    {
+        ShopSetup shop = AsyncShop();
+        GraphValidationResult report = shop.Graph.Validate();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(report.HasErrors, Is.False);
+            Assert.That(report.Diagnostics.Any(d =>
+                    d.Severity == Severity.Info && d.Message.Contains("event entry")),
+                Is.True, "The presence Info fires for event graphs.");
+            Assert.That(report.Diagnostics.Any(d =>
+                    d.Severity == Severity.Warning && d.Message.Contains("unreachable")),
+                Is.False, "All entry chains are reachable through the dispatcher's static targets.");
+        });
+    }
+
+    [Test]
+    public void validator_warns_when_event_graph_declares_no_graph_schema()
+    {
+        BlackboardSchema schema = new("undeclared");
+        BlackboardKey<OrderPlaced> placed = schema.Register<OrderPlaced>("orderPlaced");
+
+        Graph graph = GraphBuilder.StartWithEvents()
+            .On(placed, e => e.To(() => Result.Success))
+            .Build(); // no WithSchema
+
+        GraphValidationResult report = graph.Validate();
+        Assert.That(report.Diagnostics.Any(d =>
+                d.Severity == Severity.Warning && d.Message.Contains("declares no Graph-scoped blackboard schema")),
+            Is.True, "The missing-schema Warning fires.");
+    }
+
+    [Test]
+    public void validator_warns_when_event_key_schema_differs_from_declared_graph_schema()
+    {
+        BlackboardSchema keySchema = new("keys");
+        BlackboardKey<OrderPlaced> placed = keySchema.Register<OrderPlaced>("orderPlaced");
+        BlackboardSchema declared = new("declared");
+        declared.Register<int>("unrelated");
+
+        Graph graph = GraphBuilder.StartWithEvents()
+            .On(placed, e => e.To(() => Result.Success))
+            .WithSchema(declared)
+            .Build();
+
+        GraphValidationResult report = graph.Validate();
+        Assert.That(report.Diagnostics.Any(d =>
+                d.Severity == Severity.Warning && d.Message.Contains("not the graph's declared")),
+            Is.True, "The foreign-key-schema Warning fires.");
+    }
+
+    [Test]
+    public void validator_warns_when_event_entry_is_combined_with_token_nodes()
+    {
+        BlackboardSchema schema = new("mixed");
+        BlackboardKey<OrderPlaced> placed = schema.Register<OrderPlaced>("orderPlaced");
+        JoinState join = new(JoinPolicy.Any);
+
+        Graph graph = GraphBuilder.StartWithEvents()
+            .On(placed, e => e
+                .To(() => Result.Success)
+                .To((ILogic)join))
+            .WithSchema(schema)
+            .Build();
+
+        GraphValidationResult report = graph.Validate();
+        Assert.That(report.Diagnostics.Any(d =>
+                d.Severity == Severity.Warning && d.Message.Contains("token fork/join")),
+            Is.True, "The token-mix Warning fires — event dispatch under the token runtime is unvalidated.");
+    }
+
+    // ── Mermaid export ───────────────────────────────────────────────────
+
+    [Test]
+    public void mermaid_labels_entry_edges_with_event_short_names_and_the_otherwise_edge()
+    {
+        ShopSetup shop = AsyncShop();
+        string mermaid = shop.Graph.ToMermaid();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mermaid, Does.Contain("-. OrderPlaced .->"));
+            Assert.That(mermaid, Does.Contain("-. OrderCanceled .->"));
+            Assert.That(mermaid, Does.Contain("-. otherwise .->"));
+        });
+    }
+}

--- a/NxGraph.Tests/PublicApi/NxGraph.Serialization.Abstraction.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.Serialization.Abstraction.approved.txt
@@ -1,6 +1,56 @@
+sealed class NxGraph.Serialization.Abstraction.BehaviorBinding
+  ctor Void .ctor(System.String, NxGraph.Serialization.Abstraction.BehaviorFieldValue)
+  property NxGraph.Serialization.Abstraction.BehaviorFieldValue Literal { get; }
+  property System.String KeyName { get; }
+sealed class NxGraph.Serialization.Abstraction.BehaviorField
+  ctor Void .ctor(System.String, NxGraph.Serialization.Abstraction.BehaviorFieldValue)
+  property NxGraph.Serialization.Abstraction.BehaviorFieldValue Value { get; }
+  property System.String Name { get; }
+enum NxGraph.Serialization.Abstraction.BehaviorFieldKind : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Binding = 7
+  Bool = 1
+  Double = 5
+  Enum = 6
+  Int32 = 2
+  Int64 = 3
+  Single = 4
+  String = 0
+sealed class NxGraph.Serialization.Abstraction.BehaviorFieldReader
+  ctor Void .ctor(System.Collections.Generic.IReadOnlyList`1[NxGraph.Serialization.Abstraction.BehaviorField])
+  method Boolean Has(System.String)
+  method Boolean ReadBool(System.String)
+  method Double ReadDouble(System.String)
+  method Int32 ReadInt32(System.String)
+  method Int64 ReadInt64(System.String)
+  method NxGraph.Behaviors.BlackboardValue`1[T] ReadBinding[T](System.String)
+  method Single ReadSingle(System.String)
+  method System.String ReadString(System.String)
+  method TEnum ReadEnum[TEnum](System.String)
+sealed class NxGraph.Serialization.Abstraction.BehaviorFieldValue
+  ctor Void .ctor(NxGraph.Serialization.Abstraction.BehaviorFieldKind, System.String, Boolean, Int64, Double, NxGraph.Serialization.Abstraction.BehaviorBinding)
+  property Boolean Flag { get; }
+  property Double Number { get; }
+  property Int64 Integer { get; }
+  property NxGraph.Serialization.Abstraction.BehaviorBinding Binding { get; }
+  property NxGraph.Serialization.Abstraction.BehaviorFieldKind Kind { get; }
+  property System.String Text { get; }
+sealed class NxGraph.Serialization.Abstraction.BehaviorFieldWriter
+  ctor Void .ctor()
+  method NxGraph.Serialization.Abstraction.BehaviorField[] ToFields()
+  method Void WriteBinding[T](System.String, NxGraph.Behaviors.BlackboardValue`1[T] ByRef)
+  method Void WriteBool(System.String, Boolean)
+  method Void WriteDouble(System.String, Double)
+  method Void WriteEnum[TEnum](System.String, TEnum)
+  method Void WriteInt32(System.String, Int32)
+  method Void WriteInt64(System.String, Int64)
+  method Void WriteSingle(System.String, Single)
+  method Void WriteString(System.String, System.String)
 enum NxGraph.Serialization.Abstraction.BlackboardMismatchPolicy : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
   Skip = 1
   Strict = 0
+interface NxGraph.Serialization.Abstraction.IBehaviorRegistry
+  method Boolean TryRead(System.String, NxGraph.Serialization.Abstraction.BehaviorFieldReader, System.Object ByRef)
+  method Boolean TryWrite(System.Object, NxGraph.Serialization.Abstraction.BehaviorFieldWriter)
 interface NxGraph.Serialization.Abstraction.IBlackboardBinarySerializer
   method System.Threading.Tasks.ValueTask RestoreFromBinaryAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, NxGraph.Serialization.Abstraction.BlackboardMismatchPolicy, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask ToBinaryAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, System.Threading.CancellationToken)
@@ -25,3 +75,5 @@ interface NxGraph.Serialization.Abstraction.ILogicCodec`1 : NxGraph.Serializatio
 interface NxGraph.Serialization.Abstraction.IRegionSelectorRegistry
   method Boolean TryGetKey(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], System.String ByRef)
   method Boolean TryGetSelector(System.String, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask] ByRef)
+interface NxGraph.Serialization.Abstraction.ISerializableBehavior
+  method Void Write(NxGraph.Serialization.Abstraction.BehaviorFieldWriter)

--- a/NxGraph.Tests/PublicApi/NxGraph.Serialization.Abstraction.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.Serialization.Abstraction.approved.txt
@@ -2,11 +2,16 @@ sealed class NxGraph.Serialization.Abstraction.BehaviorBinding
   ctor Void .ctor(System.String, NxGraph.Serialization.Abstraction.BehaviorFieldValue)
   property NxGraph.Serialization.Abstraction.BehaviorFieldValue Literal { get; }
   property System.String KeyName { get; }
+sealed class NxGraph.Serialization.Abstraction.BehaviorEntry
+  ctor Void .ctor(System.String, NxGraph.Serialization.Abstraction.BehaviorField[])
+  property NxGraph.Serialization.Abstraction.BehaviorField[] Fields { get; }
+  property System.String BehaviorTypeName { get; }
 sealed class NxGraph.Serialization.Abstraction.BehaviorField
   ctor Void .ctor(System.String, NxGraph.Serialization.Abstraction.BehaviorFieldValue)
   property NxGraph.Serialization.Abstraction.BehaviorFieldValue Value { get; }
   property System.String Name { get; }
 enum NxGraph.Serialization.Abstraction.BehaviorFieldKind : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Behaviors = 8
   Binding = 7
   Bool = 1
   Double = 5
@@ -24,19 +29,22 @@ sealed class NxGraph.Serialization.Abstraction.BehaviorFieldReader
   method Int64 ReadInt64(System.String)
   method NxGraph.Behaviors.BlackboardValue`1[T] ReadBinding[T](System.String)
   method Single ReadSingle(System.String)
+  method System.Object[] ReadBehaviors(System.String)
   method System.String ReadString(System.String)
   method TEnum ReadEnum[TEnum](System.String)
 sealed class NxGraph.Serialization.Abstraction.BehaviorFieldValue
-  ctor Void .ctor(NxGraph.Serialization.Abstraction.BehaviorFieldKind, System.String, Boolean, Int64, Double, NxGraph.Serialization.Abstraction.BehaviorBinding)
+  ctor Void .ctor(NxGraph.Serialization.Abstraction.BehaviorFieldKind, System.String, Boolean, Int64, Double, NxGraph.Serialization.Abstraction.BehaviorBinding, NxGraph.Serialization.Abstraction.BehaviorEntry[])
   property Boolean Flag { get; }
   property Double Number { get; }
   property Int64 Integer { get; }
   property NxGraph.Serialization.Abstraction.BehaviorBinding Binding { get; }
+  property NxGraph.Serialization.Abstraction.BehaviorEntry[] Entries { get; }
   property NxGraph.Serialization.Abstraction.BehaviorFieldKind Kind { get; }
   property System.String Text { get; }
 sealed class NxGraph.Serialization.Abstraction.BehaviorFieldWriter
   ctor Void .ctor()
   method NxGraph.Serialization.Abstraction.BehaviorField[] ToFields()
+  method Void WriteBehaviors(System.String, System.Collections.Generic.IReadOnlyList`1[System.Object])
   method Void WriteBinding[T](System.String, NxGraph.Behaviors.BlackboardValue`1[T] ByRef)
   method Void WriteBool(System.String, Boolean)
   method Void WriteDouble(System.String, Double)

--- a/NxGraph.Tests/PublicApi/NxGraph.Serialization.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.Serialization.approved.txt
@@ -1,3 +1,8 @@
+sealed class NxGraph.Serialization.BehaviorRegistry : NxGraph.Serialization.Abstraction.IBehaviorRegistry
+  ctor Void .ctor()
+  method Boolean TryRead(System.String, NxGraph.Serialization.Abstraction.BehaviorFieldReader, System.Object ByRef)
+  method Boolean TryWrite(System.Object, NxGraph.Serialization.Abstraction.BehaviorFieldWriter)
+  method Void Register(System.String, System.Func`2[NxGraph.Serialization.Abstraction.BehaviorFieldReader,System.Object])
 sealed class NxGraph.Serialization.BlackboardSerializer : NxGraph.Serialization.Abstraction.IBlackboardBinarySerializer, NxGraph.Serialization.Abstraction.IBlackboardJsonSerializer
   ctor Void .ctor(System.Text.Json.JsonSerializerOptions, MessagePack.MessagePackSerializerOptions)
   method System.Threading.Tasks.ValueTask RestoreFromBinaryAsync(NxGraph.Blackboards.Blackboard, System.IO.Stream, NxGraph.Serialization.Abstraction.BlackboardMismatchPolicy, System.Threading.CancellationToken)
@@ -15,6 +20,7 @@ sealed class NxGraph.Serialization.GraphSerializer : NxGraph.Serialization.Abstr
   method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.Graph] FromJsonAsync(System.IO.Stream, System.Threading.CancellationToken)
 sealed class NxGraph.Serialization.GraphSerializerOptions
   ctor Void .ctor()
+  property NxGraph.Serialization.Abstraction.IBehaviorRegistry BehaviorRegistry { get; set; }
   property NxGraph.Serialization.Abstraction.IContainerCodec ContainerCodec { get; set; }
   property NxGraph.Serialization.Abstraction.IRegionSelectorRegistry SelectorRegistry { get; set; }
 interface NxGraph.Serialization.IContainerBinaryCodec : NxGraph.Serialization.Abstraction.IContainerCodec, NxGraph.Serialization.Abstraction.IContainerCodec`1[[System.ReadOnlyMemory`1[[System.Byte]]]]

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -176,6 +176,22 @@ struct NxGraph.Authoring.Dsl+SwitchBuilder`1
   method SwitchBuilder`1 CaseAsync(TKey, NxGraph.Graphs.IAsyncLogic)
   method SwitchBuilder`1 Default(NxGraph.Graphs.ILogic)
   method SwitchBuilder`1 DefaultAsync(NxGraph.Graphs.IAsyncLogic)
+sealed class NxGraph.Authoring.EventBranch
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken)
+  method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken To(System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken ToAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn](NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken To[TIn](NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+struct NxGraph.Authoring.EventsToken
+  method NxGraph.Authoring.EventsToken On[TEvent](NxGraph.Blackboards.BlackboardKey`1[TEvent], System.Func`2[NxGraph.Authoring.EventBranch,NxGraph.Authoring.StateToken])
+  method NxGraph.Authoring.EventsToken Otherwise(System.Func`2[NxGraph.Authoring.EventBranch,NxGraph.Authoring.StateToken])
+  method NxGraph.Authoring.EventsToken WithSchema(NxGraph.Blackboards.BlackboardSchema)
+  method NxGraph.Graphs.Graph Build(Boolean)
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
 sealed class NxGraph.Authoring.ForkBranch
   method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken)
   method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
@@ -194,6 +210,7 @@ struct NxGraph.Authoring.GotoToken
   property NxGraph.Authoring.GraphBuilder Builder { get; }
 sealed class NxGraph.Authoring.GraphBuilder
   ctor Void .ctor()
+  method NxGraph.Authoring.EventsToken StartWithEvents()
   method NxGraph.Authoring.GraphBuilder AddFailureTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
   method NxGraph.Authoring.GraphBuilder AddGoto(NxGraph.Graphs.NodeId, System.String)
   method NxGraph.Authoring.GraphBuilder AddTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
@@ -301,6 +318,7 @@ struct NxGraph.Blackboards.BlackboardKey`1 : IEquatable`1
 sealed class NxGraph.Blackboards.BlackboardSchema
   ctor Void .ctor(System.String, NxGraph.Blackboards.BlackboardScope)
   method Boolean TryGetKey(System.String, NxGraph.Blackboards.BlackboardKeyDescriptor ByRef)
+  method Boolean TryResolve[T](System.String, NxGraph.Blackboards.BlackboardKey`1[T] ByRef)
   method NxGraph.Blackboards.BlackboardKey`1[T] Register[T](System.String)
   method NxGraph.Blackboards.BlackboardKey`1[T] Register[T](System.String, T)
   property Boolean IsFrozen { get; }
@@ -479,11 +497,14 @@ class NxGraph.Fsm.Async.AsyncStateMachine : NxGraph.Fsm.Async.AsyncState, NxGrap
   field readonly NxGraph.Graphs.Graph Graph
   method NxGraph.Fsm.StateMachineDeepSnapshot SuspendDeep()
   method NxGraph.Fsm.StateMachineSnapshot Suspend()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync[TEvent](TEvent, System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] Reset(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] StepAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] StepAsync[TEvent](TEvent, System.Threading.CancellationToken)
   method Void Resume(NxGraph.Fsm.StateMachineSnapshot)
   method Void ResumeDeep(NxGraph.Fsm.StateMachineDeepSnapshot)
   method Void SetAutoReset(Boolean)
@@ -543,6 +564,19 @@ sealed class NxGraph.Fsm.DynamicParallelState : NxGraph.Blackboards.IBlackboardS
   property NxGraph.Fsm.ParallelStepMode Mode { get; }
   property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.StateMachine] Regions { get; }
   property System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask] Selector { get; }
+sealed class NxGraph.Fsm.EventEntryState : NxGraph.Fsm.IAsyncDirector, NxGraph.Fsm.IDirector, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ILogic
+  ctor Void .ctor(System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.EventRegistration])
+  ctor Void .ctor(System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.EventRegistration], NxGraph.Graphs.NodeId)
+  property NxGraph.Graphs.NodeId DefaultTarget { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.EventRegistration] Registrations { get; }
+abstract class NxGraph.Fsm.EventRegistration
+  method NxGraph.Fsm.EventRegistration Unbound(System.String, System.String, NxGraph.Graphs.NodeId)
+  property NxGraph.Graphs.NodeId Target { get; }
+  property System.String EventTypeName { get; }
+  property System.String KeyName { get; }
+sealed class NxGraph.Fsm.EventRegistration`1 : NxGraph.Fsm.EventRegistration
+  ctor Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TEvent], NxGraph.Graphs.NodeId)
+  property NxGraph.Blackboards.BlackboardKey`1[TEvent] Key { get; }
 enum NxGraph.Fsm.ExecutionStatus : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
   Cancelled = 6
   Completed = 4
@@ -677,6 +711,7 @@ class NxGraph.Fsm.StateMachine : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackbo
   field readonly NxGraph.Graphs.Graph Graph
   method NxGraph.Fsm.StateMachineDeepSnapshot SuspendDeep()
   method NxGraph.Fsm.StateMachineSnapshot Suspend()
+  method NxGraph.Result Execute[TEvent](TEvent)
   method NxGraph.Result OnRun()
   method NxGraph.Result Reset()
   method Void OnEnter()
@@ -806,6 +841,7 @@ class NxGraph.Graphs.LogicNode : NxGraph.Graphs.INode
   ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.IAsyncLogic, System.Action, System.Action)
   field static readonly NxGraph.Graphs.LogicNode DynamicParallelStateMarker
   field static readonly NxGraph.Graphs.LogicNode Empty
+  field static readonly NxGraph.Graphs.LogicNode EventEntryStateMarker
   field static readonly NxGraph.Graphs.LogicNode ForkStateMarker
   field static readonly NxGraph.Graphs.LogicNode HistoryStateMarker
   field static readonly NxGraph.Graphs.LogicNode JoinStateMarker
@@ -835,6 +871,7 @@ struct NxGraph.Graphs.NodeId : System.IEquatable`1[[NxGraph.Graphs.NodeId]]
   property Int32 Index { get; }
   property NxGraph.Graphs.NodeId Default { get; }
   property NxGraph.Graphs.NodeId DynamicParallelStateMarker { get; }
+  property NxGraph.Graphs.NodeId EventEntryStateMarker { get; }
   property NxGraph.Graphs.NodeId ForkStateMarker { get; }
   property NxGraph.Graphs.NodeId HistoryStateMarker { get; }
   property NxGraph.Graphs.NodeId JoinStateMarker { get; }

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -18,6 +18,10 @@ static class NxGraph.Authoring.Dsl
   method BranchBuilder ToAsync[TIn,TOut](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
   method BranchBuilder ToAsync[TIn](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
   method BranchBuilder ToAsync[TOut](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method BranchBuilder ToBehaviors(BranchBuilder, NxGraph.Behaviors.IBehavior[])
+  method BranchBuilder ToBehaviorsAsync(BranchBuilder, NxGraph.Behaviors.IAsyncBehavior[])
+  method BranchBuilder ToBehaviorsAsync[TAgent](BranchBuilder, NxGraph.Behaviors.IAsyncBehavior[])
+  method BranchBuilder ToBehaviors[TAgent](BranchBuilder, NxGraph.Behaviors.IBehavior[])
   method BranchBuilder To[TIn,TOut](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
   method BranchBuilder To[TIn](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
   method BranchBuilder To[TOut](BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
@@ -76,6 +80,18 @@ static class NxGraph.Authoring.Dsl
   method NxGraph.Authoring.StateToken ToAsync[TOut](BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
   method NxGraph.Authoring.StateToken ToAsync[TOut](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
   method NxGraph.Authoring.StateToken ToAsync[TOut](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToBehaviors(BranchEnd, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviors(NxGraph.Authoring.StartToken, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviors(NxGraph.Authoring.StateToken, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync(BranchEnd, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync(NxGraph.Authoring.StartToken, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync(NxGraph.Authoring.StateToken, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync[TAgent](BranchEnd, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync[TAgent](NxGraph.Authoring.StartToken, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync[TAgent](NxGraph.Authoring.StateToken, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviors[TAgent](BranchEnd, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviors[TAgent](NxGraph.Authoring.StartToken, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviors[TAgent](NxGraph.Authoring.StateToken, NxGraph.Behaviors.IBehavior[])
   method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StartToken, System.TimeSpan, NxGraph.Graphs.ILogic, NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StartToken, System.TimeSpan, System.Func`1[NxGraph.Result], NxGraph.Fsm.TimeoutBehavior)
   method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StateToken, System.TimeSpan, NxGraph.Graphs.ILogic, NxGraph.Fsm.TimeoutBehavior)
@@ -277,6 +293,69 @@ static class NxGraph.Authoring.TokenDsl
   method NxGraph.Tokens.AsyncTokenMachine`1[TAgent] ToAsyncTokenMachine[TAgent](NxGraph.Graphs.Graph, NxGraph.Tokens.IAsyncTokenMachineObserver, Int32)
   method NxGraph.Tokens.TokenMachine ToTokenMachine(NxGraph.Graphs.Graph, NxGraph.Tokens.ITokenMachineObserver, Int32)
   method NxGraph.Tokens.TokenMachine`1[TAgent] ToTokenMachine[TAgent](NxGraph.Graphs.Graph, NxGraph.Tokens.ITokenMachineObserver, Int32)
+sealed class NxGraph.Behaviors.AsyncBehaviorState : NxGraph.Fsm.Async.AsyncState, NxGraph.Behaviors.IBehaviorComposite, NxGraph.Behaviors.IBehaviorReportSink, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(NxGraph.Behaviors.IAsyncBehavior[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IAsyncBehavior] Behaviors { get; }
+sealed class NxGraph.Behaviors.AsyncBehaviorState`1 : AsyncState`1, IAgentSettable`1, NxGraph.Behaviors.IBehaviorComposite, NxGraph.Behaviors.IBehaviorReportSink, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor Void .ctor(NxGraph.Behaviors.IAsyncBehavior[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IAsyncBehavior] Behaviors { get; }
+struct NxGraph.Behaviors.BehaviorContext
+  method T Resolve[T](NxGraph.Behaviors.BlackboardValue`1[T] ByRef)
+  method Void Report(System.String)
+  property Boolean HasReporter { get; }
+  property NxGraph.Blackboards.BlackboardContext Bb { get; }
+sealed class NxGraph.Behaviors.BehaviorState : NxGraph.Fsm.State, NxGraph.Behaviors.IBehaviorComposite, NxGraph.Behaviors.IBehaviorReportSink, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor Void .ctor(NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Result OnRun()
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IBehavior] Behaviors { get; }
+sealed class NxGraph.Behaviors.BehaviorState`1 : State`1, IAgentSettable`1, NxGraph.Behaviors.IBehaviorComposite, NxGraph.Behaviors.IBehaviorReportSink, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor Void .ctor(NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Result OnRun()
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IBehavior] Behaviors { get; }
+struct NxGraph.Behaviors.BlackboardValue`1
+  method NxGraph.Behaviors.BlackboardValue`1[T] Bound(System.String)
+  method System.String ToString()
+  operator NxGraph.Behaviors.BlackboardValue`1[T] op_Implicit(NxGraph.Blackboards.BlackboardKey`1[T])
+  operator NxGraph.Behaviors.BlackboardValue`1[T] op_Implicit(T)
+  property Boolean IsBound { get; }
+  property System.String KeyName { get; }
+  property T Literal { get; }
+interface NxGraph.Behaviors.IAgentBehavior : NxGraph.Behaviors.IBehavior
+interface NxGraph.Behaviors.IAsyncAgentBehavior : NxGraph.Behaviors.IAsyncBehavior
+interface NxGraph.Behaviors.IAsyncBehavior
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+interface NxGraph.Behaviors.IAsyncBehavior`1 : NxGraph.Behaviors.IAsyncAgentBehavior, NxGraph.Behaviors.IAsyncBehavior
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(TAgent, NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+interface NxGraph.Behaviors.IBehavior
+  method NxGraph.Result Execute(NxGraph.Behaviors.BehaviorContext ByRef)
+interface NxGraph.Behaviors.IBehaviorComposite
+  property Boolean IsSync { get; }
+  property System.Collections.Generic.IReadOnlyList`1[System.Object] Entries { get; }
+  property System.Type AgentType { get; }
+interface NxGraph.Behaviors.IBehavior`1 : NxGraph.Behaviors.IAgentBehavior, NxGraph.Behaviors.IBehavior
+  method NxGraph.Result Execute(TAgent, NxGraph.Behaviors.BehaviorContext ByRef)
+sealed class NxGraph.Behaviors.Log : NxGraph.Behaviors.IAsyncBehavior, NxGraph.Behaviors.IBehavior
+  ctor Void .ctor(NxGraph.Behaviors.BlackboardValue`1[NxGraph.Behaviors.LogSeverity], NxGraph.Behaviors.BlackboardValue`1[System.String])
+  ctor Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.String])
+  method NxGraph.Result Execute(NxGraph.Behaviors.BehaviorContext ByRef)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[NxGraph.Behaviors.LogSeverity] Severity { get; }
+  property NxGraph.Behaviors.BlackboardValue`1[System.String] Message { get; }
+enum NxGraph.Behaviors.LogSeverity : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+  Error = 3
+  Info = 1
+  Trace = 0
+  Warning = 2
+sealed class NxGraph.Behaviors.SetValue`1 : NxGraph.Behaviors.IAsyncBehavior, NxGraph.Behaviors.IBehavior
+  ctor Void .ctor(NxGraph.Blackboards.BlackboardKey`1[T], NxGraph.Behaviors.BlackboardValue`1[T])
+  method NxGraph.Behaviors.SetValue`1[T] Unbound(System.String, NxGraph.Behaviors.BlackboardValue`1[T])
+  method NxGraph.Result Execute(NxGraph.Behaviors.BehaviorContext ByRef)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[T] Value { get; }
+  property NxGraph.Blackboards.BlackboardKey`1[T] Key { get; }
+  property System.String KeyName { get; }
 sealed class NxGraph.Blackboards.Blackboard
   ctor Void .ctor(NxGraph.Blackboards.BlackboardSchema)
   method Boolean TryGet[T](NxGraph.Blackboards.BlackboardKey`1[T], T ByRef)
@@ -839,6 +918,8 @@ interface NxGraph.Graphs.ISubGraphProvider
   property System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.Graph] SubGraphs { get; }
 class NxGraph.Graphs.LogicNode : NxGraph.Graphs.INode
   ctor Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.IAsyncLogic, System.Action, System.Action)
+  field static readonly NxGraph.Graphs.LogicNode AsyncBehaviorStateMarker
+  field static readonly NxGraph.Graphs.LogicNode BehaviorStateMarker
   field static readonly NxGraph.Graphs.LogicNode DynamicParallelStateMarker
   field static readonly NxGraph.Graphs.LogicNode Empty
   field static readonly NxGraph.Graphs.LogicNode EventEntryStateMarker
@@ -869,6 +950,8 @@ struct NxGraph.Graphs.NodeId : System.IEquatable`1[[NxGraph.Graphs.NodeId]]
   operator Boolean op_Equality(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
   operator Boolean op_Inequality(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
   property Int32 Index { get; }
+  property NxGraph.Graphs.NodeId AsyncBehaviorStateMarker { get; }
+  property NxGraph.Graphs.NodeId BehaviorStateMarker { get; }
   property NxGraph.Graphs.NodeId Default { get; }
   property NxGraph.Graphs.NodeId DynamicParallelStateMarker { get; }
   property NxGraph.Graphs.NodeId EventEntryStateMarker { get; }

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -301,6 +301,22 @@ sealed class NxGraph.Behaviors.AsyncBehaviorState`1 : AsyncState`1, IAgentSettab
   ctor Void .ctor(NxGraph.Behaviors.IAsyncBehavior[])
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
   property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IAsyncBehavior] Behaviors { get; }
+sealed class NxGraph.Behaviors.AsyncRepeat : NxGraph.Behaviors.IAsyncBehavior
+  ctor Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Behaviors.IAsyncBehavior[])
+  ctor Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Blackboards.BlackboardKey`1[System.Int32], NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Behaviors.AsyncRepeat Unbound(NxGraph.Behaviors.BlackboardValue`1[System.Int32], System.String, NxGraph.Behaviors.IAsyncBehavior[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[System.Int32] Count { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IAsyncBehavior] Body { get; }
+  property System.String IndexKeyName { get; }
+sealed class NxGraph.Behaviors.AsyncRepeat`1 : IAsyncBehavior`1, NxGraph.Behaviors.IAsyncAgentBehavior, NxGraph.Behaviors.IAsyncBehavior
+  ctor Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Behaviors.IAsyncBehavior[])
+  ctor Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Blackboards.BlackboardKey`1[System.Int32], NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Behaviors.AsyncRepeat`1[TAgent] Unbound(NxGraph.Behaviors.BlackboardValue`1[System.Int32], System.String, NxGraph.Behaviors.IAsyncBehavior[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(TAgent, NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[System.Int32] Count { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IAsyncBehavior] Body { get; }
+  property System.String IndexKeyName { get; }
 struct NxGraph.Behaviors.BehaviorContext
   method T Resolve[T](NxGraph.Behaviors.BlackboardValue`1[T] ByRef)
   method Void Report(System.String)
@@ -348,6 +364,24 @@ enum NxGraph.Behaviors.LogSeverity : System.IComparable, System.IConvertible, Sy
   Info = 1
   Trace = 0
   Warning = 2
+sealed class NxGraph.Behaviors.Repeat : NxGraph.Behaviors.IAsyncBehavior, NxGraph.Behaviors.IBehavior
+  ctor Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Behaviors.IBehavior[])
+  ctor Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Blackboards.BlackboardKey`1[System.Int32], NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Behaviors.Repeat Unbound(NxGraph.Behaviors.BlackboardValue`1[System.Int32], System.String, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Result Execute(NxGraph.Behaviors.BehaviorContext ByRef)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[System.Int32] Count { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IBehavior] Body { get; }
+  property System.String IndexKeyName { get; }
+sealed class NxGraph.Behaviors.Repeat`1 : IAsyncBehavior`1, IBehavior`1, NxGraph.Behaviors.IAgentBehavior, NxGraph.Behaviors.IAsyncAgentBehavior, NxGraph.Behaviors.IAsyncBehavior, NxGraph.Behaviors.IBehavior
+  ctor Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Behaviors.IBehavior[])
+  ctor Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Blackboards.BlackboardKey`1[System.Int32], NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Behaviors.Repeat`1[TAgent] Unbound(NxGraph.Behaviors.BlackboardValue`1[System.Int32], System.String, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Result Execute(TAgent, NxGraph.Behaviors.BehaviorContext ByRef)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(TAgent, NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[System.Int32] Count { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IBehavior] Body { get; }
+  property System.String IndexKeyName { get; }
 sealed class NxGraph.Behaviors.SetValue`1 : NxGraph.Behaviors.IAsyncBehavior, NxGraph.Behaviors.IBehavior
   ctor Void .ctor(NxGraph.Blackboards.BlackboardKey`1[T], NxGraph.Behaviors.BlackboardValue`1[T])
   method NxGraph.Behaviors.SetValue`1[T] Unbound(System.String, NxGraph.Behaviors.BlackboardValue`1[T])

--- a/NxGraph.Tests/RepeatBehaviorTests.cs
+++ b/NxGraph.Tests/RepeatBehaviorTests.cs
@@ -1,0 +1,590 @@
+using NxGraph.Authoring;
+using NxGraph.Behaviors;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Repeat — bounded sub-node iteration for behavior sequences (spec 015). Codifies the
+/// contract: the trip count resolves <b>once at entry</b> (literal negative rejected at
+/// construction, key-bound ≤ 0 vacuous <c>Success</c>), the optional 0-based index key is
+/// written before each iteration, fail-fast applies at every level (entry → iteration →
+/// sequence → node), the node fault model is untouched (a <c>.Retry</c> re-runs all
+/// iterations), the context passes through to nested bodies (reports route to the owning
+/// node), the async paths observe cancellation between iterations, and the agent channel
+/// stays a call parameter through nested bodies.
+/// </summary>
+[TestFixture]
+[Category("behaviors")]
+public class RepeatBehaviorTests
+{
+    // ── Test doubles ─────────────────────────────────────────────────────
+
+    /// <summary>Dual-interface probe: appends its id to a shared trace, returns a fixed result.</summary>
+    private sealed class TraceBehavior(string id, List<string> trace, Func<Result>? result = null)
+        : IBehavior, IAsyncBehavior
+    {
+        public Result Execute(in BehaviorContext ctx)
+        {
+            trace.Add(id);
+            return result?.Invoke() ?? Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct)
+        {
+            trace.Add(id);
+            return new ValueTask<Result>(result?.Invoke() ?? Result.Success);
+        }
+    }
+
+    /// <summary>Dual-interface probe: resolves a binding and records the value.</summary>
+    private sealed class CaptureBehavior<T>(BlackboardValue<T> value, List<T?> captured)
+        : IBehavior, IAsyncBehavior
+    {
+        public Result Execute(in BehaviorContext ctx)
+        {
+            captured.Add(ctx.Resolve(value));
+            return Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct)
+        {
+            captured.Add(ctx.Resolve(value));
+            return ResultHelpers.Success;
+        }
+    }
+
+    /// <summary>Dual-interface probe: adds a delta to an int key — the count-mutation probe.</summary>
+    private sealed class AddToKey(BlackboardKey<int> key, int delta) : IBehavior, IAsyncBehavior
+    {
+        public Result Execute(in BehaviorContext ctx)
+        {
+            ctx.Bb.Set(key, ctx.Bb.Get(key) + delta);
+            return Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct)
+        {
+            ctx.Bb.Set(key, ctx.Bb.Get(key) + delta);
+            return ResultHelpers.Success;
+        }
+    }
+
+    /// <summary>Cancels the shared source and succeeds — the between-iterations probe.</summary>
+    private sealed class CancelSource(CancellationTokenSource cts) : IAsyncBehavior
+    {
+        public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct)
+        {
+            cts.Cancel();
+            return ResultHelpers.Success;
+        }
+    }
+
+    private sealed class Hero
+    {
+        public required string Name;
+        public List<string> Visits = [];
+    }
+
+    private sealed class Villain;
+
+    /// <summary>Agent-typed dual-interface probe: records which agent instance it received.</summary>
+    private sealed class GreetHero : IBehavior<Hero>, IAsyncBehavior<Hero>
+    {
+        public Result Execute(Hero agent, in BehaviorContext ctx)
+        {
+            agent.Visits.Add($"greet:{agent.Name}");
+            return Result.Success;
+        }
+
+        public ValueTask<Result> ExecuteAsync(Hero agent, BehaviorContext ctx, CancellationToken ct)
+        {
+            agent.Visits.Add($"greet:{agent.Name}");
+            return ResultHelpers.Success;
+        }
+    }
+
+    private sealed class VillainOnly : IBehavior<Villain>
+    {
+        public Result Execute(Villain agent, in BehaviorContext ctx) => Result.Success;
+    }
+
+    private sealed class AsyncVillainOnly : IAsyncBehavior<Villain>
+    {
+        public ValueTask<Result> ExecuteAsync(Villain agent, BehaviorContext ctx, CancellationToken ct) =>
+            ResultHelpers.Success;
+    }
+
+    private sealed class LogCapturingAsyncObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+
+        public ValueTask OnLogReport(NodeId nodeId, string message, CancellationToken ct)
+        {
+            Messages.Add(message);
+            return default;
+        }
+    }
+
+    private sealed class LogCapturingSyncObserver : IStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+
+        void IStateMachineObserver.OnLogReport(NodeId nodeId, string message) => Messages.Add(message);
+    }
+
+    private static Result RunToEnd(StateMachine machine)
+    {
+        Result result = machine.Execute();
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+
+    // ── Trip count ───────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Literal_count_runs_the_body_that_many_times([Values] bool sync)
+    {
+        List<string> trace = [];
+        Repeat repeat = new(3, new TraceBehavior("a", trace), new TraceBehavior("b", trace));
+
+        Graph graph = sync
+            ? GraphBuilder.Start().ToBehaviors(repeat).Build()
+            : GraphBuilder.Start().ToBehaviorsAsync(repeat).Build();
+
+        Result result = sync
+            ? RunToEnd(graph.ToStateMachine())
+            : await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "a", "b", "a", "b", "a", "b" }));
+        });
+    }
+
+    [Test]
+    public async Task Key_bound_count_reads_the_trip_count_from_the_board()
+    {
+        BlackboardSchema schema = new("loops");
+        BlackboardKey<int> countKey = schema.Register("trips", 0);
+
+        List<string> trace = [];
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new AsyncRepeat(countKey, new TraceBehavior("tick", trace)))
+            .WithSchema(schema)
+            .Build();
+
+        Blackboard board = new(schema);
+        board.Set(countKey, 4);
+        Result result = await graph.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Has.Count.EqualTo(4));
+        });
+    }
+
+    [Test]
+    public async Task Count_is_resolved_once_at_entry_even_when_the_body_writes_the_bound_key([Values] bool sync)
+    {
+        BlackboardSchema schema = new("loops");
+        BlackboardKey<int> countKey = schema.Register("trips", 2);
+
+        List<string> trace = [];
+        // The body inflates its own count key every iteration — the trip count must stay the
+        // entry-resolved 2, or Repeat would be a While in disguise.
+        Repeat repeat = new(countKey, new TraceBehavior("tick", trace), new AddToKey(countKey, 5));
+
+        Graph graph = sync
+            ? GraphBuilder.Start().ToBehaviors(repeat).WithSchema(schema).Build()
+            : GraphBuilder.Start().ToBehaviorsAsync(repeat).WithSchema(schema).Build();
+
+        Blackboard board = new(schema);
+        Result result = sync
+            ? RunToEnd(graph.ToStateMachine().WithBlackboard(board))
+            : await graph.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Has.Count.EqualTo(2), "The trip count is fixed at entry.");
+            Assert.That(board.Get(countKey), Is.EqualTo(12), "The body's writes did land — they just don't steer.");
+        });
+    }
+
+    [Test]
+    public async Task Key_bound_count_of_zero_or_negative_is_vacuous_success([Values(0, -5)] int boundCount)
+    {
+        BlackboardSchema schema = new("loops");
+        BlackboardKey<int> countKey = schema.Register("trips", 0);
+
+        List<string> trace = [];
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new AsyncRepeat(countKey, new TraceBehavior("never", trace)))
+            .WithSchema(schema)
+            .Build();
+
+        Blackboard board = new(schema);
+        board.Set(countKey, boundCount);
+        Result result = await graph.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success), "Runtime data must not throw — vacuous Success.");
+            Assert.That(trace, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Literal_negative_count_is_rejected_at_construction()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = new Repeat(-1, new Log("x")));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = new Repeat<Hero>(-1, new Log("x")));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = new AsyncRepeat(-1, new Log("x")));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = new AsyncRepeat<Hero>(-1, new Log("x")));
+        });
+    }
+
+    // ── Index key ────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Index_key_is_written_zero_based_before_each_iteration([Values] bool sync)
+    {
+        BlackboardSchema schema = new("loops");
+        BlackboardKey<int> indexKey = schema.Register("i", -1);
+
+        List<int> captured = [];
+        Repeat repeat = new(3, indexKey, new CaptureBehavior<int>(indexKey, captured));
+
+        Graph graph = sync
+            ? GraphBuilder.Start().ToBehaviors(repeat).WithSchema(schema).Build()
+            : GraphBuilder.Start().ToBehaviorsAsync(repeat).WithSchema(schema).Build();
+
+        Blackboard board = new(schema);
+        Result result = sync
+            ? RunToEnd(graph.ToStateMachine().WithBlackboard(board))
+            : await graph.ToAsyncStateMachine().WithBlackboard(board).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(captured, Is.EqualTo(new[] { 0, 1, 2 }));
+        });
+    }
+
+    [Test]
+    public async Task Absent_index_key_writes_nothing()
+    {
+        BlackboardSchema schema = new("loops");
+        BlackboardKey<int> indexKey = schema.Register("i", 99);
+
+        List<int> captured = [];
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new AsyncRepeat(2, new CaptureBehavior<int>(indexKey, captured)))
+            .WithSchema(schema)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine()
+            .WithBlackboard(new Blackboard(schema))
+            .ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(captured, Is.EqualTo(new[] { 99, 99 }),
+                "With no index key the slot keeps its registered default — no write, zero cost.");
+        });
+    }
+
+    // ── Fail-fast and the node fault model ───────────────────────────────
+
+    [Test]
+    public async Task Fail_fast_stops_the_iteration_and_all_later_iterations([Values] bool sync)
+    {
+        List<string> trace = [];
+        int flakyCalls = 0;
+        Repeat repeat = new(3,
+            new TraceBehavior("a", trace),
+            new TraceBehavior("flaky", trace, () => ++flakyCalls == 2 ? Result.Failure : Result.Success),
+            new TraceBehavior("tail", trace));
+
+        Graph graph = sync
+            ? GraphBuilder.Start().ToBehaviors(repeat).Build()
+            : GraphBuilder.Start().ToBehaviorsAsync(repeat).Build();
+
+        Result result = sync
+            ? RunToEnd(graph.ToStateMachine())
+            : await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Failure));
+            Assert.That(trace, Is.EqualTo(new[] { "a", "flaky", "tail", "a", "flaky" }),
+                "The failing entry stops its iteration's tail and every later iteration — one rule at every level.");
+        });
+    }
+
+    [Test]
+    public async Task Node_retry_reruns_all_iterations()
+    {
+        List<string> trace = [];
+        int calls = 0;
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new AsyncRepeat(2,
+                new TraceBehavior("tick", trace, () => ++calls == 1 ? Result.Failure : Result.Success)))
+            .Retry(maxAttempts: 2)
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "tick", "tick", "tick" }),
+                "Attempt 1 died at iteration 0; the retry re-ran all iterations — idempotency compounds with trip count.");
+        });
+    }
+
+    // ── Composition, context pass-through, runtime parity ────────────────
+
+    [Test]
+    public async Task Nested_repeat_multiplies_the_trip_counts([Values] bool sync)
+    {
+        List<string> trace = [];
+        Repeat repeat = new(2, new Repeat(2, new TraceBehavior("inner", trace)));
+
+        Graph graph = sync
+            ? GraphBuilder.Start().ToBehaviors(repeat).Build()
+            : GraphBuilder.Start().ToBehaviorsAsync(repeat).Build();
+
+        Result result = sync
+            ? RunToEnd(graph.ToStateMachine())
+            : await graph.ToAsyncStateMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Has.Count.EqualTo(4));
+        });
+    }
+
+    [Test]
+    public async Task Nested_log_reaches_the_observer_through_the_pass_through_context([Values] bool sync)
+    {
+        Repeat repeat = new(2, new Log("inside"));
+        Graph graph = sync
+            ? GraphBuilder.Start().ToBehaviors(repeat).Build()
+            : GraphBuilder.Start().ToBehaviorsAsync(repeat).Build();
+
+        Result result;
+        List<string> messages;
+        if (sync)
+        {
+            LogCapturingSyncObserver observer = new();
+            result = RunToEnd(graph.ToStateMachine(observer));
+            messages = observer.Messages;
+        }
+        else
+        {
+            LogCapturingAsyncObserver observer = new();
+            result = await graph.ToAsyncStateMachine(observer).ExecuteAsync();
+            messages = observer.Messages;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(messages, Is.EqualTo(new[] { "[Info] inside", "[Info] inside" }),
+                "Reports from the body route to the owning node's report channel — no new plumbing.");
+        });
+    }
+
+    [Test]
+    public async Task Sync_repeat_runs_under_the_async_machine_via_the_adapter()
+    {
+        List<string> trace = [];
+        LogCapturingAsyncObserver observer = new();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviors(new Repeat(2, new TraceBehavior("tick", trace), new Log("adapted")))
+            .Build();
+
+        Result result = await graph.ToAsyncStateMachine(observer).ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "tick", "tick" }));
+            Assert.That(observer.Messages, Is.EqualTo(new[] { "[Info] adapted", "[Info] adapted" }));
+        });
+    }
+
+    // ── Cancellation ─────────────────────────────────────────────────────
+
+    [Test]
+    public void Async_repeat_observes_cancellation_between_iterations()
+    {
+        List<string> trace = [];
+        CancellationTokenSource cts = new();
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync(new AsyncRepeat(3,
+                new CancelSource(cts),
+                new TraceBehavior("tick", trace)))
+            .Build();
+
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(async () => await machine.ExecuteAsync(cts.Token),
+                Throws.InstanceOf<OperationCanceledException>());
+            Assert.That(trace, Is.EqualTo(new[] { "tick" }),
+                "Iteration 0 completes; the check between iterations stops iteration 1.");
+        });
+    }
+
+    // ── Wiring-time rejections ───────────────────────────────────────────
+
+    [Test]
+    public void Empty_and_null_bodies_are_rejected()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<ArgumentException>(() => _ = new Repeat(1));
+            Assert.Throws<ArgumentException>(() => _ = new AsyncRepeat(1));
+            Assert.Throws<ArgumentException>(() => _ = new Repeat(1, new Log("a"), null!));
+            Assert.Throws<ArgumentException>(() => _ = new AsyncRepeat(1, new Log("a"), null!));
+            Assert.Throws<ArgumentException>(() => _ = new Repeat<Hero>(1));
+            Assert.Throws<ArgumentException>(() => _ = new AsyncRepeat<Hero>(1));
+        });
+    }
+
+    [Test]
+    public void Untyped_repeat_rejects_agent_typed_body_entries_naming_the_typed_twin()
+    {
+        ArgumentException? syncEx =
+            Assert.Throws<ArgumentException>(() => _ = new Repeat(1, new GreetHero()));
+        ArgumentException? asyncEx =
+            Assert.Throws<ArgumentException>(() => _ = new AsyncRepeat(1, new GreetHero()));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncEx!.Message, Does.Contain("Repeat<TAgent>").And.Contain("GreetHero"));
+            Assert.That(asyncEx!.Message, Does.Contain("AsyncRepeat<TAgent>").And.Contain("GreetHero"));
+        });
+    }
+
+    [Test]
+    public void Typed_repeat_rejects_wrong_agent_body_entries_naming_both_types()
+    {
+        ArgumentException? syncEx =
+            Assert.Throws<ArgumentException>(() => _ = new Repeat<Hero>(1, new VillainOnly()));
+        ArgumentException? asyncEx =
+            Assert.Throws<ArgumentException>(() => _ = new AsyncRepeat<Hero>(1, new AsyncVillainOnly()));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncEx!.Message, Does.Contain("Villain").And.Contain("Hero"));
+            Assert.That(asyncEx!.Message, Does.Contain("Villain").And.Contain("Hero"));
+        });
+    }
+
+    [Test]
+    public void Untyped_composite_rejects_a_typed_repeat_entry()
+    {
+        // Repeat<TAgent> is itself an IAgentBehavior, so the composite-level rules apply to it
+        // automatically — nothing repeat-specific needed.
+        ArgumentException? ex = Assert.Throws<ArgumentException>(
+            () => _ = new BehaviorState(new Repeat<Hero>(1, new GreetHero())));
+
+        Assert.That(ex!.Message, Does.Contain("ToBehaviors<TAgent>").And.Contain("Repeat"));
+    }
+
+    [Test]
+    public void Dim_guards_throw_on_the_untyped_entry_points_of_the_typed_twins()
+    {
+        IBehavior syncRepeat = new Repeat<Hero>(1, new GreetHero());
+        IAsyncBehavior asyncRepeat = new AsyncRepeat<Hero>(1, new GreetHero());
+        BehaviorContext ctx = default;
+
+        NotSupportedException? syncEx =
+            Assert.Throws<NotSupportedException>(() => syncRepeat.Execute(in ctx));
+        NotSupportedException? asyncEx = Assert.ThrowsAsync<NotSupportedException>(
+            async () => await asyncRepeat.ExecuteAsync(default, CancellationToken.None));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncEx!.Message, Does.Contain("Repeat").And.Contain("agent-typed"));
+            Assert.That(asyncEx!.Message, Does.Contain("AsyncRepeat").And.Contain("agent-typed"));
+        });
+    }
+
+    // ── Agent-typed channel ──────────────────────────────────────────────
+
+    [Test]
+    public async Task Typed_repeat_delivers_the_machine_bound_agent_every_iteration([Values] bool sync)
+    {
+        List<string> trace = [];
+        Hero hero = new() { Name = "Asta" };
+        Graph graph = sync
+            ? GraphBuilder.Start()
+                .ToBehaviors<Hero>(new Repeat<Hero>(3, new TraceBehavior("plain", trace), new GreetHero()))
+                .Build()
+            : GraphBuilder.Start()
+                .ToBehaviorsAsync<Hero>(new AsyncRepeat<Hero>(3, new TraceBehavior("plain", trace), new GreetHero()))
+                .Build();
+
+        Result result;
+        if (sync)
+        {
+            result = RunToEnd(graph.ToStateMachine<Hero>().WithAgent(hero));
+        }
+        else
+        {
+            result = await graph.ToAsyncStateMachine<Hero>().WithAgent(hero).ExecuteAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(trace, Is.EqualTo(new[] { "plain", "plain", "plain" }),
+                "Plain entries run agent-blind in the mixed body.");
+            Assert.That(hero.Visits, Is.EqualTo(new[] { "greet:Asta", "greet:Asta", "greet:Asta" }),
+                "The agent reaches typed body entries as a call parameter, per iteration.");
+        });
+    }
+
+    [Test]
+    public async Task Two_machines_sharing_one_graph_deliver_their_own_agent_through_the_body()
+    {
+        Graph graph = GraphBuilder.Start()
+            .ToBehaviorsAsync<Hero>(new AsyncRepeat<Hero>(2, new GreetHero()))
+            .Build();
+
+        Hero first = new() { Name = "Asta" };
+        Hero second = new() { Name = "Yuno" };
+        AsyncStateMachine<Hero> machineA = graph.ToAsyncStateMachine<Hero>().WithAgent(first);
+        AsyncStateMachine<Hero> machineB = graph.ToAsyncStateMachine<Hero>().WithAgent(second);
+
+        // Non-overlapping runs — the standard shared-graph contract; the agent re-stamps at
+        // every run start and flows through the nested body as a call parameter.
+        await machineA.ExecuteAsync();
+        await machineB.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Visits, Is.EqualTo(new[] { "greet:Asta", "greet:Asta" }));
+            Assert.That(second.Visits, Is.EqualTo(new[] { "greet:Yuno", "greet:Yuno" }));
+        });
+    }
+}

--- a/NxGraph/Authoring/Dsl.Behaviors.cs
+++ b/NxGraph/Authoring/Dsl.Behaviors.cs
@@ -1,0 +1,143 @@
+using NxGraph.Behaviors;
+
+namespace NxGraph.Authoring;
+
+public static partial class Dsl
+{
+    // ── Behaviors: declarative, reusable, blackboard-bound state composition ──
+    //
+    // .ToBehaviors(...) authors a node as a sequence of small data-shaped behaviors instead
+    // of an opaque lambda or a hand-written State subclass. Explicit names (not .To
+    // overloads): params interface arrays next to the single-logic To(ILogic) overloads
+    // would invite overload-resolution surprises.
+
+    /// <summary>
+    /// Starts the graph with a node that runs <paramref name="behaviors"/> <b>in order,
+    /// fail-fast</b>: the first non-<c>Success</c> entry stops the sequence and the node
+    /// returns <c>Failure</c> (see <see cref="BehaviorState"/> — the deliberate opposite of
+    /// <c>ToAll</c>'s run-all-then-combine, because sequence entries may depend on earlier
+    /// entries' writes). The node keeps the whole fault model: <c>.Retry(...)</c> re-runs the
+    /// whole list, <c>.OnError(...)</c> reroutes, <c>.WithOutcome(...)</c> codes. An empty or
+    /// null array throws <see cref="ArgumentException"/> at wiring time, as do null entries
+    /// and agent-typed (<see cref="IAgentBehavior"/>) entries — those need
+    /// <see cref="ToBehaviors{TAgent}(StartToken, IBehavior[])"/>. The node is plain sync
+    /// logic and also runs under the async machine via the sync-logic adapter.
+    /// </summary>
+    public static StateToken ToBehaviors(this StartToken token, params IBehavior[] behaviors)
+    {
+        return token.To(new BehaviorState(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviors(StartToken, IBehavior[])"/>
+    public static StateToken ToBehaviors(this StateToken prev, params IBehavior[] behaviors)
+    {
+        return prev.To(new BehaviorState(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviors(StartToken, IBehavior[])"/>
+    public static BranchBuilder ToBehaviors(this BranchBuilder branch, params IBehavior[] behaviors)
+    {
+        return branch.To(new BehaviorState(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviors(StartToken, IBehavior[])"/>
+    public static StateToken ToBehaviors(this BranchEnd branchEnd, params IBehavior[] behaviors)
+    {
+        return branchEnd.To(new BehaviorState(behaviors));
+    }
+
+    /// <summary>
+    /// Starts the graph with the async twin of
+    /// <see cref="ToBehaviors(StartToken, IBehavior[])"/>: the same in-order, fail-fast
+    /// sequence over <see cref="IAsyncBehavior"/> entries (see
+    /// <see cref="AsyncBehaviorState"/>). Dual-interface behaviors (the standard set) pass to
+    /// either overload. Agent-typed (<see cref="IAsyncAgentBehavior"/>) entries need
+    /// <see cref="ToBehaviorsAsync{TAgent}(StartToken, IAsyncBehavior[])"/>.
+    /// </summary>
+    public static StateToken ToBehaviorsAsync(this StartToken token, params IAsyncBehavior[] behaviors)
+    {
+        return token.ToAsync(new AsyncBehaviorState(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviorsAsync(StartToken, IAsyncBehavior[])"/>
+    public static StateToken ToBehaviorsAsync(this StateToken prev, params IAsyncBehavior[] behaviors)
+    {
+        return prev.ToAsync(new AsyncBehaviorState(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviorsAsync(StartToken, IAsyncBehavior[])"/>
+    public static BranchBuilder ToBehaviorsAsync(this BranchBuilder branch, params IAsyncBehavior[] behaviors)
+    {
+        return branch.ToAsync(new AsyncBehaviorState(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviorsAsync(StartToken, IAsyncBehavior[])"/>
+    public static StateToken ToBehaviorsAsync(this BranchEnd branchEnd, params IAsyncBehavior[] behaviors)
+    {
+        return branchEnd.ToAsync(new AsyncBehaviorState(behaviors));
+    }
+
+    /// <summary>
+    /// Starts the graph with an <b>agent-typed</b> behavior node (see
+    /// <see cref="BehaviorState{TAgent}"/>): plain and <see cref="IBehavior{TAgent}"/> entries
+    /// may mix — typed entries receive the machine-bound agent as a call parameter per
+    /// execution (the agent is never stamped onto behavior instances), plain entries run
+    /// agent-blind. The composite participates in the standard agent stamping walk, so
+    /// <c>Graph.SetAgent</c> counts it as an acceptor and machines sharing one graph each
+    /// deliver their own agent. An <see cref="IAgentBehavior"/> entry of a different agent
+    /// type throws at wiring time naming both types. Sequence semantics match the untyped
+    /// overloads (in order, fail-fast).
+    /// </summary>
+    public static StateToken ToBehaviors<TAgent>(this StartToken token, params IBehavior[] behaviors)
+    {
+        return token.To(new BehaviorState<TAgent>(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviors{TAgent}(StartToken, IBehavior[])"/>
+    public static StateToken ToBehaviors<TAgent>(this StateToken prev, params IBehavior[] behaviors)
+    {
+        return prev.To(new BehaviorState<TAgent>(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviors{TAgent}(StartToken, IBehavior[])"/>
+    public static BranchBuilder ToBehaviors<TAgent>(this BranchBuilder branch, params IBehavior[] behaviors)
+    {
+        return branch.To(new BehaviorState<TAgent>(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviors{TAgent}(StartToken, IBehavior[])"/>
+    public static StateToken ToBehaviors<TAgent>(this BranchEnd branchEnd, params IBehavior[] behaviors)
+    {
+        return branchEnd.To(new BehaviorState<TAgent>(behaviors));
+    }
+
+    /// <summary>
+    /// Starts the graph with the async twin of
+    /// <see cref="ToBehaviors{TAgent}(StartToken, IBehavior[])"/> (see
+    /// <see cref="AsyncBehaviorState{TAgent}"/>).
+    /// </summary>
+    public static StateToken ToBehaviorsAsync<TAgent>(this StartToken token, params IAsyncBehavior[] behaviors)
+    {
+        return token.ToAsync(new AsyncBehaviorState<TAgent>(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviorsAsync{TAgent}(StartToken, IAsyncBehavior[])"/>
+    public static StateToken ToBehaviorsAsync<TAgent>(this StateToken prev, params IAsyncBehavior[] behaviors)
+    {
+        return prev.ToAsync(new AsyncBehaviorState<TAgent>(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviorsAsync{TAgent}(StartToken, IAsyncBehavior[])"/>
+    public static BranchBuilder ToBehaviorsAsync<TAgent>(this BranchBuilder branch,
+        params IAsyncBehavior[] behaviors)
+    {
+        return branch.ToAsync(new AsyncBehaviorState<TAgent>(behaviors));
+    }
+
+    /// <inheritdoc cref="ToBehaviorsAsync{TAgent}(StartToken, IAsyncBehavior[])"/>
+    public static StateToken ToBehaviorsAsync<TAgent>(this BranchEnd branchEnd,
+        params IAsyncBehavior[] behaviors)
+    {
+        return branchEnd.ToAsync(new AsyncBehaviorState<TAgent>(behaviors));
+    }
+}

--- a/NxGraph/Authoring/Dsl.Events.cs
+++ b/NxGraph/Authoring/Dsl.Events.cs
@@ -1,0 +1,246 @@
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Authoring;
+
+public sealed partial class GraphBuilder
+{
+    /// <summary>
+    /// Begins building an event-entry graph (spec 013): one graph that responds to several
+    /// externally-raised, typed events, each entering the flow at its own entry chain.
+    /// Register entries with <see cref="EventsToken.On{TEvent}"/> — each binds a CLR event
+    /// type to a chain through a Graph-scoped <see cref="BlackboardKey{TEvent}"/> that
+    /// carries the payload — and optionally declare an <see cref="EventsToken.Otherwise"/>
+    /// chain for plain (non-raised) runs. <c>Build()</c> seeds the dispatcher
+    /// (<see cref="EventEntryState"/>) as the start node; raise events through the machines'
+    /// typed overloads (<c>ExecuteAsync&lt;TEvent&gt;(evt)</c> /
+    /// <c>Execute&lt;TEvent&gt;(evt)</c> / <c>StepAsync&lt;TEvent&gt;(evt)</c>).
+    /// </summary>
+    public static EventsToken StartWithEvents()
+    {
+        return new EventsToken(new GraphBuilder());
+    }
+}
+
+/// <summary>
+/// Seed handed to each entry lambda of <see cref="EventsToken.On{TEvent}"/> /
+/// <see cref="EventsToken.Otherwise"/>. The first <c>To</c>/<c>ToAsync</c> call creates the
+/// chain's head node (the dispatch target); it returns an ordinary <see cref="StateToken"/>
+/// for continued chaining with the full DSL vocabulary (<c>.OnError</c>, <c>.Retry</c>,
+/// <c>.WithOutcome</c>, ports, composites, …). Chains may converge on shared nodes — route
+/// several chains to the same logic instance (or an existing <see cref="StateToken"/>) and
+/// the builder's reference dedup merges them.
+/// </summary>
+public sealed class EventBranch
+{
+    private readonly GraphBuilder _builder;
+    private NodeId _head = NodeId.Default;
+    private bool _hasHead;
+
+    internal EventBranch(GraphBuilder builder)
+    {
+        _builder = builder;
+    }
+
+    internal NodeId Head => _hasHead
+        ? _head
+        : throw new InvalidOperationException(
+            "An event entry chain must add at least one state — call To(...)/ToAsync(...) inside the entry lambda.");
+
+    private StateToken Record(NodeId head)
+    {
+        if (_hasHead)
+        {
+            throw new InvalidOperationException(
+                "An event entry chain declares its head once — continue the chain on the returned StateToken.");
+        }
+
+        _head = head;
+        _hasHead = true;
+        return new StateToken(head, _builder);
+    }
+
+    /// <summary>Creates the chain head from sync logic. Routing several chains to the same instance converges them on one node.</summary>
+    public StateToken To(ILogic syncLogic)
+    {
+        Guard.NotNull(syncLogic, nameof(syncLogic));
+        return Record(_builder.AddNode(syncLogic));
+    }
+
+    /// <summary>Creates the chain head from async logic.</summary>
+    public StateToken ToAsync(IAsyncLogic asyncLogic)
+    {
+        Guard.NotNull(asyncLogic, nameof(asyncLogic));
+        return Record(_builder.AddNode(asyncLogic));
+    }
+
+    /// <summary>Creates the chain head from a sync function.</summary>
+    public StateToken To(Func<Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return To(new RelayState(run));
+    }
+
+    /// <summary>Creates the chain head from an async function.</summary>
+    public StateToken ToAsync(Func<CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return ToAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>Creates the chain head from a sync function receiving the machine-bound routed blackboard context.</summary>
+    public StateToken To(Func<BlackboardContext, Result> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return To(new RelayState(run));
+    }
+
+    /// <summary>Creates the chain head from an async function receiving the machine-bound routed blackboard context.</summary>
+    public StateToken ToAsync(Func<BlackboardContext, CancellationToken, ValueTask<Result>> run)
+    {
+        Guard.NotNull(run, nameof(run));
+        return ToAsync(new AsyncRelayState(run));
+    }
+
+    /// <summary>
+    /// Creates the chain head as a port-consuming step (spec 010 sugar): the relay reads
+    /// <paramref name="input"/> — typically the entry's own event key — and hands the value
+    /// (plus the routed context) to the lambda. Node-scoped keys are rejected at wiring time.
+    /// </summary>
+    public StateToken To<TIn>(BlackboardKey<TIn> input, Func<TIn, BlackboardContext, Result> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        Dsl.ThrowIfNotPortScope(input, nameof(input));
+        return To(new PortConsumerRelayState<TIn>(input, step));
+    }
+
+    /// <inheritdoc cref="To{TIn}(BlackboardKey{TIn}, Func{TIn, BlackboardContext, Result})"/>
+    public StateToken ToAsync<TIn>(BlackboardKey<TIn> input,
+        Func<TIn, BlackboardContext, CancellationToken, ValueTask<Result>> step)
+    {
+        Guard.NotNull(step, nameof(step));
+        Dsl.ThrowIfNotPortScope(input, nameof(input));
+        return ToAsync(new AsyncPortConsumerRelayState<TIn>(input, step));
+    }
+
+    /// <summary>Points the chain at an already-added node (e.g. a shared handler).</summary>
+    public StateToken To(StateToken existing)
+    {
+        return Record(existing.Id);
+    }
+}
+
+/// <summary>
+/// Returned by <see cref="GraphBuilder.StartWithEvents"/>. Accumulates typed event entries and
+/// seeds the <see cref="EventEntryState"/> dispatcher at index 0 when <see cref="Build"/> is
+/// called — the dispatcher stays the single start node, so the core graph invariants are
+/// untouched.
+/// </summary>
+public readonly struct EventsToken
+{
+    private sealed class EventsState
+    {
+        internal readonly List<EventRegistration> Registrations = [];
+        internal readonly HashSet<Type> EventTypes = [];
+        internal readonly HashSet<(BlackboardSchema Schema, int Ordinal)> KeyIdentities = [];
+        internal NodeId OtherwiseTarget = NodeId.Default;
+        internal bool HasOtherwise;
+    }
+
+    private readonly GraphBuilder _builder;
+    private readonly EventsState _state;
+
+    internal EventsToken(GraphBuilder builder)
+    {
+        _builder = builder;
+        _state = new EventsState();
+    }
+
+    public GraphBuilder Builder => _builder;
+
+    /// <summary>
+    /// Registers an entry: raising a <typeparamref name="TEvent"/> starts a run at the chain
+    /// built by <paramref name="entry"/>, with the payload delivered through
+    /// <paramref name="key"/> (an ordinary Graph-scoped <see cref="BlackboardKey{TEvent}"/> —
+    /// handlers read it via <c>Bb.Get(key)</c> or the spec-010 consumer sugar). Dispatch is by
+    /// CLR event type: a second <c>On</c> for the same type throws at wiring time, as do
+    /// Node-scoped or schema-less keys and a key already bound to another entry. Global-scoped
+    /// keys are allowed but shared across machines — prefer Graph scope.
+    /// </summary>
+    public EventsToken On<TEvent>(BlackboardKey<TEvent> key, Func<EventBranch, StateToken> entry)
+    {
+        Guard.NotNull(entry, nameof(entry));
+        EventRegistration.ValidateEventKey(key, nameof(key));
+
+        // Key check first: reusing the exact key implies reusing the type, and the key
+        // message is the more precise diagnosis for that case.
+        if (!_state.KeyIdentities.Add((key.Schema!, key.Ordinal)))
+        {
+            throw new ArgumentException(
+                $"Event key '{key.Name}' is already bound to an entry — one delivery key per entry.",
+                nameof(key));
+        }
+
+        if (!_state.EventTypes.Add(typeof(TEvent)))
+        {
+            throw new ArgumentException(
+                $"An entry for event type '{typeof(TEvent)}' is already registered — dispatch is by CLR event " +
+                "type, one entry per type. Route variants inside one entry chain (e.g. with .If/.Switch).",
+                nameof(key));
+        }
+
+        EventBranch seed = new(_builder);
+        entry(seed);
+        _state.Registrations.Add(new EventRegistration<TEvent>(key, seed.Head));
+        return this;
+    }
+
+    /// <summary>
+    /// Declares the chain a plain (non-raised) run routes to — the optional default entry.
+    /// Without one, a plain <c>ExecuteAsync()</c>/<c>Execute()</c> throws pointing at the
+    /// typed raise overloads. At most one <c>Otherwise</c> chain may be declared.
+    /// </summary>
+    public EventsToken Otherwise(Func<EventBranch, StateToken> entry)
+    {
+        Guard.NotNull(entry, nameof(entry));
+        if (_state.HasOtherwise)
+        {
+            throw new InvalidOperationException(
+                "An Otherwise chain has already been declared — an event graph has at most one plain-run entry.");
+        }
+
+        EventBranch seed = new(_builder);
+        entry(seed);
+        _state.OtherwiseTarget = seed.Head;
+        _state.HasOtherwise = true;
+        return this;
+    }
+
+    /// <inheritdoc cref="Dsl.WithSchema(StartToken, BlackboardSchema)"/>
+    public EventsToken WithSchema(BlackboardSchema schema)
+    {
+        _builder.WithSchema(schema);
+        return this;
+    }
+
+    /// <summary>
+    /// Seeds the <see cref="EventEntryState"/> dispatcher as the start node and produces the
+    /// immutable <see cref="Graph"/>. Throws when no entry has been registered.
+    /// </summary>
+    public Graph Build(bool throwOnError = false)
+    {
+        if (_state.Registrations.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "An event graph needs at least one event entry — register entries with On(key, e => ...) " +
+                "before Build().");
+        }
+
+        EventEntryState dispatcher = new(_state.Registrations, _state.OtherwiseTarget);
+        _builder.AddNode((IAsyncLogic)dispatcher, isStart: true);
+        return _builder.Build(throwOnError);
+    }
+}

--- a/NxGraph/Authoring/Dsl.Ports.cs
+++ b/NxGraph/Authoring/Dsl.Ports.cs
@@ -13,7 +13,7 @@ public static partial class Dsl
     // overloads only read/write ports around the step lambda; routing, validation, and
     // durability are the blackboard's existing machinery.
 
-    private static void ThrowIfNotPortScope<T>(in BlackboardKey<T> key, string paramName)
+    internal static void ThrowIfNotPortScope<T>(in BlackboardKey<T> key, string paramName)
     {
         if (key.Schema is null)
         {

--- a/NxGraph/Behaviors/AsyncBehaviorState.cs
+++ b/NxGraph/Behaviors/AsyncBehaviorState.cs
@@ -1,0 +1,147 @@
+using NxGraph.Fsm.Async;
+
+namespace NxGraph.Behaviors;
+
+/// <summary>
+/// Async twin of <see cref="BehaviorState"/>: runs a declarative sequence of
+/// <see cref="IAsyncBehavior"/> entries inside one node — in order, <b>fail-fast</b>: the
+/// first non-<c>Success</c> entry stops the sequence and the node returns <c>Failure</c>.
+/// Fail-fast is the deliberate opposite of <c>AsyncAllState</c>'s run-all-then-combine:
+/// sequence entries may depend on earlier entries' writes, while <c>AllState</c>'s works are
+/// concurrent and independent.
+/// <para>
+/// The node keeps the whole fault model: <c>.Retry(...)</c> re-runs the <b>whole</b> list in
+/// place (behaviors should be idempotent or tolerate re-execution), <c>.OnError(...)</c>
+/// reroutes, <c>.WithOutcome(...)</c> codes, and exceptions propagate as from any node logic.
+/// Behavior output goes through the report channel (<see cref="BehaviorContext.Report"/> →
+/// observer <c>OnLogReport</c>), never the console. Agent-typed entries
+/// (<see cref="IAsyncAgentBehavior"/>) are rejected at wiring time — use
+/// <see cref="AsyncBehaviorState{TAgent}"/> / <c>ToBehaviorsAsync&lt;TAgent&gt;</c>.
+/// </para>
+/// </summary>
+public sealed class AsyncBehaviorState : AsyncState, IBehaviorComposite, IBehaviorReportSink
+{
+    private readonly IAsyncBehavior[] _behaviors;
+    private CancellationToken _reportCt;
+
+    /// <param name="behaviors">The behaviors to run in order. At least one is required;
+    /// null entries and agent-typed (<see cref="IAsyncAgentBehavior"/>) entries are rejected.</param>
+    public AsyncBehaviorState(params IAsyncBehavior[] behaviors)
+    {
+        _behaviors = BehaviorComposition.ValidateEntries(behaviors);
+        for (int i = 0; i < behaviors.Length; i++)
+        {
+            if (behaviors[i] is IAsyncAgentBehavior)
+            {
+                throw BehaviorComposition.AgentEntryInUntyped(behaviors[i], i, "ToBehaviorsAsync<TAgent>");
+            }
+        }
+    }
+
+    /// <summary>The behavior entries in sequence order.</summary>
+    public IReadOnlyList<IAsyncBehavior> Behaviors => _behaviors;
+
+    protected override async ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        _reportCt = ct;
+        BehaviorContext ctx = new(Bb, this);
+        IAsyncBehavior[] behaviors = _behaviors;
+        for (int i = 0; i < behaviors.Length; i++)
+        {
+            Result result = await behaviors[i].ExecuteAsync(ctx, ct).ConfigureAwait(false);
+            if (result != Result.Success)
+            {
+                return Result.Failure;
+            }
+        }
+
+        return Result.Success;
+    }
+
+    bool IBehaviorComposite.IsSync => false;
+    Type? IBehaviorComposite.AgentType => null;
+    IReadOnlyList<object> IBehaviorComposite.Entries => _behaviors;
+
+    bool IBehaviorReportSink.HasReporter => LogReport is not null;
+
+    void IBehaviorReportSink.Report(string message)
+    {
+        if (LogReport is { } report)
+        {
+            BehaviorComposition.Await(report(message, _reportCt));
+        }
+    }
+}
+
+/// <summary>
+/// Agent-typed twin of <see cref="AsyncBehaviorState"/> — see
+/// <see cref="BehaviorState{TAgent}"/> for the full contract: the agent arrives through the
+/// standard <c>IAgentSettable</c> stamping walk and is passed to
+/// <see cref="IAsyncBehavior{TAgent}"/> entries as a call parameter per execution (never
+/// stamped onto behavior instances); plain entries run agent-blind; wrong-agent-type entries
+/// are rejected at wiring time; dispatch is pre-split at construction so the run loop is a
+/// branch plus a call.
+/// </summary>
+/// <typeparam name="TAgent">The agent type delivered to typed entries.</typeparam>
+public sealed class AsyncBehaviorState<TAgent> : AsyncState<TAgent>, IBehaviorComposite, IBehaviorReportSink
+{
+    private readonly IAsyncBehavior[] _behaviors;
+    private readonly IAsyncBehavior<TAgent>?[] _typed;
+    private CancellationToken _reportCt;
+
+    /// <param name="behaviors">The behaviors to run in order — plain and agent-typed entries
+    /// may mix. At least one is required; null entries are rejected, as is any
+    /// <see cref="IAsyncAgentBehavior"/> entry whose agent type is not <typeparamref name="TAgent"/>.</param>
+    public AsyncBehaviorState(params IAsyncBehavior[] behaviors)
+    {
+        _behaviors = BehaviorComposition.ValidateEntries(behaviors);
+        _typed = new IAsyncBehavior<TAgent>?[behaviors.Length];
+        for (int i = 0; i < behaviors.Length; i++)
+        {
+            if (behaviors[i] is not IAsyncAgentBehavior)
+            {
+                continue;
+            }
+
+            _typed[i] = behaviors[i] as IAsyncBehavior<TAgent> ?? throw BehaviorComposition.AgentTypeMismatch(
+                behaviors[i], i, typeof(TAgent), typeof(IAsyncBehavior<>));
+        }
+    }
+
+    /// <summary>The behavior entries in sequence order.</summary>
+    public IReadOnlyList<IAsyncBehavior> Behaviors => _behaviors;
+
+    protected override async ValueTask<Result> OnRunAsync(CancellationToken ct)
+    {
+        _reportCt = ct;
+        BehaviorContext ctx = new(Bb, this);
+        IAsyncBehavior[] behaviors = _behaviors;
+        IAsyncBehavior<TAgent>?[] typed = _typed;
+        for (int i = 0; i < behaviors.Length; i++)
+        {
+            Result result = typed[i] is { } agentBehavior
+                ? await agentBehavior.ExecuteAsync(Agent, ctx, ct).ConfigureAwait(false)
+                : await behaviors[i].ExecuteAsync(ctx, ct).ConfigureAwait(false);
+            if (result != Result.Success)
+            {
+                return Result.Failure;
+            }
+        }
+
+        return Result.Success;
+    }
+
+    bool IBehaviorComposite.IsSync => false;
+    Type? IBehaviorComposite.AgentType => typeof(TAgent);
+    IReadOnlyList<object> IBehaviorComposite.Entries => _behaviors;
+
+    bool IBehaviorReportSink.HasReporter => LogReport is not null;
+
+    void IBehaviorReportSink.Report(string message)
+    {
+        if (LogReport is { } report)
+        {
+            BehaviorComposition.Await(report(message, _reportCt));
+        }
+    }
+}

--- a/NxGraph/Behaviors/AsyncRepeat.cs
+++ b/NxGraph/Behaviors/AsyncRepeat.cs
@@ -1,0 +1,191 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Behaviors;
+
+/// <summary>
+/// Async twin of <see cref="Repeat"/>: runs an <see cref="IAsyncBehavior"/> body a
+/// <b>bounded, fixed</b> number of times inside a single node execution, async runtime only
+/// (a sync <c>Execute</c> cannot await a body entry — a sync <see cref="Repeat"/> authors
+/// either runtime). Same contract as the sync form: the count is resolved through the context
+/// <b>once at entry</b> (a literal negative count is rejected at construction; a key-bound
+/// count resolving to zero or less is vacuous <c>Success</c>), the optional 0-based index key
+/// is written before each iteration, iterations are fail-fast, the context passes through
+/// unchanged, and a node <c>.Retry(...)</c> re-runs <b>all</b> iterations — the idempotency
+/// note on <see cref="IAsyncBehavior"/> compounds with the trip count. Cancellation is
+/// observed between iterations, so a large key-bound count cannot pin a cancelled machine.
+/// Condition-driven loops belong in director nodes, where validators, Mermaid export, and
+/// snapshots can see them.
+/// </summary>
+public sealed class AsyncRepeat : IAsyncBehavior
+{
+    private readonly IAsyncBehavior[] _body;
+    private readonly BlackboardKey<int> _indexKey;
+    private readonly string? _indexKeyName;
+
+    /// <summary>Creates a repeat of <paramref name="body"/>, <paramref name="count"/> (literal or key-bound) times.</summary>
+    public AsyncRepeat(BlackboardValue<int> count, params IAsyncBehavior[] body)
+        : this(count, default, indexKeyName: null, body)
+    {
+    }
+
+    /// <summary>
+    /// Creates a repeat that writes the 0-based iteration to <paramref name="indexKey"/>
+    /// before each iteration. Any key scope binds — Node scratch is the natural home.
+    /// </summary>
+    public AsyncRepeat(BlackboardValue<int> count, BlackboardKey<int> indexKey, params IAsyncBehavior[] body)
+        : this(count, RepeatComposition.ValidateIndexKey(in indexKey), indexKey.Name, body)
+    {
+    }
+
+    private AsyncRepeat(BlackboardValue<int> count, BlackboardKey<int> indexKey, string? indexKeyName,
+        IAsyncBehavior[] body)
+    {
+        Count = RepeatComposition.ValidateCount(in count);
+        _indexKey = indexKey;
+        _indexKeyName = indexKeyName;
+        _body = BehaviorComposition.ValidateEntries(body);
+        for (int i = 0; i < body.Length; i++)
+        {
+            if (body[i] is IAsyncAgentBehavior)
+            {
+                throw BehaviorComposition.AgentEntryInUntyped(body[i], i, "AsyncRepeat<TAgent>");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a name-bound repeat — the deserialization rebind form (see
+    /// <see cref="Repeat.Unbound"/>); <see langword="null"/> means no index key.
+    /// </summary>
+    public static AsyncRepeat Unbound(BlackboardValue<int> count, string? indexKeyName,
+        params IAsyncBehavior[] body) =>
+        new(count, default, RepeatComposition.ValidateIndexKeyName(indexKeyName), body);
+
+    /// <summary>The trip-count binding — literal or key; resolved once at entry.</summary>
+    public BlackboardValue<int> Count { get; }
+
+    /// <summary>The index key's registered name, or <see langword="null"/> when no index key — the serialization identity.</summary>
+    public string? IndexKeyName => _indexKeyName;
+
+    /// <summary>The body entries, walked in order each iteration — inspectable, editor-facing.</summary>
+    public IReadOnlyList<IAsyncBehavior> Body => _body;
+
+    /// <inheritdoc />
+    public async ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct)
+    {
+        int count = ctx.Resolve(Count); // Resolved once at entry — the trip count is fixed.
+        IAsyncBehavior[] body = _body;
+        for (int iteration = 0; iteration < count; iteration++)
+        {
+            // Between iterations — a large key-bound count cannot pin a cancelled machine.
+            ct.ThrowIfCancellationRequested();
+            RepeatComposition.WriteIndex(ctx.Bb, _indexKey, _indexKeyName, iteration);
+            for (int i = 0; i < body.Length; i++)
+            {
+                Result result = await body[i].ExecuteAsync(ctx, ct).ConfigureAwait(false);
+                if (result != Result.Success)
+                {
+                    return Result.Failure;
+                }
+            }
+        }
+
+        return Result.Success;
+    }
+}
+
+/// <summary>
+/// Agent-typed twin of <see cref="AsyncRepeat"/> — see <see cref="Repeat{TAgent}"/> for the
+/// full agent contract: a mixed body (plain and agent-typed async entries), typed dispatch
+/// pre-split at construction, the agent received per execution passed to typed body entries
+/// per iteration as a call parameter (never stamped), plain entries agent-blind, wrong-agent
+/// entries rejected at wiring time naming both types. Count resolved once at entry (literal
+/// negative rejected, key-bound ≤ 0 vacuous), fail-fast iterations, compounded retry
+/// idempotency, cancellation observed between iterations.
+/// </summary>
+/// <typeparam name="TAgent">The agent type delivered to typed body entries.</typeparam>
+public sealed class AsyncRepeat<TAgent> : IAsyncBehavior<TAgent>
+{
+    private readonly IAsyncBehavior[] _body;
+    private readonly IAsyncBehavior<TAgent>?[] _typed;
+    private readonly BlackboardKey<int> _indexKey;
+    private readonly string? _indexKeyName;
+
+    /// <summary>Creates a repeat of <paramref name="body"/>, <paramref name="count"/> (literal or key-bound) times.</summary>
+    public AsyncRepeat(BlackboardValue<int> count, params IAsyncBehavior[] body)
+        : this(count, default, indexKeyName: null, body)
+    {
+    }
+
+    /// <summary>
+    /// Creates a repeat that writes the 0-based iteration to <paramref name="indexKey"/>
+    /// before each iteration. Any key scope binds — Node scratch is the natural home.
+    /// </summary>
+    public AsyncRepeat(BlackboardValue<int> count, BlackboardKey<int> indexKey, params IAsyncBehavior[] body)
+        : this(count, RepeatComposition.ValidateIndexKey(in indexKey), indexKey.Name, body)
+    {
+    }
+
+    private AsyncRepeat(BlackboardValue<int> count, BlackboardKey<int> indexKey, string? indexKeyName,
+        IAsyncBehavior[] body)
+    {
+        Count = RepeatComposition.ValidateCount(in count);
+        _indexKey = indexKey;
+        _indexKeyName = indexKeyName;
+        _body = BehaviorComposition.ValidateEntries(body);
+        _typed = new IAsyncBehavior<TAgent>?[body.Length];
+        for (int i = 0; i < body.Length; i++)
+        {
+            if (body[i] is not IAsyncAgentBehavior)
+            {
+                continue;
+            }
+
+            _typed[i] = body[i] as IAsyncBehavior<TAgent> ?? throw BehaviorComposition.AgentTypeMismatch(
+                body[i], i, typeof(TAgent), typeof(IAsyncBehavior<>));
+        }
+    }
+
+    /// <summary>
+    /// Creates a name-bound repeat — the deserialization rebind form (see
+    /// <see cref="Repeat.Unbound"/>); <see langword="null"/> means no index key.
+    /// </summary>
+    public static AsyncRepeat<TAgent> Unbound(BlackboardValue<int> count, string? indexKeyName,
+        params IAsyncBehavior[] body) =>
+        new(count, default, RepeatComposition.ValidateIndexKeyName(indexKeyName), body);
+
+    /// <summary>The trip-count binding — literal or key; resolved once at entry.</summary>
+    public BlackboardValue<int> Count { get; }
+
+    /// <summary>The index key's registered name, or <see langword="null"/> when no index key — the serialization identity.</summary>
+    public string? IndexKeyName => _indexKeyName;
+
+    /// <summary>The body entries, walked in order each iteration — inspectable, editor-facing.</summary>
+    public IReadOnlyList<IAsyncBehavior> Body => _body;
+
+    /// <inheritdoc />
+    public async ValueTask<Result> ExecuteAsync(TAgent agent, BehaviorContext ctx, CancellationToken ct)
+    {
+        int count = ctx.Resolve(Count); // Resolved once at entry — the trip count is fixed.
+        IAsyncBehavior[] body = _body;
+        IAsyncBehavior<TAgent>?[] typed = _typed;
+        for (int iteration = 0; iteration < count; iteration++)
+        {
+            // Between iterations — a large key-bound count cannot pin a cancelled machine.
+            ct.ThrowIfCancellationRequested();
+            RepeatComposition.WriteIndex(ctx.Bb, _indexKey, _indexKeyName, iteration);
+            for (int i = 0; i < body.Length; i++)
+            {
+                Result result = typed[i] is { } agentBehavior
+                    ? await agentBehavior.ExecuteAsync(agent, ctx, ct).ConfigureAwait(false)
+                    : await body[i].ExecuteAsync(ctx, ct).ConfigureAwait(false);
+                if (result != Result.Success)
+                {
+                    return Result.Failure;
+                }
+            }
+        }
+
+        return Result.Success;
+    }
+}

--- a/NxGraph/Behaviors/BehaviorContext.cs
+++ b/NxGraph/Behaviors/BehaviorContext.cs
@@ -1,0 +1,61 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Behaviors;
+
+/// <summary>
+/// The execution context a behavior composite hands to each of its entries: the machine-bound
+/// routed <see cref="BlackboardContext"/>, typed binding resolution, and the owning node's
+/// report channel. A default-constructed context is valid but inert — blackboard access
+/// throws the usual unbound-scope errors and <see cref="Report"/> is a no-op.
+/// </summary>
+public readonly struct BehaviorContext
+{
+    private readonly BlackboardContext _bb;
+    private readonly IBehaviorReportSink? _sink;
+
+    internal BehaviorContext(in BlackboardContext bb, IBehaviorReportSink? sink)
+    {
+        _bb = bb;
+        _sink = sink;
+    }
+
+    /// <summary>The machine-bound routed blackboard context (see <see cref="BlackboardContext"/>).</summary>
+    public BlackboardContext Bb => _bb;
+
+    /// <summary>
+    /// <see langword="true"/> when the owning composite's report channel is wired to an
+    /// observer. Behaviors that build report strings should check this first so observer-less
+    /// machines pay nothing (the library <see cref="Log"/> behavior does).
+    /// </summary>
+    public bool HasReporter => _sink is not null && _sink.HasReporter;
+
+    /// <summary>
+    /// Resolves a <see cref="BlackboardValue{T}"/>: the literal as-is, or a typed
+    /// <see cref="BlackboardContext.Get{T}"/> through the bound key. Zero boxing, zero
+    /// allocation.
+    /// </summary>
+    public T Resolve<T>(in BlackboardValue<T> value) => value.Resolve(in _bb);
+
+    /// <summary>
+    /// Emits a message on the owning node's report channel — routed to the machine observer's
+    /// <c>OnLogReport</c>, exactly like <c>State.Log</c>. Where the message lands is the
+    /// observer's decision (the library imposes no I/O policy); a no-op when unwired.
+    /// </summary>
+    public void Report(string message)
+    {
+        _sink?.Report(message);
+    }
+}
+
+/// <summary>
+/// Internal bridge between <see cref="BehaviorContext.Report"/> and the owning composite's
+/// machine-wired log-report callback. Implemented by the four behavior composites.
+/// </summary>
+internal interface IBehaviorReportSink
+{
+    /// <summary><see langword="true"/> when a log-report callback is currently wired.</summary>
+    bool HasReporter { get; }
+
+    /// <summary>Delivers one report message through the wired callback.</summary>
+    void Report(string message);
+}

--- a/NxGraph/Behaviors/BehaviorState.cs
+++ b/NxGraph/Behaviors/BehaviorState.cs
@@ -1,0 +1,221 @@
+using NxGraph.Diagnostics.Replay;
+using NxGraph.Fsm;
+
+namespace NxGraph.Behaviors;
+
+/// <summary>
+/// Runs a declarative sequence of <see cref="IBehavior"/> entries inside one node — in order,
+/// <b>fail-fast</b>: the first non-<c>Success</c> entry stops the sequence and the node
+/// returns <c>Failure</c>. Fail-fast is the deliberate opposite of <c>AllState</c>'s
+/// run-all-then-combine: sequence entries may depend on earlier entries' writes, while
+/// <c>AllState</c>'s works are concurrent and independent.
+/// <para>
+/// Everything above the node is untouched: <c>.Retry(...)</c> re-runs the <b>whole</b> list
+/// in place (behaviors should be idempotent or tolerate re-execution), <c>.OnError(...)</c>
+/// reroutes, <c>.WithOutcome(...)</c> codes, and exceptions propagate as from any node logic.
+/// Behavior output goes through the report channel (<see cref="BehaviorContext.Report"/> →
+/// observer <c>OnLogReport</c>), never the console. The run loop is an array walk over one
+/// stack-allocated context — 0 B. Agent-typed entries (<see cref="IAgentBehavior"/>) are
+/// rejected at wiring time — use <see cref="BehaviorState{TAgent}"/> /
+/// <c>ToBehaviors&lt;TAgent&gt;</c>. Being a <see cref="State"/>, this node also runs under
+/// the async machine via the sync-logic adapter.
+/// </para>
+/// </summary>
+public sealed class BehaviorState : State, IBehaviorComposite, IBehaviorReportSink
+{
+    private readonly IBehavior[] _behaviors;
+
+    /// <param name="behaviors">The behaviors to run in order. At least one is required;
+    /// null entries and agent-typed (<see cref="IAgentBehavior"/>) entries are rejected.</param>
+    public BehaviorState(params IBehavior[] behaviors)
+    {
+        _behaviors = BehaviorComposition.ValidateEntries(behaviors);
+        for (int i = 0; i < behaviors.Length; i++)
+        {
+            if (behaviors[i] is IAgentBehavior)
+            {
+                throw BehaviorComposition.AgentEntryInUntyped(behaviors[i], i, "ToBehaviors<TAgent>");
+            }
+        }
+    }
+
+    /// <summary>The behavior entries in sequence order.</summary>
+    public IReadOnlyList<IBehavior> Behaviors => _behaviors;
+
+    protected override Result OnRun()
+    {
+        BehaviorContext ctx = new(Bb, this);
+        IBehavior[] behaviors = _behaviors;
+        for (int i = 0; i < behaviors.Length; i++)
+        {
+            if (behaviors[i].Execute(in ctx) != Result.Success)
+            {
+                return Result.Failure;
+            }
+        }
+
+        return Result.Success;
+    }
+
+    bool IBehaviorComposite.IsSync => true;
+    Type? IBehaviorComposite.AgentType => null;
+    IReadOnlyList<object> IBehaviorComposite.Entries => _behaviors;
+
+    bool IBehaviorReportSink.HasReporter => BehaviorComposition.SyncHasReporter(this);
+    void IBehaviorReportSink.Report(string message) => BehaviorComposition.SyncReport(this, message);
+}
+
+/// <summary>
+/// Agent-typed twin of <see cref="BehaviorState"/>: receives the machine-bound agent through
+/// the standard <c>IAgentSettable</c> stamping walk (so <c>Graph.SetAgent</c> acceptor
+/// counting and the shared-graph contract apply unchanged) and passes it to
+/// <see cref="IBehavior{TAgent}"/> entries <b>as a call parameter per execution</b> — the
+/// agent is never stamped onto behavior instances, which stay shareable data objects. Plain
+/// <see cref="IBehavior"/> entries run agent-blind in the same sequence; an
+/// <see cref="IAgentBehavior"/> entry of a different agent type is rejected at wiring time.
+/// Dispatch is pre-split at construction, so the run loop stays a branch plus a call — 0 B.
+/// Sequence semantics are identical to the untyped composite (in order, fail-fast).
+/// </summary>
+/// <typeparam name="TAgent">The agent type delivered to typed entries.</typeparam>
+public sealed class BehaviorState<TAgent> : State<TAgent>, IBehaviorComposite, IBehaviorReportSink
+{
+    private readonly IBehavior[] _behaviors;
+    private readonly IBehavior<TAgent>?[] _typed;
+
+    /// <param name="behaviors">The behaviors to run in order — plain and agent-typed entries
+    /// may mix. At least one is required; null entries are rejected, as is any
+    /// <see cref="IAgentBehavior"/> entry whose agent type is not <typeparamref name="TAgent"/>.</param>
+    public BehaviorState(params IBehavior[] behaviors)
+    {
+        _behaviors = BehaviorComposition.ValidateEntries(behaviors);
+        _typed = new IBehavior<TAgent>?[behaviors.Length];
+        for (int i = 0; i < behaviors.Length; i++)
+        {
+            if (behaviors[i] is not IAgentBehavior)
+            {
+                continue;
+            }
+
+            _typed[i] = behaviors[i] as IBehavior<TAgent> ?? throw BehaviorComposition.AgentTypeMismatch(
+                behaviors[i], i, typeof(TAgent), typeof(IBehavior<>));
+        }
+    }
+
+    /// <summary>The behavior entries in sequence order.</summary>
+    public IReadOnlyList<IBehavior> Behaviors => _behaviors;
+
+    protected override Result OnRun()
+    {
+        BehaviorContext ctx = new(Bb, this);
+        IBehavior[] behaviors = _behaviors;
+        IBehavior<TAgent>?[] typed = _typed;
+        for (int i = 0; i < behaviors.Length; i++)
+        {
+            Result result = typed[i] is { } agentBehavior
+                ? agentBehavior.Execute(Agent, in ctx)
+                : behaviors[i].Execute(in ctx);
+            if (result != Result.Success)
+            {
+                return Result.Failure;
+            }
+        }
+
+        return Result.Success;
+    }
+
+    bool IBehaviorComposite.IsSync => true;
+    Type? IBehaviorComposite.AgentType => typeof(TAgent);
+    IReadOnlyList<object> IBehaviorComposite.Entries => _behaviors;
+
+    bool IBehaviorReportSink.HasReporter => BehaviorComposition.SyncHasReporter(this);
+    void IBehaviorReportSink.Report(string message) => BehaviorComposition.SyncReport(this, message);
+}
+
+/// <summary>
+/// Shared wiring-time validation and report-channel plumbing for the four behavior
+/// composites.
+/// </summary>
+internal static class BehaviorComposition
+{
+    internal const string ParamName = "behaviors";
+
+    internal static TEntry[] ValidateEntries<TEntry>(TEntry[] behaviors) where TEntry : class
+    {
+        if (behaviors is null || behaviors.Length == 0)
+        {
+            throw new ArgumentException("At least one behavior is required.", ParamName);
+        }
+
+        foreach (TEntry? behavior in behaviors)
+        {
+            if (behavior is null)
+            {
+                throw new ArgumentException("Behaviors must not contain null entries.", ParamName);
+            }
+        }
+
+        return behaviors;
+    }
+
+    internal static ArgumentException AgentEntryInUntyped(object entry, int index, string typedDsl)
+    {
+        return new ArgumentException(
+            $"Behavior at index {index} ('{entry.GetType().Name}') is agent-typed and cannot run in an " +
+            $"untyped composite — use {typedDsl}(...) so the machine-bound agent reaches it.", ParamName);
+    }
+
+    internal static ArgumentException AgentTypeMismatch(object entry, int index, Type compositeAgent,
+        Type openInterface)
+    {
+        // Cold throw path: reflection is only used to name the entry's agent type in the
+        // message — the check itself is the marker-interface pattern match above.
+        Type? entryAgent = null;
+        foreach (Type implemented in entry.GetType().GetInterfaces())
+        {
+            if (implemented.IsGenericType && implemented.GetGenericTypeDefinition() == openInterface)
+            {
+                entryAgent = implemented.GetGenericArguments()[0];
+                break;
+            }
+        }
+
+        return new ArgumentException(
+            $"Behavior at index {index} ('{entry.GetType().Name}') expects agent type " +
+            $"'{entryAgent?.Name ?? "<unknown>"}' but this composite binds agent type " +
+            $"'{compositeAgent.Name}'.", ParamName);
+    }
+
+    internal static bool SyncHasReporter(State state) =>
+        state.SyncLogReport is not null || ((ILogReporter)state).LogReport is not null;
+
+    /// <summary>
+    /// Delivers a report from a sync composite: through the sync callback when the sync
+    /// machine wired it, else through the async callback (the async machine wires that slot
+    /// when the composite runs behind the sync-logic adapter), waiting out a genuinely
+    /// asynchronous observer so delivery-before-return holds on both runtimes.
+    /// </summary>
+    internal static void SyncReport(State state, string message)
+    {
+        if (state.SyncLogReport is { } sync)
+        {
+            sync(message);
+            return;
+        }
+
+        if (((ILogReporter)state).LogReport is { } asyncReport)
+        {
+            Await(asyncReport(message, CancellationToken.None));
+        }
+    }
+
+    internal static void Await(ValueTask task)
+    {
+        if (task.IsCompletedSuccessfully)
+        {
+            task.GetAwaiter().GetResult();
+            return;
+        }
+
+        task.AsTask().GetAwaiter().GetResult();
+    }
+}

--- a/NxGraph/Behaviors/BlackboardValue.cs
+++ b/NxGraph/Behaviors/BlackboardValue.cs
@@ -1,0 +1,164 @@
+using System.Runtime.CompilerServices;
+using NxGraph.Blackboards;
+
+namespace NxGraph.Behaviors;
+
+/// <summary>
+/// The one binding primitive of the behavior model: a field that is either a <b>literal</b>
+/// value or a <b>key binding</b> resolved against the machine-bound blackboards per
+/// execution. Both forms convert implicitly, so behavior fields read naturally:
+/// <c>new Log(LogSeverity.Info, greetingKey)</c>. A <c>default</c> value is a literal
+/// <c>default(T)</c>.
+/// <para>
+/// Any key scope binds — Node scratch included: behavior bindings resolve <b>within one
+/// visit</b>, so the ports rule (spec 010) that rejects Node-scoped keys deliberately does
+/// not apply here. Resolution is a branch plus a typed <c>Get</c> — zero boxing, zero
+/// allocation. Deserialized bindings hold only the key <b>name</b>
+/// (<see cref="Bound(string)"/>) and resolve it against the bound boards' schemas
+/// (Graph, then Global, then Node) at execution, with targeted miss/type-mismatch errors.
+/// </para>
+/// </summary>
+public readonly struct BlackboardValue<T>
+{
+    private readonly T _literal;
+    private readonly BlackboardKey<T> _key;
+    private readonly string? _keyName;
+
+    private BlackboardValue(T literal)
+    {
+        _literal = literal;
+        _key = default;
+        _keyName = null;
+    }
+
+    private BlackboardValue(in BlackboardKey<T> key)
+    {
+        _literal = default!;
+        _key = key;
+        _keyName = key.Name;
+    }
+
+    private BlackboardValue(string keyName)
+    {
+        _literal = default!;
+        _key = default;
+        _keyName = keyName;
+    }
+
+    /// <summary>Wraps a literal value.</summary>
+    public static implicit operator BlackboardValue<T>(T literal) => new(literal);
+
+    /// <summary>
+    /// Binds to a blackboard key; resolution reads the key per execution. Invalid
+    /// (default-constructed) keys are rejected at wiring time.
+    /// </summary>
+    public static implicit operator BlackboardValue<T>(BlackboardKey<T> key)
+    {
+        if (!key.IsValid)
+        {
+            ThrowInvalidKey();
+        }
+
+        return new BlackboardValue<T>(in key);
+    }
+
+    /// <summary>
+    /// Creates a name-bound binding — the deserialization rebind form. The name resolves per
+    /// execution against the machine's bound boards' schemas (Graph, then Global, then Node)
+    /// via <see cref="BlackboardSchema.TryResolve{T}"/>, throwing targeted errors when the
+    /// name is missing or declared with a different value type.
+    /// </summary>
+    public static BlackboardValue<T> Bound(string keyName)
+    {
+        if (string.IsNullOrEmpty(keyName))
+        {
+            throw new ArgumentException("Binding key name cannot be null or empty.", nameof(keyName));
+        }
+
+        return new BlackboardValue<T>(keyName);
+    }
+
+    /// <summary><see langword="true"/> when key-backed (live key or name-bound); <see langword="false"/> for a literal.</summary>
+    public bool IsBound => _keyName is not null;
+
+    /// <summary>The bound key's name, or <see langword="null"/> for a literal — the serialization identity of the key form.</summary>
+    public string? KeyName => _keyName;
+
+    /// <summary>The literal value; meaningful only when <see cref="IsBound"/> is <see langword="false"/>.</summary>
+    public T Literal => _literal;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal T Resolve(in BlackboardContext bb)
+    {
+        if (_keyName is null)
+        {
+            return _literal;
+        }
+
+        return _key.IsValid ? bb.Get(_key) : bb.Get(BehaviorKeyResolver.Resolve<T>(in bb, _keyName));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowInvalidKey() =>
+        throw new ArgumentException(
+            "Invalid blackboard key — obtain keys via BlackboardSchema.Register<T>(...).");
+
+    /// <summary>Diagnostics only — the key name or the literal.</summary>
+    public override string ToString() =>
+        _keyName is not null ? $"@{_keyName}" : _literal?.ToString() ?? "<null>";
+}
+
+/// <summary>
+/// Resolves name-bound behavior keys (deserialized bindings and <see cref="SetValue{T}"/>
+/// targets) against the machine's bound boards, probing schemas in Graph → Global → Node
+/// order. Cold-ish path (one dictionary lookup per execution, zero allocation); failures are
+/// targeted <c>NoInlining</c> throws in the event-entry rebind style.
+/// </summary>
+internal static class BehaviorKeyResolver
+{
+    internal static BlackboardKey<T> Resolve<T>(in BlackboardContext bb, string name)
+    {
+        if (bb.Graph is { } graph && graph.Schema.TryResolve(name, out BlackboardKey<T> key))
+        {
+            return key;
+        }
+
+        if (bb.Global is { } global && global.Schema.TryResolve(name, out key))
+        {
+            return key;
+        }
+
+        if (bb.Node is { } node && node.Schema.TryResolve(name, out key))
+        {
+            return key;
+        }
+
+        return ThrowUnresolved<T>(bb, name);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static BlackboardKey<T> ThrowUnresolved<T>(in BlackboardContext bb, string name)
+    {
+        // A same-name declaration with a different value type gets the precise mismatch
+        // message; otherwise the name is simply absent from every bound schema.
+        ReportMismatch<T>(bb.Graph, name, "Graph");
+        ReportMismatch<T>(bb.Global, name, "Global");
+        ReportMismatch<T>(bb.Node, name, "Node");
+
+        throw new InvalidOperationException(
+            $"Behavior binding key '{name}' does not exist on any bound blackboard schema (checked Graph, " +
+            "Global, and Node scopes) — a deserialized behavior resolves its keys by name against the " +
+            "machine's bound boards.");
+    }
+
+    private static void ReportMismatch<T>(Blackboard? board, string name, string scopeWord)
+    {
+        if (board is not null && board.Schema.TryGetKey(name, out BlackboardKeyDescriptor descriptor))
+        {
+            throw new InvalidOperationException(
+                $"Behavior binding key '{name}' is declared as '{descriptor.ValueType}' on the bound " +
+                $"{scopeWord} schema '{board.Schema.Name ?? "<unnamed>"}' but the behavior expects " +
+                $"'{typeof(T)}'.");
+        }
+    }
+}

--- a/NxGraph/Behaviors/IBehavior.cs
+++ b/NxGraph/Behaviors/IBehavior.cs
@@ -1,0 +1,101 @@
+namespace NxGraph.Behaviors;
+
+/// <summary>
+/// One entry of a behavior composite (<see cref="BehaviorState"/>): a small, reusable,
+/// data-shaped unit of node logic. Behaviors are <b>sub-node</b> logic — the node keeps the
+/// whole fault model (retry, failure edge, outcome codes), and a behavior failure is a plain
+/// node <c>Failure</c>. Fields should be literals or <see cref="BlackboardValue{T}"/>
+/// bindings so instances stay inspectable, rebindable, and (via the serialization packages)
+/// wire-able without user codecs.
+/// <para>
+/// Behaviors should be idempotent or tolerate re-execution: a per-node <c>.Retry(...)</c>
+/// re-runs the composite's <b>whole</b> sequence in place. Output belongs on the report
+/// channel (<see cref="BehaviorContext.Report"/>) or the blackboard — never the console.
+/// </para>
+/// </summary>
+public interface IBehavior
+{
+    /// <summary>Executes the behavior against the owning composite's context.</summary>
+    Result Execute(in BehaviorContext ctx);
+}
+
+/// <summary>
+/// Async twin of <see cref="IBehavior"/> — one entry of an
+/// <see cref="AsyncBehaviorState"/> sequence. Same contract: sub-node logic under the node's
+/// fault model, idempotent under retry, report channel instead of console.
+/// </summary>
+public interface IAsyncBehavior
+{
+    /// <summary>Executes the behavior against the owning composite's context.</summary>
+    ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct);
+}
+
+/// <summary>
+/// Marker for agent-typed sync behaviors: an entry implementing this interface requires an
+/// agent-typed composite (<see cref="BehaviorState{TAgent}"/> /
+/// <c>ToBehaviors&lt;TAgent&gt;</c>) — the untyped composites reject it at wiring time.
+/// Behaviors are never <c>IAgentSettable</c> themselves: the agent is a call parameter,
+/// passed per execution by the composite, so behavior instances stay shareable data objects
+/// with no mutable runtime state.
+/// </summary>
+public interface IAgentBehavior : IBehavior;
+
+/// <summary>
+/// Agent-typed sync behavior: receives the machine-bound agent as a call parameter per
+/// execution, mirroring the <c>State&lt;TAgent&gt;</c> channel. The inherited untyped
+/// <see cref="IBehavior.Execute"/> is sealed off with a throwing default implementation —
+/// a typed behavior only runs inside an agent-typed composite.
+/// </summary>
+/// <typeparam name="TAgent">The agent type the behavior acts on.</typeparam>
+public interface IBehavior<in TAgent> : IAgentBehavior
+{
+    /// <summary>Executes the behavior with the machine-bound agent.</summary>
+    Result Execute(TAgent agent, in BehaviorContext ctx);
+
+    Result IBehavior.Execute(in BehaviorContext ctx) =>
+        throw new NotSupportedException(
+            $"'{GetType().Name}' is an agent-typed behavior (IBehavior<{typeof(TAgent).Name}>) — run it inside " +
+            "an agent-typed composite (ToBehaviors<TAgent>(...) / BehaviorState<TAgent>), which passes the " +
+            "machine-bound agent per execution.");
+}
+
+/// <summary>
+/// Marker for agent-typed async behaviors — the async twin of <see cref="IAgentBehavior"/>.
+/// </summary>
+public interface IAsyncAgentBehavior : IAsyncBehavior;
+
+/// <summary>
+/// Agent-typed async behavior — the async twin of <see cref="IBehavior{TAgent}"/>. The
+/// inherited untyped <see cref="IAsyncBehavior.ExecuteAsync"/> is sealed off with a throwing
+/// default implementation.
+/// </summary>
+/// <typeparam name="TAgent">The agent type the behavior acts on.</typeparam>
+public interface IAsyncBehavior<in TAgent> : IAsyncAgentBehavior
+{
+    /// <summary>Executes the behavior with the machine-bound agent.</summary>
+    ValueTask<Result> ExecuteAsync(TAgent agent, BehaviorContext ctx, CancellationToken ct);
+
+    ValueTask<Result> IAsyncBehavior.ExecuteAsync(BehaviorContext ctx, CancellationToken ct) =>
+        throw new NotSupportedException(
+            $"'{GetType().Name}' is an agent-typed behavior (IAsyncBehavior<{typeof(TAgent).Name}>) — run it " +
+            "inside an agent-typed composite (ToBehaviorsAsync<TAgent>(...) / AsyncBehaviorState<TAgent>), " +
+            "which passes the machine-bound agent per execution.");
+}
+
+/// <summary>
+/// Non-generic serialization surface implemented by all four behavior composites
+/// (<see cref="BehaviorState"/>/<see cref="BehaviorState{TAgent}"/> and the async twins), so
+/// the graph serializer can detect a behavior node and enumerate its entries without knowing
+/// the closed agent type. Never consulted by any runtime.
+/// </summary>
+public interface IBehaviorComposite
+{
+    /// <summary><see langword="true"/> for the sync composites (wire marker "BehaviorState").</summary>
+    bool IsSync { get; }
+
+    /// <summary>The closed agent type of a typed composite, or <see langword="null"/> when untyped.</summary>
+    Type? AgentType { get; }
+
+    /// <summary>The behavior entries in sequence order (each an <see cref="IBehavior"/> or <see cref="IAsyncBehavior"/>).</summary>
+    IReadOnlyList<object> Entries { get; }
+}

--- a/NxGraph/Behaviors/Log.cs
+++ b/NxGraph/Behaviors/Log.cs
@@ -1,0 +1,70 @@
+namespace NxGraph.Behaviors;
+
+/// <summary>
+/// Standard behavior: emits <c>"[{severity}] {message}"</c> through the owning node's report
+/// channel (<see cref="BehaviorContext.Report"/> → observer <c>OnLogReport</c>). The report
+/// channel — never the console — is the sanctioned output: where the message lands is the
+/// observer's decision, and baking console I/O into core would be an imposed policy.
+/// <para>
+/// Both fields are <see cref="BlackboardValue{T}"/> bindings, so severity and message may be
+/// literals or blackboard keys. The string is formatted <b>only when a reporter is wired</b>
+/// — observer-less machines build no string and pay nothing. One class implements both
+/// behavior interfaces (the <c>ForkState</c> dual-interface shape), so a single instance
+/// authors either runtime.
+/// </para>
+/// </summary>
+public sealed class Log : IBehavior, IAsyncBehavior
+{
+    /// <summary>Creates a log entry with <see cref="LogSeverity.Info"/> severity.</summary>
+    public Log(BlackboardValue<string> message)
+        : this(LogSeverity.Info, message)
+    {
+    }
+
+    /// <summary>Creates a log entry with an explicit (literal or key-bound) severity.</summary>
+    public Log(BlackboardValue<LogSeverity> severity, BlackboardValue<string> message)
+    {
+        Severity = severity;
+        Message = message;
+    }
+
+    /// <summary>The severity binding — literal or key.</summary>
+    public BlackboardValue<LogSeverity> Severity { get; }
+
+    /// <summary>The message binding — literal or key.</summary>
+    public BlackboardValue<string> Message { get; }
+
+    /// <inheritdoc />
+    public Result Execute(in BehaviorContext ctx)
+    {
+        Emit(in ctx);
+        return Result.Success;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct)
+    {
+        Emit(in ctx);
+        return ResultHelpers.Success;
+    }
+
+    private void Emit(in BehaviorContext ctx)
+    {
+        if (!ctx.HasReporter)
+        {
+            return; // No observer, no string — the hot path stays allocation-free.
+        }
+
+        LogSeverity severity = ctx.Resolve(Severity);
+        string message = ctx.Resolve(Message);
+        ctx.Report($"[{SeverityName(severity)}] {message}");
+    }
+
+    private static string SeverityName(LogSeverity severity) => severity switch
+    {
+        LogSeverity.Trace => "Trace",
+        LogSeverity.Warning => "Warning",
+        LogSeverity.Error => "Error",
+        _ => "Info",
+    };
+}

--- a/NxGraph/Behaviors/LogSeverity.cs
+++ b/NxGraph/Behaviors/LogSeverity.cs
@@ -1,0 +1,20 @@
+namespace NxGraph.Behaviors;
+
+/// <summary>
+/// Severity of a <see cref="Log"/> behavior's report message. The <see cref="Log"/> behavior
+/// defaults to <see cref="Info"/> when no severity is given.
+/// </summary>
+public enum LogSeverity : byte
+{
+    /// <summary>Fine-grained diagnostic detail.</summary>
+    Trace = 0,
+
+    /// <summary>Ordinary informational message — the <see cref="Log"/> behavior's default.</summary>
+    Info = 1,
+
+    /// <summary>Something unexpected but recoverable.</summary>
+    Warning = 2,
+
+    /// <summary>A genuine error condition.</summary>
+    Error = 3,
+}

--- a/NxGraph/Behaviors/Repeat.cs
+++ b/NxGraph/Behaviors/Repeat.cs
@@ -1,0 +1,310 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Behaviors;
+
+/// <summary>
+/// Standard composite behavior: runs an inner behavior list a <b>bounded, fixed</b> number of
+/// times inside a single node execution — the one control-flow behavior, a leaf-level For.
+/// The trip count is a <see cref="BlackboardValue{T}"/> resolved through the context
+/// <b>once at entry</b>, fixing the iteration count for that execution — the body cannot
+/// extend its own loop by writing the bound key mid-run. A <b>literal</b> negative count is
+/// rejected at construction (an authoring error, caught at wiring time); a <b>key-bound</b>
+/// count resolving to zero or less runs nothing and returns <c>Success</c> (vacuous — runtime
+/// data must not throw). Anything condition-driven (<c>While</c>, guards, branches) belongs
+/// in director nodes, where validators, Mermaid export, and snapshots can see it.
+/// <para>
+/// Each iteration writes the optional 0-based index key (any scope binds; Node scratch is the
+/// natural home) and walks the body in order, fail-fast: the first non-<c>Success</c> entry
+/// stops the body <b>and</b> the remaining iterations, and the behavior returns
+/// <c>Failure</c>. The composite's context passes through unchanged, so nested
+/// <see cref="BehaviorContext.Report"/> calls route to the owning node's report channel. The
+/// node keeps the whole fault model: <c>.Retry(...)</c> re-runs the node's whole entry list,
+/// meaning <b>all</b> iterations re-execute — the idempotency note on <see cref="IBehavior"/>
+/// compounds with the trip count. One class implements both behavior interfaces, so a single
+/// instance authors either runtime: the async path observes cancellation between iterations,
+/// while the sync path cannot (the sync runtime has no token — existing contract); the fixed
+/// entry-resolved trip count is the deliberate mitigation.
+/// </para>
+/// </summary>
+public sealed class Repeat : IBehavior, IAsyncBehavior
+{
+    private readonly IBehavior[] _body;
+    private readonly BlackboardKey<int> _indexKey;
+    private readonly string? _indexKeyName;
+
+    /// <summary>Creates a repeat of <paramref name="body"/>, <paramref name="count"/> (literal or key-bound) times.</summary>
+    public Repeat(BlackboardValue<int> count, params IBehavior[] body)
+        : this(count, default, indexKeyName: null, body)
+    {
+    }
+
+    /// <summary>
+    /// Creates a repeat that writes the 0-based iteration to <paramref name="indexKey"/>
+    /// before each iteration. Any key scope binds — Node scratch is the natural home, since
+    /// the index is meaningful within one visit only.
+    /// </summary>
+    public Repeat(BlackboardValue<int> count, BlackboardKey<int> indexKey, params IBehavior[] body)
+        : this(count, RepeatComposition.ValidateIndexKey(in indexKey), indexKey.Name, body)
+    {
+    }
+
+    private Repeat(BlackboardValue<int> count, BlackboardKey<int> indexKey, string? indexKeyName, IBehavior[] body)
+    {
+        Count = RepeatComposition.ValidateCount(in count);
+        _indexKey = indexKey;
+        _indexKeyName = indexKeyName;
+        _body = BehaviorComposition.ValidateEntries(body);
+        for (int i = 0; i < body.Length; i++)
+        {
+            if (body[i] is IAgentBehavior)
+            {
+                throw BehaviorComposition.AgentEntryInUntyped(body[i], i, "Repeat<TAgent>");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a name-bound repeat — the deserialization rebind form. The optional index key
+    /// resolves per execution against the machine's bound boards' schemas (Graph, then
+    /// Global, then Node), with targeted miss/type-mismatch errors — exactly
+    /// <see cref="SetValue{T}.Unbound"/>; <see langword="null"/> means no index key.
+    /// </summary>
+    public static Repeat Unbound(BlackboardValue<int> count, string? indexKeyName, params IBehavior[] body) =>
+        new(count, default, RepeatComposition.ValidateIndexKeyName(indexKeyName), body);
+
+    /// <summary>The trip-count binding — literal or key; resolved once at entry.</summary>
+    public BlackboardValue<int> Count { get; }
+
+    /// <summary>The index key's registered name, or <see langword="null"/> when no index key — the serialization identity.</summary>
+    public string? IndexKeyName => _indexKeyName;
+
+    /// <summary>The body entries, walked in order each iteration — inspectable, editor-facing.</summary>
+    public IReadOnlyList<IBehavior> Body => _body;
+
+    /// <inheritdoc />
+    public Result Execute(in BehaviorContext ctx)
+    {
+        int count = ctx.Resolve(Count); // Resolved once at entry — the trip count is fixed.
+        IBehavior[] body = _body;
+        for (int iteration = 0; iteration < count; iteration++)
+        {
+            RepeatComposition.WriteIndex(ctx.Bb, _indexKey, _indexKeyName, iteration);
+            for (int i = 0; i < body.Length; i++)
+            {
+                if (body[i].Execute(in ctx) != Result.Success)
+                {
+                    return Result.Failure;
+                }
+            }
+        }
+
+        return Result.Success;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct)
+    {
+        int count = ctx.Resolve(Count);
+        IBehavior[] body = _body;
+        for (int iteration = 0; iteration < count; iteration++)
+        {
+            // Between iterations — a large key-bound count cannot pin a cancelled machine.
+            ct.ThrowIfCancellationRequested();
+            RepeatComposition.WriteIndex(ctx.Bb, _indexKey, _indexKeyName, iteration);
+            for (int i = 0; i < body.Length; i++)
+            {
+                if (body[i].Execute(in ctx) != Result.Success)
+                {
+                    return ResultHelpers.Failure;
+                }
+            }
+        }
+
+        return ResultHelpers.Success;
+    }
+}
+
+/// <summary>
+/// Agent-typed twin of <see cref="Repeat"/>: takes a mixed body (plain and agent-typed sync
+/// entries), pre-splits typed dispatch at construction (the
+/// <see cref="BehaviorState{TAgent}"/> pattern), and passes the agent received per execution
+/// to typed body entries <b>per iteration</b> as a call parameter — never stamped, so
+/// instances stay shareable data objects. Plain entries run agent-blind in the same
+/// sequence; an <see cref="IAgentBehavior"/> entry of a different agent type is rejected at
+/// wiring time naming both types. All other semantics match the untyped form: the count is
+/// resolved <b>once at entry</b> (literal negative rejected at construction, key-bound ≤ 0
+/// vacuous <c>Success</c>), iterations are fail-fast, a node <c>.Retry(...)</c> re-runs all
+/// iterations, and only the async path observes cancellation between iterations —
+/// condition-driven loops belong in director nodes.
+/// </summary>
+/// <typeparam name="TAgent">The agent type delivered to typed body entries.</typeparam>
+public sealed class Repeat<TAgent> : IBehavior<TAgent>, IAsyncBehavior<TAgent>
+{
+    private readonly IBehavior[] _body;
+    private readonly IBehavior<TAgent>?[] _typed;
+    private readonly BlackboardKey<int> _indexKey;
+    private readonly string? _indexKeyName;
+
+    /// <summary>Creates a repeat of <paramref name="body"/>, <paramref name="count"/> (literal or key-bound) times.</summary>
+    public Repeat(BlackboardValue<int> count, params IBehavior[] body)
+        : this(count, default, indexKeyName: null, body)
+    {
+    }
+
+    /// <summary>
+    /// Creates a repeat that writes the 0-based iteration to <paramref name="indexKey"/>
+    /// before each iteration. Any key scope binds — Node scratch is the natural home.
+    /// </summary>
+    public Repeat(BlackboardValue<int> count, BlackboardKey<int> indexKey, params IBehavior[] body)
+        : this(count, RepeatComposition.ValidateIndexKey(in indexKey), indexKey.Name, body)
+    {
+    }
+
+    private Repeat(BlackboardValue<int> count, BlackboardKey<int> indexKey, string? indexKeyName, IBehavior[] body)
+    {
+        Count = RepeatComposition.ValidateCount(in count);
+        _indexKey = indexKey;
+        _indexKeyName = indexKeyName;
+        _body = BehaviorComposition.ValidateEntries(body);
+        _typed = new IBehavior<TAgent>?[body.Length];
+        for (int i = 0; i < body.Length; i++)
+        {
+            if (body[i] is not IAgentBehavior)
+            {
+                continue;
+            }
+
+            _typed[i] = body[i] as IBehavior<TAgent> ?? throw BehaviorComposition.AgentTypeMismatch(
+                body[i], i, typeof(TAgent), typeof(IBehavior<>));
+        }
+    }
+
+    /// <summary>
+    /// Creates a name-bound repeat — the deserialization rebind form (see
+    /// <see cref="Repeat.Unbound"/>); <see langword="null"/> means no index key.
+    /// </summary>
+    public static Repeat<TAgent> Unbound(BlackboardValue<int> count, string? indexKeyName,
+        params IBehavior[] body) =>
+        new(count, default, RepeatComposition.ValidateIndexKeyName(indexKeyName), body);
+
+    /// <summary>The trip-count binding — literal or key; resolved once at entry.</summary>
+    public BlackboardValue<int> Count { get; }
+
+    /// <summary>The index key's registered name, or <see langword="null"/> when no index key — the serialization identity.</summary>
+    public string? IndexKeyName => _indexKeyName;
+
+    /// <summary>The body entries, walked in order each iteration — inspectable, editor-facing.</summary>
+    public IReadOnlyList<IBehavior> Body => _body;
+
+    /// <inheritdoc />
+    public Result Execute(TAgent agent, in BehaviorContext ctx)
+    {
+        int count = ctx.Resolve(Count); // Resolved once at entry — the trip count is fixed.
+        IBehavior[] body = _body;
+        IBehavior<TAgent>?[] typed = _typed;
+        for (int iteration = 0; iteration < count; iteration++)
+        {
+            RepeatComposition.WriteIndex(ctx.Bb, _indexKey, _indexKeyName, iteration);
+            for (int i = 0; i < body.Length; i++)
+            {
+                Result result = typed[i] is { } agentBehavior
+                    ? agentBehavior.Execute(agent, in ctx)
+                    : body[i].Execute(in ctx);
+                if (result != Result.Success)
+                {
+                    return Result.Failure;
+                }
+            }
+        }
+
+        return Result.Success;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<Result> ExecuteAsync(TAgent agent, BehaviorContext ctx, CancellationToken ct)
+    {
+        int count = ctx.Resolve(Count);
+        IBehavior[] body = _body;
+        IBehavior<TAgent>?[] typed = _typed;
+        for (int iteration = 0; iteration < count; iteration++)
+        {
+            // Between iterations — a large key-bound count cannot pin a cancelled machine.
+            ct.ThrowIfCancellationRequested();
+            RepeatComposition.WriteIndex(ctx.Bb, _indexKey, _indexKeyName, iteration);
+            for (int i = 0; i < body.Length; i++)
+            {
+                Result result = typed[i] is { } agentBehavior
+                    ? agentBehavior.Execute(agent, in ctx)
+                    : body[i].Execute(in ctx);
+                if (result != Result.Success)
+                {
+                    return ResultHelpers.Failure;
+                }
+            }
+        }
+
+        return ResultHelpers.Success;
+    }
+}
+
+/// <summary>
+/// Shared count/index-key validation and the per-iteration index write for the four repeat
+/// forms.
+/// </summary>
+internal static class RepeatComposition
+{
+    internal static BlackboardValue<int> ValidateCount(in BlackboardValue<int> count)
+    {
+        if (!count.IsBound && count.Literal < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count), count.Literal,
+                "A literal repeat count cannot be negative — an authoring error, caught at wiring time. " +
+                "(A key-bound count resolving to zero or less runs nothing and succeeds.)");
+        }
+
+        return count;
+    }
+
+    internal static BlackboardKey<int> ValidateIndexKey(in BlackboardKey<int> indexKey)
+    {
+        if (!indexKey.IsValid)
+        {
+            throw new ArgumentException(
+                "Invalid blackboard key — obtain keys via BlackboardSchema.Register<T>(...).", nameof(indexKey));
+        }
+
+        return indexKey;
+    }
+
+    internal static string? ValidateIndexKeyName(string? indexKeyName)
+    {
+        if (indexKeyName is { Length: 0 })
+        {
+            throw new ArgumentException("Index key name cannot be empty.", nameof(indexKeyName));
+        }
+
+        return indexKeyName;
+    }
+
+    /// <summary>
+    /// Writes the 0-based iteration to the index key: the live key for authored instances,
+    /// the name resolved per execution for deserialized ones (the <see cref="SetValue{T}"/>
+    /// recipe); a no-op with no key — zero cost.
+    /// </summary>
+    internal static void WriteIndex(in BlackboardContext bb, in BlackboardKey<int> indexKey, string? indexKeyName,
+        int iteration)
+    {
+        if (indexKeyName is null)
+        {
+            return;
+        }
+
+        if (indexKey.IsValid)
+        {
+            bb.Set(indexKey, iteration);
+            return;
+        }
+
+        bb.Set(BehaviorKeyResolver.Resolve<int>(in bb, indexKeyName), iteration);
+    }
+}

--- a/NxGraph/Behaviors/SetValue.cs
+++ b/NxGraph/Behaviors/SetValue.cs
@@ -1,0 +1,94 @@
+using NxGraph.Blackboards;
+
+namespace NxGraph.Behaviors;
+
+/// <summary>
+/// Standard behavior: writes a resolved <see cref="BlackboardValue{T}"/> to a blackboard key
+/// — the typed copy/constant/key-to-key primitive (<c>SetValue(target, 42)</c>,
+/// <c>SetValue(target, sourceKey)</c>). Always succeeds; idempotent under retry by
+/// construction (re-running re-writes the same resolved value). One class implements both
+/// behavior interfaces, so a single instance authors either runtime.
+/// <para>
+/// Authored instances hold a live key; deserialized instances (<see cref="Unbound"/>) hold
+/// only the key <b>name</b> and resolve it per execution against the machine's bound boards'
+/// schemas — the same name-based rebind as key-form bindings.
+/// </para>
+/// </summary>
+/// <typeparam name="T">The slot's value type.</typeparam>
+public sealed class SetValue<T> : IBehavior, IAsyncBehavior
+{
+    private readonly BlackboardKey<T> _key;
+    private readonly string _keyName;
+
+    /// <summary>Creates a write of <paramref name="value"/> (literal or key-bound) to <paramref name="key"/>.</summary>
+    public SetValue(BlackboardKey<T> key, BlackboardValue<T> value)
+    {
+        if (!key.IsValid)
+        {
+            throw new ArgumentException(
+                "Invalid blackboard key — obtain keys via BlackboardSchema.Register<T>(...).", nameof(key));
+        }
+
+        _key = key;
+        _keyName = key.Name;
+        Value = value;
+    }
+
+    private SetValue(string keyName, BlackboardValue<T> value)
+    {
+        _key = default;
+        _keyName = keyName;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Creates a name-bound write — the deserialization rebind form. The target key resolves
+    /// per execution against the machine's bound boards' schemas (Graph, then Global, then
+    /// Node), with targeted miss/type-mismatch errors.
+    /// </summary>
+    public static SetValue<T> Unbound(string keyName, BlackboardValue<T> value)
+    {
+        if (string.IsNullOrEmpty(keyName))
+        {
+            throw new ArgumentException("Key name cannot be null or empty.", nameof(keyName));
+        }
+
+        return new SetValue<T>(keyName, value);
+    }
+
+    /// <summary>The live target key; default (invalid) for name-bound instances.</summary>
+    public BlackboardKey<T> Key => _key;
+
+    /// <summary>The target key's registered name — the serialization identity.</summary>
+    public string KeyName => _keyName;
+
+    /// <summary>The value binding — literal or key.</summary>
+    public BlackboardValue<T> Value { get; }
+
+    /// <inheritdoc />
+    public Result Execute(in BehaviorContext ctx)
+    {
+        Apply(in ctx);
+        return Result.Success;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<Result> ExecuteAsync(BehaviorContext ctx, CancellationToken ct)
+    {
+        Apply(in ctx);
+        return ResultHelpers.Success;
+    }
+
+    private void Apply(in BehaviorContext ctx)
+    {
+        T value = ctx.Resolve(Value);
+        BlackboardContext bb = ctx.Bb;
+        if (_key.IsValid)
+        {
+            bb.Set(_key, value);
+            return;
+        }
+
+        bb.Set(BehaviorKeyResolver.Resolve<T>(in bb, _keyName), value);
+    }
+}

--- a/NxGraph/Blackboards/BlackboardKeyDescriptor.cs
+++ b/NxGraph/Blackboards/BlackboardKeyDescriptor.cs
@@ -50,6 +50,9 @@ internal sealed class SlotDefinition<T> : BlackboardKeyDescriptor
         _defaultValue = defaultValue;
     }
 
+    /// <summary>The typed key this slot was registered under (schema rebinding lookups).</summary>
+    internal BlackboardKey<T> Key => _key;
+
     public override object? GetValue(Blackboard blackboard) => blackboard.Get(_key);
 
     public override void SetValue(Blackboard blackboard, object? value) => blackboard.Set(_key, (T)value!);

--- a/NxGraph/Blackboards/BlackboardSchema.cs
+++ b/NxGraph/Blackboards/BlackboardSchema.cs
@@ -86,6 +86,26 @@ public sealed class BlackboardSchema
         return key;
     }
 
+    /// <summary>
+    /// Resolves a registered key by name with an exact value-type check. Returns
+    /// <see langword="false"/> when the name is unknown or the slot's value type is not
+    /// <typeparamref name="T"/>. Rebinding lookup for name-only references — e.g. a
+    /// deserialized event entry resolving its delivery key against the machine's bound board.
+    /// </summary>
+    public bool TryResolve<T>(string name, out BlackboardKey<T> key)
+    {
+        Guard.NotNull(name, nameof(name));
+
+        if (_ordinalByName.TryGetValue(name, out int ordinal) && _descriptors[ordinal] is SlotDefinition<T> slot)
+        {
+            key = slot.Key;
+            return true;
+        }
+
+        key = default;
+        return false;
+    }
+
     /// <summary>Looks up a slot descriptor by registered name.</summary>
     public bool TryGetKey(string name, out BlackboardKeyDescriptor descriptor)
     {

--- a/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
+++ b/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
@@ -181,6 +181,32 @@ public sealed class MermaidGraphExporter : IGraphExporter
                 continue;
             }
 
+            // Event entries (spec 013) render as an event surface, not an anonymous switch:
+            // each entry edge carries the event type's short name, and the Otherwise edge is
+            // labeled "otherwise". Dashed like other director edges — the branch taken is a
+            // runtime (raise-time) decision.
+            if (EventEntryOf(dn) is { } eventEntry)
+            {
+                string entryVar = NodeVar(i);
+                foreach (EventRegistration registration in eventEntry.Registrations)
+                {
+                    int dstIdx = registration.Target.Index;
+                    if ((uint)dstIdx >= (uint)graph.NodeCount) continue;
+                    sb.Append("  ").Append(entryVar).Append(" -. ")
+                        .Append(EscapeLabel(registration.EventTypeShortName)).Append(" .-> ")
+                        .Append(NodeVar(dstIdx)).AppendLine();
+                }
+
+                int defaultIdx = eventEntry.DefaultTarget.Index;
+                if (!eventEntry.DefaultTarget.Equals(NodeId.Default) && (uint)defaultIdx < (uint)graph.NodeCount)
+                {
+                    sb.Append("  ").Append(entryVar).Append(" -. otherwise .-> ")
+                        .Append(NodeVar(defaultIdx)).AppendLine();
+                }
+
+                continue;
+            }
+
             IEnumerable<NodeId>? targets =
                 (dn.AsyncLogic as IDirector)?.EnumerateStaticTargets()
                 ?? (dn.Logic as IDirector)?.EnumerateStaticTargets()
@@ -211,6 +237,9 @@ public sealed class MermaidGraphExporter : IGraphExporter
 
     private static JoinState? JoinOf(LogicNode node) =>
         node.Logic as JoinState ?? node.AsyncLogic as JoinState;
+
+    private static EventEntryState? EventEntryOf(LogicNode node) =>
+        node.AsyncLogic as EventEntryState ?? node.Logic as EventEntryState;
 
     private static bool IsFork(Graph graph, int index) =>
         graph.GetNodeByIndex(index) is LogicNode ln && ForkOf(ln) is not null;

--- a/NxGraph/Diagnostics/Validations/GraphValidator.cs
+++ b/NxGraph/Diagnostics/Validations/GraphValidator.cs
@@ -218,6 +218,9 @@ public static class GraphValidator
         // external tooling and two nodes claiming it makes lookups ambiguous.
         ValidateUids(graph, result);
 
+        // 4e) Event-entry lints (spec 013) — always on, mirroring the fork/join presence Info.
+        ValidateEventEntries(graph, result);
+
         // 5) If AllNodes are supplied, check for unreachable nodes and duplicate names
         if (options.AllNodes is { Count: > 0 } all)
         {
@@ -288,6 +291,73 @@ public static class GraphValidator
 
             foreach (int dup in kvp.Value)
                 result.Add(Severity.Error, $"Duplicate node UID '{kvp.Key:D}'.", graph.GetNodeByIndex(dup).Id);
+        }
+    }
+
+    private static void ValidateEventEntries(Graph graph, GraphValidationResult result)
+    {
+        if (!graph.TryGetNodeByIndex(NodeId.Start.Index, out INode? startNode) ||
+            startNode is not LogicNode startLogic ||
+            (startLogic.AsyncLogic as EventEntryState ?? startLogic.Logic as EventEntryState) is not { } dispatcher)
+        {
+            return;
+        }
+
+        NodeId dispatcherId = startNode.Id;
+        result.Add(Severity.Info,
+            "Graph starts with an event entry — start runs with the typed raise overloads " +
+            "(ExecuteAsync<TEvent>(evt) / Execute<TEvent>(evt) / StepAsync<TEvent>(evt)); a plain run " +
+            "routes to the Otherwise chain.", dispatcherId);
+
+        // Event delivery writes through the machine's bound Graph board — a graph declaring no
+        // Graph schema at all defers the failure to the unbound-board throw at raise time.
+        if (graph.Schema is null)
+        {
+            result.Add(Severity.Warning,
+                "Event graph declares no Graph-scoped blackboard schema — event delivery writes through the " +
+                "machine's bound Graph board, so a raise without one hits the unbound-scope throw. Declare " +
+                "the schema via WithSchema(...) and bind a board via WithBlackboard(...).", dispatcherId);
+        }
+
+        foreach (EventRegistration registration in dispatcher.Registrations)
+        {
+            BlackboardSchema? keySchema = registration.KeySchema;
+            if (keySchema is null)
+            {
+                continue; // unbound (deserialized) registrations resolve by name at raise time
+            }
+
+            BlackboardSchema? declared = keySchema.Scope == BlackboardScope.Global
+                ? graph.GlobalSchema
+                : graph.Schema;
+            if (declared is not null && !ReferenceEquals(declared, keySchema))
+            {
+                result.Add(Severity.Warning,
+                    $"Event key '{registration.KeyName}' is registered on a schema that is not the graph's " +
+                    $"declared {keySchema.Scope} schema — a board bound over the declared schema makes " +
+                    "delivery fail at raise time.", dispatcherId);
+            }
+        }
+
+        for (int i = 0; i < graph.NodeCount; i++)
+        {
+            if (!graph.TryGetNodeByIndex(i, out INode? node) || node is not LogicNode logicNode)
+            {
+                continue;
+            }
+
+            bool isTokenNode =
+                logicNode.Logic is ForkState or JoinState ||
+                logicNode.AsyncLogic is ForkState or JoinState;
+            if (!isTokenNode)
+            {
+                continue;
+            }
+
+            result.Add(Severity.Warning,
+                "Graph combines an event entry with token fork/join nodes — event dispatch under the token " +
+                "runtime is unvalidated; keep event graphs and token graphs separate.", dispatcherId);
+            break;
         }
     }
 

--- a/NxGraph/Docs/readme.md
+++ b/NxGraph/Docs/readme.md
@@ -205,6 +205,25 @@ var sm = graph.ToAsyncStateMachine()
 
 Boards serialize independently via `BlackboardSerializer` (`NxGraph.Serialization`) — one payload per board, restored into a live board over the same schema.
 
+### Event entry points
+
+One graph can respond to several externally-raised, typed events, each entering the flow at its own entry chain. `GraphBuilder.StartWithEvents()` seeds an `EventEntryState` dispatcher as the start node; `.On(key, e => chain)` binds a CLR event type to a chain through a Graph-scoped `BlackboardKey<TEvent>` that carries the payload, and `.Otherwise(...)` declares the optional plain-run entry. Raise through the machines' typed overloads — `ExecuteAsync<TEvent>(evt)` / `Execute<TEvent>(evt)` / `StepAsync<TEvent>(evt)` — one event, one run; the machine must be idle and restart policies apply verbatim.
+
+```csharp
+var shop = new BlackboardSchema("shop");
+var orderPlaced = shop.Register<OrderPlaced>("orderPlaced");
+
+Graph graph = GraphBuilder.StartWithEvents()
+    .On(orderPlaced, e => e.ToAsync(orderPlaced, (order, bb, ct) => HandleAsync(order)))
+    .WithSchema(shop)
+    .Build();
+
+var sm = graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop));
+await sm.ExecuteAsync(new OrderPlaced("o-1", 42m));
+```
+
+Serialization note: the dispatch table rides the graph payload since version 7 as plain structure (key names, runtime-stable event type names, targets, `Otherwise` target). Keys never serialize — a deserialized graph raises by resolving the event's type name and the delivery key by name against the machine's bound Graph board (`BlackboardSchema.TryResolve<T>`), with targeted errors on a missing name or changed value type. The event payload itself is ordinary board state, so `BlackboardSerializer` persists it and a run suspended mid-handler resumes with the payload intact — no event replay.
+
 ---
 
 ## Execution

--- a/NxGraph/Docs/readme.md
+++ b/NxGraph/Docs/readme.md
@@ -224,6 +224,19 @@ await sm.ExecuteAsync(new OrderPlaced("o-1", 42m));
 
 Serialization note: the dispatch table rides the graph payload since version 7 as plain structure (key names, runtime-stable event type names, targets, `Otherwise` target). Keys never serialize — a deserialized graph raises by resolving the event's type name and the delivery key by name against the machine's bound Graph board (`BlackboardSchema.TryResolve<T>`), with targeted errors on a missing name or changed value type. The event payload itself is ordinary board state, so `BlackboardSerializer` persists it and a run suspended mid-handler resumes with the payload intact — no event replay.
 
+### Behaviors
+
+A state can be authored as a sequence of small reusable behaviors instead of a lambda: `.ToBehaviors(...)` / `.ToBehaviorsAsync(...)` run their entries in order, fail-fast (the first non-`Success` stops the sequence and the node fails — the node keeps the whole fault model: `.Retry` re-runs the list, `.OnError` reroutes). Fields are `BlackboardValue<T>` bindings — literal or blackboard key, any scope. The standard set is `Log` (report channel, formatted only when an observer is wired) and `SetValue<T>`; agent-typed behaviors (`IBehavior<TAgent>`) receive the machine-bound agent as a call parameter via `.ToBehaviors<TAgent>(...)`.
+
+```csharp
+Graph graph = GraphBuilder.Start()
+    .ToBehaviors(new Log(LogSeverity.Info, playerName), new SetValue<int>(score, 100))
+    .WithSchema(stats)
+    .Build();
+```
+
+Serialization note: behavior composites ride the graph payload since version 8 as self-describing field lists. The standard set round-trips with zero options via the default `BehaviorRegistry` (closed generics and agent types resolve from runtime-stable names); key bindings ride by name and rebind against the machine's bound boards at execution. Custom behaviors implement `ISerializableBehavior` and register a factory on `GraphSerializerOptions.BehaviorRegistry`; the agent never rides — re-attach it via `SetAgent`.
+
 ---
 
 ## Execution

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using NxGraph.Blackboards;
 using NxGraph.Compatibility;
 using NxGraph.Diagnostics.Replay;
@@ -70,6 +71,11 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
     private bool _nodeEntered; // the current node's EnterAction has fired for this visit
     private readonly int[]? _outcomeCodes; // graph-owned; null when no node declares one
 
+    // Event dispatch (spec 013): node 0's dispatcher, cached at construction (BuildReporterTable
+    // precedent) so a raise never probes the graph; null for graphs without event entries.
+    private readonly EventEntryState? _eventEntry;
+    private NodeId _pendingEntry = NodeId.Default; // armed by a typed raise, consumed at run start
+
     /// <summary>
     /// The outcome code of the node the last run terminated at (default 0).
     /// Reset when a new run starts.
@@ -94,6 +100,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
         _current = _initial;
         _cachedLogReportCallback = LogReportCallback;
         _reporters = BuildReporterTable(graph);
+        _eventEntry = FindEventEntry(graph);
         _retryPolicies = graph.RetryPolicies;
         _outcomeCodes = graph.OutcomeCodes;
         if (graph.NodeSchema is { } nodeSchema)
@@ -187,6 +194,137 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
     }
 
     private int OutcomeOf(NodeId id) => _outcomeCodes is null ? 0 : _outcomeCodes[id.Index];
+
+    private static EventEntryState? FindEventEntry(Graph graph)
+    {
+        return graph.TryGetNodeByIndex(NodeId.Start.Index, out INode? node) && node is LogicNode logicNode
+            ? logicNode.AsyncLogic as EventEntryState ?? logicNode.Logic as EventEntryState
+            : null;
+    }
+
+    /// <summary>
+    /// Stamps the pending event entry onto the dispatcher and clears the machine's field.
+    /// Called at every run start, right after <see cref="ApplyExecutionContext"/> —
+    /// unconditionally (<see cref="NodeId.Default"/> when no raise armed one), same
+    /// philosophy as the blackboard re-stamp: a stale entry must never leak into a later
+    /// plain run, and interleaved machines sharing a graph each stamp their own.
+    /// </summary>
+    private void StampPendingEntry()
+    {
+        if (_eventEntry is null)
+        {
+            return;
+        }
+
+        _eventEntry.SetPendingEntry(_pendingEntry);
+        _pendingEntry = NodeId.Default;
+    }
+
+    // ── Typed event raise surface (spec 013) ────────────────────────────
+
+    /// <summary>
+    /// Runs the machine to its terminal result (see <see cref="AsyncState.ExecuteAsync"/>).
+    /// Declared here (hiding the base method by forwarding) so overload resolution keeps
+    /// routing <c>ExecuteAsync()</c>/<c>ExecuteAsync(ct)</c> to the plain run — without this,
+    /// the typed raise overload below would capture a lone <see cref="CancellationToken"/>
+    /// argument as an event payload.
+    /// </summary>
+    public new ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => base.ExecuteAsync(ct);
+
+    /// <summary>
+    /// Raises a typed event: resolves <typeparamref name="TEvent"/> against the graph's event
+    /// entries, delivers the payload through the registration's blackboard key into this
+    /// machine's bound boards (typed end-to-end — struct events never box), and starts an
+    /// ordinary run at the entry's chain. One event = one run: the machine must be idle, and
+    /// the existing restart policies apply verbatim (under <see cref="RestartPolicy.Auto"/>
+    /// the machine is re-raisable after each run; under <see cref="RestartPolicy.Manual"/> a
+    /// raise after a terminal run throws the usual "call Reset()" error). Hosts that want
+    /// buffering feed this from their own queue (e.g. a <c>Channel&lt;T&gt;</c>).
+    /// </summary>
+    public ValueTask<Result> ExecuteAsync<TEvent>(TEvent evt, CancellationToken ct = default)
+    {
+        ArmRaise(evt);
+        return RunRaisedAsync(ct);
+    }
+
+    /// <summary>
+    /// Typed-raise twin of <see cref="StepAsync(CancellationToken)"/>: raises the event and
+    /// advances the run by exactly one node. Legal only as a run's <b>first</b> step — the
+    /// dispatch decision is made at run start, so raising mid-stepped-run throws. Continue
+    /// the run with plain <see cref="StepAsync(CancellationToken)"/> calls.
+    /// </summary>
+    public ValueTask<Result> StepAsync<TEvent>(TEvent evt, CancellationToken ct = default)
+    {
+        if (_stepping)
+        {
+            throw new InvalidOperationException(
+                "A stepped run is in progress — a typed event can only start a run. Finish it with StepAsync " +
+                "or Reset() before raising.");
+        }
+
+        ArmRaise(evt);
+        return StepRaisedAsync(ct);
+    }
+
+    private void ArmRaise<TEvent>(TEvent evt)
+    {
+        EventEntryState? dispatcher = _eventEntry;
+        if (dispatcher is null)
+        {
+            ThrowNoEventEntries();
+        }
+
+        // Best-effort idle guard — the execute gate in the plain path remains the real barrier.
+        ExecutionStatus status = Status;
+        if (status is ExecutionStatus.Starting or ExecutionStatus.Running or ExecutionStatus.Transitioning)
+        {
+            ThrowRaiseWhileExecuting();
+        }
+
+        _pendingEntry = dispatcher!.RaiseInto(in _blackboards, evt);
+    }
+
+    private async ValueTask<Result> RunRaisedAsync(CancellationToken ct)
+    {
+        try
+        {
+            return await ExecuteAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            // Consumed at run start; anything left means the run never started (terminal-Manual
+            // throw, Ignore policy) — clear so the entry cannot leak into a later plain run.
+            _pendingEntry = NodeId.Default;
+        }
+    }
+
+    private async ValueTask<Result> StepRaisedAsync(CancellationToken ct)
+    {
+        try
+        {
+            return await StepAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            // Same guarantee as RunRaisedAsync: a step that never started a run must not
+            // leave the entry armed. A successfully started stepped run consumed it already.
+            if (!_stepping)
+            {
+                _pendingEntry = NodeId.Default;
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowNoEventEntries() =>
+        throw new InvalidOperationException(
+            "This graph has no event entries — author it with GraphBuilder.StartWithEvents() to raise typed events.");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowRaiseWhileExecuting() =>
+        throw new InvalidOperationException(
+            "Cannot raise an event while the machine is executing — an event starts a new run. Await completion " +
+            "(or finish the stepped run) before raising.");
 
     private static ILogReporter?[] BuildReporterTable(Graph graph)
     {
@@ -335,6 +473,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
 
             // Re-stamp this machine's context onto the (potentially shared) graph before running.
             ApplyExecutionContext();
+            StampPendingEntry();
 
             // First entry or re-entry after Ready: Starting -> (enter first node) -> Running
             await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
@@ -628,6 +767,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                     }
 
                     ApplyExecutionContext();
+                    StampPendingEntry();
 
                     await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
                     _current = _initial;

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -887,8 +887,10 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             if (reporter is not null)
             {
                 // Reassigned on every visit so interleaved machines sharing a graph each
-                // attribute log reports to their own observer.
-                reporter.LogReport = _cachedLogReportCallback;
+                // attribute log reports to their own observer; null when this machine has no
+                // observer, so nodes that gate report formatting on a wired callback
+                // (behavior composites) pay nothing on observer-less machines.
+                reporter.LogReport = _observer is null ? null : _cachedLogReportCallback;
             }
 
             LogicNode logic = (LogicNode)node;

--- a/NxGraph/Fsm/EventEntryState.cs
+++ b/NxGraph/Fsm/EventEntryState.cs
@@ -1,0 +1,407 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using NxGraph.Blackboards;
+using NxGraph.Compatibility;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Fsm;
+
+/// <summary>
+/// One event entry of an <see cref="EventEntryState"/>: binds a CLR event type to the entry
+/// chain that handles it, through the Graph-scoped blackboard key that carries the payload.
+/// Authored registrations are the typed <see cref="EventRegistration{TEvent}"/>; deserialized
+/// graphs rebuild <i>unbound</i> registrations (<see cref="Unbound"/>) whose delivery key is
+/// resolved by name against the machine's bound board at raise time.
+/// </summary>
+public abstract class EventRegistration
+{
+    private protected EventRegistration(string keyName, string eventTypeName, string eventTypeShortName,
+        NodeId target)
+    {
+        KeyName = keyName;
+        EventTypeName = eventTypeName;
+        EventTypeShortName = eventTypeShortName;
+        Target = target;
+    }
+
+    /// <summary>The name of the blackboard key the event payload is delivered through.</summary>
+    public string KeyName { get; }
+
+    /// <summary>
+    /// The event's runtime-stable CLR type name (version-agnostic rendering, the same rules
+    /// blackboard payloads use) — the dispatch identity that rides serialization payloads.
+    /// </summary>
+    public string EventTypeName { get; }
+
+    /// <summary>The head node of the entry chain a raise of this event starts at.</summary>
+    public NodeId Target { get; }
+
+    /// <summary>Short display name of the event type (diagnostics/Mermaid labels).</summary>
+    internal string EventTypeShortName { get; }
+
+    /// <summary>The live CLR event type, or <c>null</c> for unbound (deserialized) registrations.</summary>
+    internal abstract Type? EventType { get; }
+
+    /// <summary>The schema of the live delivery key, or <c>null</c> for unbound registrations.</summary>
+    internal abstract BlackboardSchema? KeySchema { get; }
+
+    /// <summary>
+    /// Creates an unbound registration from serialized identity data. The delivery key is
+    /// resolved per raise against the machine's bound Graph board schema by
+    /// <see cref="BlackboardSchema.TryResolve{T}"/>; the event type is matched by its
+    /// runtime-stable name.
+    /// </summary>
+    public static EventRegistration Unbound(string keyName, string eventTypeName, NodeId target)
+    {
+        Guard.NotNull(keyName, nameof(keyName));
+        Guard.NotNull(eventTypeName, nameof(eventTypeName));
+        if (keyName.Length == 0)
+        {
+            throw new ArgumentException("Event key name cannot be empty.", nameof(keyName));
+        }
+
+        if (eventTypeName.Length == 0)
+        {
+            throw new ArgumentException("Event type name cannot be empty.", nameof(eventTypeName));
+        }
+
+        if (target == NodeId.Default)
+        {
+            throw new ArgumentException("An event entry target cannot be NodeId.Default.", nameof(target));
+        }
+
+        return new UnboundEventRegistration(keyName, eventTypeName, target);
+    }
+
+    /// <summary>
+    /// Renders a runtime-stable type name — the same rendering rules the blackboard payloads
+    /// use, so event identities survive runtime upgrades (no core-lib assembly versions for
+    /// constructed generics).
+    /// </summary>
+    internal static string StableTypeName(Type type)
+    {
+        if (type.IsArray)
+        {
+            int rank = type.GetArrayRank();
+            return StableTypeName(type.GetElementType()!) + (rank == 1 ? "[]" : $"[{new string(',', rank - 1)}]");
+        }
+
+        if (!type.IsConstructedGenericType)
+        {
+            return type.FullName ?? type.Name;
+        }
+
+        Type definition = type.GetGenericTypeDefinition();
+        Type[] arguments = type.GetGenericArguments();
+        StringBuilder sb = new(definition.FullName ?? definition.Name);
+        sb.Append('[');
+        for (int i = 0; i < arguments.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append(StableTypeName(arguments[i]));
+        }
+
+        sb.Append(']');
+        return sb.ToString();
+    }
+
+    /// <summary>Extracts the short display name from a stable type name string.</summary>
+    private protected static string ShortNameOf(string typeName)
+    {
+        int generic = typeName.IndexOf('[');
+        string core = generic < 0 ? typeName : typeName.Substring(0, generic);
+        int cut = Math.Max(core.LastIndexOf('.'), core.LastIndexOf('+'));
+        return cut < 0 ? core : core.Substring(cut + 1);
+    }
+
+    /// <summary>
+    /// Wiring-time key validation shared by the typed registration constructor and the
+    /// authoring DSL — ports precedent (<c>Dsl.Ports.cs</c>): Node-scoped keys are rejected
+    /// because Node scratch resets before the entry chain runs.
+    /// </summary>
+    internal static void ValidateEventKey<TEvent>(in BlackboardKey<TEvent> key, string paramName)
+    {
+        if (key.Schema is null)
+        {
+            throw new ArgumentException(
+                "Invalid event key — obtain keys via BlackboardSchema.Register<T>(...) on a Graph-scoped schema.",
+                paramName);
+        }
+
+        if (key.Schema.Scope == BlackboardScope.Node)
+        {
+            throw new ArgumentException(
+                $"Event key '{key.Name}' is Node-scoped — Node scratch resets before the entry chain runs, " +
+                "so the payload would be gone when the handler reads it. Register event keys on a " +
+                "Graph-scoped schema.", paramName);
+        }
+    }
+
+    private sealed class UnboundEventRegistration : EventRegistration
+    {
+        internal UnboundEventRegistration(string keyName, string eventTypeName, NodeId target)
+            : base(keyName, eventTypeName, ShortNameOf(eventTypeName), target)
+        {
+        }
+
+        internal override Type? EventType => null;
+
+        internal override BlackboardSchema? KeySchema => null;
+    }
+}
+
+/// <summary>
+/// Typed event registration: the CLR event type is the dispatch identity, and the
+/// Graph-scoped <see cref="BlackboardKey{TEvent}"/> is both that identity's payload slot and
+/// its serialization name. Global-scoped keys are allowed but shared across machines — two
+/// machines over one graph template overwrite each other's payloads, so prefer Graph scope.
+/// </summary>
+public sealed class EventRegistration<TEvent> : EventRegistration
+{
+    /// <summary>
+    /// Creates a registration delivering <typeparamref name="TEvent"/> through
+    /// <paramref name="key"/> into the chain headed by <paramref name="target"/>.
+    /// Node-scoped and invalid keys are rejected at wiring time.
+    /// </summary>
+    public EventRegistration(BlackboardKey<TEvent> key, NodeId target)
+        : base(ValidatedName(key), StableTypeName(typeof(TEvent)), typeof(TEvent).Name, target)
+    {
+        if (target == NodeId.Default)
+        {
+            throw new ArgumentException("An event entry target cannot be NodeId.Default.", nameof(target));
+        }
+
+        Key = key;
+    }
+
+    private static string ValidatedName(in BlackboardKey<TEvent> key)
+    {
+        ValidateEventKey(key, nameof(key));
+        return key.Name;
+    }
+
+    /// <summary>The typed delivery key the raise path writes the payload through.</summary>
+    public BlackboardKey<TEvent> Key { get; }
+
+    internal override Type? EventType => typeof(TEvent);
+
+    internal override BlackboardSchema? KeySchema => Key.Schema;
+}
+
+/// <summary>
+/// Event dispatcher node (spec 013): sits at index 0 of an event graph and routes each run to
+/// the entry chain registered for the raised event's CLR type. An event is a <b>run
+/// trigger</b>, not an interrupt — one event starts exactly one ordinary run (the machine must
+/// be idle; queueing and preemption stay host concerns). Raise events through the machines'
+/// typed overloads (<c>ExecuteAsync&lt;TEvent&gt;(evt)</c> / <c>Execute&lt;TEvent&gt;(evt)</c>
+/// / <c>StepAsync&lt;TEvent&gt;(evt)</c>); the payload is delivered through the
+/// registration's Graph-scoped blackboard key, so durability falls out of the ordinary
+/// blackboard artifacts.
+/// <para>
+/// The pending entry is <b>machine-stamped</b>: each machine stamps its own pending entry onto
+/// the dispatcher at every run start (unconditionally, <see cref="NodeId.Default"/> when no
+/// raise armed one), so several machines can share one <see cref="Graph"/> with distinct
+/// boards and events as long as their runs do not overlap — the same sharing contract as
+/// agents and blackboards. A plain (non-raised) run routes to the <see cref="DefaultTarget"/>
+/// (<c>Otherwise</c>) chain, else selection throws pointing at the raise API.
+/// </para>
+/// <para>
+/// Implements both director interfaces on both logic slots (the <c>ForkState</c> shape), so
+/// one class serves both runtimes and its branches are visible to reachability validation and
+/// Mermaid export via <c>EnumerateStaticTargets()</c>.
+/// </para>
+/// </summary>
+public sealed class EventEntryState : ILogic, IAsyncLogic, IDirector, IAsyncDirector
+{
+    private readonly EventRegistration[] _registrations;
+    private readonly Dictionary<Type, EventRegistration> _byType;
+    private readonly Dictionary<string, EventRegistration>? _unboundByTypeName;
+    private readonly NodeId _defaultTarget;
+    private readonly NodeId[] _staticTargets;
+    private NodeId _pendingEntry = NodeId.Default;
+
+    /// <summary>Creates a dispatcher with no <c>Otherwise</c> chain — plain runs throw.</summary>
+    public EventEntryState(IReadOnlyList<EventRegistration> registrations)
+        : this(registrations, NodeId.Default)
+    {
+    }
+
+    /// <summary>
+    /// Creates a dispatcher. <paramref name="defaultTarget"/> is the <c>Otherwise</c> chain a
+    /// plain run routes to; pass <see cref="NodeId.Default"/> for none.
+    /// </summary>
+    public EventEntryState(IReadOnlyList<EventRegistration> registrations, NodeId defaultTarget)
+    {
+        Guard.NotNull(registrations, nameof(registrations));
+        if (registrations.Count == 0)
+        {
+            throw new ArgumentException(
+                "An event entry needs at least one registration — register entries with On(key, e => ...).",
+                nameof(registrations));
+        }
+
+        _registrations = new EventRegistration[registrations.Count];
+        _byType = new Dictionary<Type, EventRegistration>(registrations.Count);
+        Dictionary<string, EventRegistration>? unbound = null;
+        HashSet<string> typeNames = new(StringComparer.Ordinal);
+        for (int i = 0; i < _registrations.Length; i++)
+        {
+            EventRegistration registration = registrations[i] ?? throw new ArgumentException(
+                "Event registrations cannot be null.", nameof(registrations));
+            if (!typeNames.Add(registration.EventTypeName))
+            {
+                throw new ArgumentException(
+                    $"An entry for event type '{registration.EventTypeName}' is already registered — " +
+                    "dispatch is by CLR event type, one entry per type.", nameof(registrations));
+            }
+
+            if (registration.EventType is { } eventType)
+            {
+                _byType.Add(eventType, registration);
+            }
+            else
+            {
+                (unbound ??= new Dictionary<string, EventRegistration>(StringComparer.Ordinal))
+                    .Add(registration.EventTypeName, registration);
+            }
+
+            _registrations[i] = registration;
+        }
+
+        _unboundByTypeName = unbound;
+        _defaultTarget = defaultTarget;
+
+        bool hasDefault = defaultTarget != NodeId.Default;
+        NodeId[] targets = new NodeId[_registrations.Length + (hasDefault ? 1 : 0)];
+        for (int i = 0; i < _registrations.Length; i++)
+        {
+            targets[i] = _registrations[i].Target;
+        }
+
+        if (hasDefault)
+        {
+            targets[targets.Length - 1] = defaultTarget;
+        }
+
+        _staticTargets = targets;
+    }
+
+    /// <summary>The registered entries, in registration order.</summary>
+    public IReadOnlyList<EventRegistration> Registrations => _registrations;
+
+    /// <summary>
+    /// The <c>Otherwise</c> chain a plain (non-raised) run routes to, or
+    /// <see cref="NodeId.Default"/> when none is declared (plain runs then throw).
+    /// </summary>
+    public NodeId DefaultTarget => _defaultTarget;
+
+    /// <summary>
+    /// Stamps the pending entry for the next selection. Called by the machines at every run
+    /// start — unconditionally, <see cref="NodeId.Default"/> when no raise armed one — so a
+    /// stale entry can never leak into a later plain run.
+    /// </summary>
+    internal void SetPendingEntry(NodeId entry) => _pendingEntry = entry;
+
+    /// <summary>
+    /// Resolves <typeparamref name="TEvent"/> against the dispatch table, delivers the payload
+    /// through the registration's key into <paramref name="boards"/> (typed end-to-end — struct
+    /// events never box), and returns the entry target for the machine to arm. Unbound
+    /// (deserialized) registrations resolve the delivery key by name against the bound Graph
+    /// board's schema per raise.
+    /// </summary>
+    internal NodeId RaiseInto<TEvent>(in BlackboardContext boards, TEvent evt)
+    {
+        if (_byType.TryGetValue(typeof(TEvent), out EventRegistration? registration))
+        {
+            // The cast is guaranteed by construction: the Type table is keyed by each typed
+            // registration's own event type, one entry per type.
+            boards.Set(((EventRegistration<TEvent>)registration).Key, evt);
+            return registration.Target;
+        }
+
+        return RaiseUnbound(boards, evt);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private NodeId RaiseUnbound<TEvent>(BlackboardContext boards, TEvent evt)
+    {
+        if (_unboundByTypeName is null ||
+            !_unboundByTypeName.TryGetValue(EventRegistration.StableTypeName(typeof(TEvent)),
+                out EventRegistration? registration))
+        {
+            throw UnregisteredEventType(typeof(TEvent));
+        }
+
+        Blackboard? board = boards.Graph;
+        if (board is null)
+        {
+            throw new InvalidOperationException(
+                $"graph key '{registration.KeyName}' used but no graph blackboard bound — " +
+                "bind one via WithBlackboard(...).");
+        }
+
+        BlackboardSchema schema = board.Schema;
+        if (!schema.TryResolve(registration.KeyName, out BlackboardKey<TEvent> key))
+        {
+            if (schema.TryGetKey(registration.KeyName, out BlackboardKeyDescriptor descriptor))
+            {
+                throw new InvalidOperationException(
+                    $"Event entry key '{registration.KeyName}' is declared as '{descriptor.ValueType}' on the " +
+                    $"bound Graph schema '{schema.Name ?? "<unnamed>"}' but the event was raised as " +
+                    $"'{typeof(TEvent)}'.");
+            }
+
+            throw new InvalidOperationException(
+                $"Event entry key '{registration.KeyName}' does not exist on the bound Graph schema " +
+                $"'{schema.Name ?? "<unnamed>"}' — a deserialized event graph resolves delivery keys by name " +
+                "against the machine's bound board.");
+        }
+
+        boards.Set(key, evt);
+        return registration.Target;
+    }
+
+    private InvalidOperationException UnregisteredEventType(Type eventType)
+    {
+        StringBuilder sb = new();
+        for (int i = 0; i < _registrations.Length; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(_registrations[i].EventTypeName);
+        }
+
+        return new InvalidOperationException(
+            $"No event entry is registered for event type '{eventType}'. Registered event types: {sb}.");
+    }
+
+    private NodeId SelectNextCore()
+    {
+        NodeId pending = _pendingEntry;
+        if (pending != NodeId.Default)
+        {
+            return pending;
+        }
+
+        return _defaultTarget != NodeId.Default ? _defaultTarget : ThrowNoPendingEntry();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static NodeId ThrowNoPendingEntry() =>
+        throw new InvalidOperationException(
+            "EventEntryState has no pending event entry and no Otherwise chain — start runs with the typed " +
+            "raise overloads (ExecuteAsync<TEvent>(evt) / Execute<TEvent>(evt) / StepAsync<TEvent>(evt)), " +
+            "or declare an Otherwise(...) chain for plain runs.");
+
+    Result ILogic.Execute() => Result.Success;
+
+    ValueTask<Result> IAsyncLogic.ExecuteAsync(CancellationToken ct) => ResultHelpers.Success;
+
+    NodeId IDirector.SelectNext() => SelectNextCore();
+
+    ValueTask<NodeId> IAsyncDirector.SelectNextAsync(CancellationToken ct) => new(SelectNextCore());
+
+    IEnumerable<NodeId> IDirector.EnumerateStaticTargets() => _staticTargets;
+
+    IEnumerable<NodeId> IAsyncDirector.EnumerateStaticTargets() => _staticTargets;
+}

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -98,6 +98,11 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
     private bool _nodeEntered; // the current node's EnterAction has fired for this visit
     private readonly int[]? _outcomeCodes; // graph-owned; null when no node declares one
 
+    // Event dispatch (spec 013): node 0's dispatcher, cached at construction (log-report-table
+    // precedent) so a raise never probes the graph; null for graphs without event entries.
+    private readonly EventEntryState? _eventEntry;
+    private NodeId _pendingEntry = NodeId.Default; // armed by a typed raise, consumed at run start
+
     /// <summary>
     /// The outcome code of the node the last run terminated at (default 0).
     /// Reset when a new run starts.
@@ -141,6 +146,7 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         _current = _initial;
         _cachedLogReportCallback = LogReportCallback;
         _logReportStates = BuildLogReportTable(graph);
+        _eventEntry = FindEventEntry(graph);
         _retryPolicies = graph.RetryPolicies;
         _outcomeCodes = graph.OutcomeCodes;
         if (graph.NodeSchema is { } nodeSchema)
@@ -233,6 +239,86 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
                 $"{blackboard.Schema.Scope} schema '{declared.Name ?? "<unnamed>"}' declared on graph '{Graph.Id}'.");
         }
     }
+
+    private static EventEntryState? FindEventEntry(Graph graph)
+    {
+        return graph.TryGetNodeByIndex(NodeId.Start.Index, out INode? node) && node is LogicNode logicNode
+            ? logicNode.Logic as EventEntryState ?? logicNode.AsyncLogic as EventEntryState
+            : null;
+    }
+
+    /// <summary>
+    /// Stamps the pending event entry onto the dispatcher and clears the machine's field.
+    /// Called at every run start, right after <see cref="ApplyExecutionContext"/> —
+    /// unconditionally (<see cref="NodeId.Default"/> when no raise armed one), same
+    /// philosophy as the blackboard re-stamp: a stale entry must never leak into a later
+    /// plain run, and interleaved machines sharing a graph each stamp their own.
+    /// </summary>
+    private void StampPendingEntry()
+    {
+        if (_eventEntry is null)
+        {
+            return;
+        }
+
+        _eventEntry.SetPendingEntry(_pendingEntry);
+        _pendingEntry = NodeId.Default;
+    }
+
+    // ── Typed event raise surface (spec 013) ────────────────────────────
+
+    /// <summary>
+    /// Raises a typed event, mirroring <see cref="AsyncStateMachine.ExecuteAsync{TEvent}"/>:
+    /// resolves <typeparamref name="TEvent"/> against the graph's event entries, delivers the
+    /// payload through the registration's blackboard key into this machine's bound boards
+    /// (typed end-to-end — struct events never box), and arms a run at the entry's chain.
+    /// The call advances the run like plain <see cref="State.Execute"/> (one node per tick by
+    /// default); subsequent plain <c>Execute()</c> ticks continue it — normal frame-stepping.
+    /// One event = one run: the machine must be idle, and the restart policies apply verbatim.
+    /// </summary>
+    public Result Execute<TEvent>(TEvent evt)
+    {
+        ArmRaise(evt);
+        try
+        {
+            return Execute();
+        }
+        finally
+        {
+            // Consumed at run start; anything left means the run never started (terminal-Manual
+            // throw, Ignore policy) — clear so the entry cannot leak into a later plain run.
+            _pendingEntry = NodeId.Default;
+        }
+    }
+
+    private void ArmRaise<TEvent>(TEvent evt)
+    {
+        EventEntryState? dispatcher = _eventEntry;
+        if (dispatcher is null)
+        {
+            ThrowNoEventEntries();
+        }
+
+        // Best-effort idle guard — the execute gate in the plain path remains the real barrier.
+        ExecutionStatus status = _status;
+        if (status is ExecutionStatus.Starting or ExecutionStatus.Running or ExecutionStatus.Transitioning)
+        {
+            ThrowRaiseWhileExecuting();
+        }
+
+        _pendingEntry = dispatcher!.RaiseInto(in _blackboards, evt);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowNoEventEntries() =>
+        throw new InvalidOperationException(
+            "This graph has no event entries — author it with GraphBuilder.StartWithEvents() to raise typed events.");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowRaiseWhileExecuting() =>
+        throw new InvalidOperationException(
+            "Cannot raise an event while the machine is executing — an event starts a new run. Finish the " +
+            "current run before raising.");
 
     private static State?[] BuildLogReportTable(Graph graph)
     {
@@ -487,6 +573,7 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
 
         // Re-stamp this machine's context onto the (potentially shared) graph before running.
         ApplyExecutionContext();
+        StampPendingEntry();
 
         TransitionTo(ExecutionStatus.Starting);
         _current = _initial;

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -688,11 +688,13 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         LogicNode logicNode = (LogicNode)node;
 
         // Wire log-report callback for nodes that support it. Reassigned on every visit so
-        // interleaved machines sharing a graph each attribute reports to their own observer.
+        // interleaved machines sharing a graph each attribute reports to their own observer;
+        // null when this machine has no observer, so nodes that gate report formatting on a
+        // wired callback (behavior composites) pay nothing on observer-less machines.
         State? stateForLog = _logReportStates[_current.Index];
         if (stateForLog is not null)
         {
-            stateForLog.SyncLogReport = _cachedLogReportCallback;
+            stateForLog.SyncLogReport = _observer is null ? null : _cachedLogReportCallback;
         }
 
         // Execute the node synchronously.

--- a/NxGraph/Graphs/LogicNode.cs
+++ b/NxGraph/Graphs/LogicNode.cs
@@ -121,6 +121,21 @@ public class LogicNode : INode
     /// </summary>
     public static readonly LogicNode EventEntryStateMarker =
         new(NodeId.EventEntryStateMarker, new EmptyAsyncLogic());
+
+    /// <summary>
+    /// Sentinel for <b>sync</b> behavior-composite owner nodes during (de)serialization
+    /// (wire marker string "BehaviorState", payload version 8). Covers both the untyped
+    /// composite and the agent-typed variant — the DTO's <c>AgentTypeName</c> discriminates.
+    /// </summary>
+    public static readonly LogicNode BehaviorStateMarker =
+        new(NodeId.BehaviorStateMarker, new EmptyAsyncLogic());
+
+    /// <summary>
+    /// Sentinel for <b>async</b> behavior-composite owner nodes during (de)serialization
+    /// (wire marker string "AsyncBehaviorState", payload version 8).
+    /// </summary>
+    public static readonly LogicNode AsyncBehaviorStateMarker =
+        new(NodeId.AsyncBehaviorStateMarker, new EmptyAsyncLogic());
 }
 
 /// <summary>

--- a/NxGraph/Graphs/LogicNode.cs
+++ b/NxGraph/Graphs/LogicNode.cs
@@ -113,6 +113,14 @@ public class LogicNode : INode
     /// </summary>
     public static readonly LogicNode SyncDynamicParallelStateMarker =
         new(NodeId.SyncDynamicParallelStateMarker, new EmptyAsyncLogic());
+
+    /// <summary>
+    /// Sentinel for event-entry dispatcher owner nodes during (de)serialization (wire marker
+    /// string "EventEntryState", payload version 7). One marker for both runtimes — the
+    /// dispatcher is one class implementing both logic interfaces.
+    /// </summary>
+    public static readonly LogicNode EventEntryStateMarker =
+        new(NodeId.EventEntryStateMarker, new EmptyAsyncLogic());
 }
 
 /// <summary>

--- a/NxGraph/Graphs/NodeId.cs
+++ b/NxGraph/Graphs/NodeId.cs
@@ -68,6 +68,8 @@ public struct NodeId(int index) : IEquatable<NodeId>
     public static NodeId DynamicParallelStateMarker => new(-10) { Name = "DynamicParallelState" };
     public static NodeId SyncDynamicParallelStateMarker => new(-11) { Name = "SyncDynamicParallelState" };
     public static NodeId EventEntryStateMarker => new(-12) { Name = "EventEntryState" };
+    public static NodeId BehaviorStateMarker => new(-13) { Name = "BehaviorState" };
+    public static NodeId AsyncBehaviorStateMarker => new(-14) { Name = "AsyncBehaviorState" };
 
     /// <summary>
     /// Represents the start NodeId with an index of 0 and a name of "Start".

--- a/NxGraph/Graphs/NodeId.cs
+++ b/NxGraph/Graphs/NodeId.cs
@@ -67,6 +67,7 @@ public struct NodeId(int index) : IEquatable<NodeId>
     public static NodeId JoinStateMarker => new(-9) { Name = "JoinState" };
     public static NodeId DynamicParallelStateMarker => new(-10) { Name = "DynamicParallelState" };
     public static NodeId SyncDynamicParallelStateMarker => new(-11) { Name = "SyncDynamicParallelState" };
+    public static NodeId EventEntryStateMarker => new(-12) { Name = "EventEntryState" };
 
     /// <summary>
     /// Represents the start NodeId with an index of 0 and a name of "Start".

--- a/NxGraph/Tokens/AsyncTokenMachine.cs
+++ b/NxGraph/Tokens/AsyncTokenMachine.cs
@@ -822,7 +822,7 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
         ILogReporter? reporter = _reporters[idx];
         if (reporter is not null)
         {
-            reporter.LogReport = _cachedLogReportCallback;
+            reporter.LogReport = _observer is null ? null : _cachedLogReportCallback;
         }
 
         if (!t.NodeEntered)

--- a/NxGraph/Tokens/TokenMachine.cs
+++ b/NxGraph/Tokens/TokenMachine.cs
@@ -687,7 +687,7 @@ public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         State? stateForLog = _logReportStates[idx];
         if (stateForLog is not null)
         {
-            stateForLog.SyncLogReport = _cachedLogReportCallback;
+            stateForLog.SyncLogReport = _observer is null ? null : _cachedLogReportCallback;
         }
 
         ILogic syncLogic = logicNode.Logic!;

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The core package targets `net8.0` and `netstandard2.1`.
   - [Blackboards (scoped shared memory)](#blackboards-scoped-shared-memory)
   - [Step I/O (ports)](#step-io-ports)
   - [Event entry points](#event-entry-points)
+  - [Behaviors (declarative state composition)](#behaviors-declarative-state-composition)
 - [Execution](#execution)
   - [Async execution](#async-execution)
   - [Sync execution, stepped model](#sync-execution-stepped-model)
@@ -525,6 +526,34 @@ await foreach (OrderPlaced evt in queue.Reader.ReadAllAsync(ct))
 ```
 
 Serialization: the dispatch table rides the graph payload (version 7) as plain structure; keys never serialize, so a deserialized graph raises by resolving the event's runtime-stable type name and the delivery key by name against the machine's bound board — see [Serialization](#serialization).
+
+### Behaviors (declarative state composition)
+
+A state can be authored as a sequence of small, reusable **behaviors** — plain data objects whose fields are literals or blackboard bindings — instead of an opaque lambda or a hand-written `State` subclass. `.ToBehaviors(...)` / `.ToBehaviorsAsync(...)` build one node that runs its entries **in order, fail-fast**: the first non-`Success` entry stops the sequence and the node returns `Failure` (deliberately the opposite of `.ToAll`'s run-all-then-combine — sequence entries may depend on earlier entries' writes). Everything above the node is unchanged: `.Retry` re-runs the whole list (keep behaviors idempotent), `.OnError` reroutes, `.WithOutcome` codes.
+
+```csharp
+var stats = new BlackboardSchema("stats"); // Graph scope (default)
+BlackboardKey<string> playerName = stats.Register("playerName", "Hero");
+BlackboardKey<int> score = stats.Register("score", 0);
+
+Graph graph = GraphBuilder.Start()
+    .ToBehaviors(
+        new Log(LogSeverity.Info, playerName), // message bound to a key, resolved per run
+        new SetValue<int>(score, 100),         // literal write — the typed copy/constant primitive
+        new Log("checkpoint saved"))           // literal message, Info severity by default
+    .WithSchema(stats)
+    .Build();
+
+Result result = graph.ToStateMachine(observer)      // Log lands in the observer's OnLogReport
+    .WithBlackboard(new Blackboard(stats))
+    .Execute();
+```
+
+Every field is a `BlackboardValue<T>` — literal and key convert implicitly, and any scope binds (Node scratch included: behavior bindings resolve within one visit, so the ports restriction doesn't apply). `Log` emits `"[{severity}] {message}"` through the node's **report channel** (observer `OnLogReport`, never the console — and no string is even formatted on observer-less machines). The standard set is deliberately tiny — `Log` and `SetValue<T>`, each one class implementing both behavior interfaces so a single instance authors either runtime.
+
+Custom behaviors implement `IBehavior` (sync), `IAsyncBehavior` (async), or both. Agent-typed behaviors (`IBehavior<TAgent>` / `IAsyncBehavior<TAgent>`) receive the machine-bound agent **as a call parameter per execution** via the typed composites (`.ToBehaviors<TAgent>(...)`), which participate in the standard agent stamping — behaviors themselves are never stamped, so instances stay shareable across graphs and machines. Untyped composites reject agent-typed entries at wiring time; typed composites accept a mix and run plain entries agent-blind.
+
+**When to write a custom behavior vs a custom `State`:** a behavior is the right shape for a small, reusable, data-configured step — fields that an editor (or a payload) could inspect and rebind, no timing, output via `ctx.Report`/the blackboard. Write a `State` subclass when the logic needs the node lifecycle (`OnEnter`/`OnExit`), multi-tick `InProgress` progress, timeouts/cancellation shape, or when it is one-off orchestration that nothing else will reuse. Behaviors are also the first node logic that serializes **without a user codec** — see [Serialization](#serialization).
 
 ---
 
@@ -1113,6 +1142,7 @@ Notes:
 - your codec controls how node logic is persisted and restored
 - nested machines, history/parallel composites, and token fork/join nodes serialize out of the box; dynamic parallel composites need a `GraphSerializerOptions.SelectorRegistry` (the selector delegate rides as a named key — author graphs with the delegate instance `RegionSelectorRegistry.Register` returns), and custom `ISubGraphProvider` containers need a `GraphSerializerOptions.ContainerCodec` (you own the reconstruction recipe; the serializer recurses into `SubGraphs` for you, order-preserving)
 - event entry dispatchers serialize out of the box (payload version 7): the dispatch table — key names, runtime-stable event type names, targets, and the `Otherwise` target — is plain structure. Blackboard keys never ride the graph payload (schemas are code), so a deserialized graph raises by resolving the event's type name and the delivery key by name against the machine's bound Graph board, with targeted errors on a missing name or a changed value type
+- behavior composites serialize out of the box for the standard set (payload version 8): `Log` and `SetValue<T>` ride as self-describing field lists with **zero options configured** — the default `BehaviorRegistry` reconstructs them, closing `SetValue<T>` (and `BehaviorState<TAgent>`'s agent type) from runtime-stable type names. Key bindings ride by name and rebind against the machine's bound boards at execution. Custom behaviors implement `ISerializableBehavior` (writing through the small neutral field model: strings, bools, numerics, enums, bindings) and register a reconstruction factory on `GraphSerializerOptions.BehaviorRegistry`; a behavior that does neither fails with a targeted error naming that option. The agent never rides — re-attach it via `SetAgent`/`WithAgent`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The core package targets `net8.0` and `netstandard2.1`.
   - [Agents / context injection](#agents--context-injection)
   - [Blackboards (scoped shared memory)](#blackboards-scoped-shared-memory)
   - [Step I/O (ports)](#step-io-ports)
+  - [Event entry points](#event-entry-points)
 - [Execution](#execution)
   - [Async execution](#async-execution)
   - [Sync execution, stepped model](#sync-execution-stepped-model)
@@ -474,6 +475,56 @@ Graph graph = GraphBuilder
 Producer and pipe steps **cannot fail** — their lambdas return the value, and the relay writes it to the port and returns `Success`. A step that both computes a value and can fail keeps using the plain context relay (`.To(bb => ...)`) with an explicit `bb.Set(...)` on its success path; exceptions thrown by a step propagate exactly as from every relay.
 
 > **Node-scope trap:** a Node-scoped key cannot pipe — Node scratch resets on the success transition, so the producer's write is back at its default before the consumer runs. The port overloads reject Node-scoped keys at wiring time with an `ArgumentException`. Global-scoped keys are accepted (legitimate for world-state ports) but shared across machines — two machines over one template would overwrite each other's values, so the default recommendation stays Graph scope.
+
+### Event entry points
+
+One graph can respond to several externally-raised, **typed** events, each entering the flow at its own entry chain. An event is a **run trigger**, not an interrupt: one event starts exactly one ordinary run at the chain registered for its CLR type, with the payload delivered type-safely through a Graph-scoped `BlackboardKey<TEvent>` — the same "a port is an ordinary key" convention as step I/O, which is also what makes event payloads durable for free.
+
+```csharp
+public sealed record OrderPlaced(string OrderId, decimal Amount);
+public readonly record struct OrderCanceled(string OrderId);
+
+var shop = new BlackboardSchema("shop"); // Graph scope (default)
+BlackboardKey<OrderPlaced> orderPlaced = shop.Register<OrderPlaced>("orderPlaced");
+BlackboardKey<OrderCanceled> orderCanceled = shop.Register<OrderCanceled>("orderCanceled");
+
+Graph graph = GraphBuilder.StartWithEvents()
+    .On(orderPlaced, e => e
+        .ToAsync(orderPlaced, (order, bb, ct) => ReserveStockAsync(order))  // payload via the consumer sugar
+        .ToAsync((bb, ct) => ChargeAsync(bb.Get(orderPlaced)))              // or via bb.Get
+        .WithOutcome(1, "Placed"))
+    .On(orderCanceled, e => e
+        .ToAsync(orderCanceled, (order, bb, ct) => RefundAsync(order))
+        .WithOutcome(2, "Canceled"))
+    .Otherwise(e => e.ToAsync((bb, ct) => LogUnsolicitedAsync()))           // optional plain-run entry
+    .WithSchema(shop)
+    .Build();
+
+AsyncStateMachine machine = graph.ToAsyncStateMachine().WithBlackboard(new Blackboard(shop));
+
+Result placed = await machine.ExecuteAsync(new OrderPlaced("o-1", 42m)); // dispatch by CLR event type
+Result canceled = await machine.ExecuteAsync(new OrderCanceled("o-1"));
+Console.WriteLine(machine.LastOutcomeName); // per-entry outcome via .WithOutcome + LastOutcome
+```
+
+The sync twin raises with `machine.Execute(evt)` — the call arms the run and advances one tick; subsequent plain `Execute()` ticks continue it (normal frame-stepping). The async stepped twin is `machine.StepAsync(evt)`, legal only as a run's **first** step. Entry chains use the full DSL vocabulary — `.OnError`, `.Retry`, `.WithOutcome`, ports, composites — and may converge on shared nodes.
+
+Rules that keep the model simple:
+
+- **One event = one run.** The machine must be idle; restart policies apply verbatim (under `RestartPolicy.Manual` a raise after a terminal run throws the usual "call Reset()" error, and raising while running throws). There is no internal queue, no mid-run delivery, no deferral.
+- **Dispatch is by CLR event type** — one entry per type, enforced at wiring time. Node-scoped and schema-less keys are rejected at wiring time too; Global keys are allowed but shared across machines (prefer Graph scope).
+- A **plain run** (`ExecuteAsync()` / `Execute()`) routes to the `Otherwise` chain; without one it throws pointing at the raise API. A raised entry never leaks into a later plain run.
+- Machines **sharing one graph** each raise their own events against their own boards, exactly like agents and blackboards — sequential runs only.
+
+A host that wants buffering feeds the machine from its own queue — three lines with a `Channel<T>`:
+
+```csharp
+var queue = Channel.CreateUnbounded<OrderPlaced>();
+await foreach (OrderPlaced evt in queue.Reader.ReadAllAsync(ct))
+    await machine.ExecuteAsync(evt, ct); // one queued event = one run
+```
+
+Serialization: the dispatch table rides the graph payload (version 7) as plain structure; keys never serialize, so a deserialized graph raises by resolving the event's runtime-stable type name and the delivery key by name against the machine's bound board — see [Serialization](#serialization).
 
 ---
 
@@ -1061,6 +1112,7 @@ Notes:
 - JSON and MessagePack are both supported through `GraphSerializer`
 - your codec controls how node logic is persisted and restored
 - nested machines, history/parallel composites, and token fork/join nodes serialize out of the box; dynamic parallel composites need a `GraphSerializerOptions.SelectorRegistry` (the selector delegate rides as a named key — author graphs with the delegate instance `RegionSelectorRegistry.Register` returns), and custom `ISubGraphProvider` containers need a `GraphSerializerOptions.ContainerCodec` (you own the reconstruction recipe; the serializer recurses into `SubGraphs` for you, order-preserving)
+- event entry dispatchers serialize out of the box (payload version 7): the dispatch table — key names, runtime-stable event type names, targets, and the `Otherwise` target — is plain structure. Blackboard keys never ride the graph payload (schemas are code), so a deserialized graph raises by resolving the event's type name and the delivery key by name against the machine's bound Graph board, with targeted errors on a missing name or a changed value type
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -535,11 +535,15 @@ A state can be authored as a sequence of small, reusable **behaviors** — plain
 var stats = new BlackboardSchema("stats"); // Graph scope (default)
 BlackboardKey<string> playerName = stats.Register("playerName", "Hero");
 BlackboardKey<int> score = stats.Register("score", 0);
+BlackboardKey<int> comboHits = stats.Register("comboHits", 3);
+BlackboardKey<int> hitIndex = stats.Register("hitIndex", -1);
 
 Graph graph = GraphBuilder.Start()
     .ToBehaviors(
         new Log(LogSeverity.Info, playerName), // message bound to a key, resolved per run
         new SetValue<int>(score, 100),         // literal write — the typed copy/constant primitive
+        new Repeat(comboHits, hitIndex,        // key-bound trip count — resolved once at entry
+            new Log("combo hit")),             // body runs comboHits times; hitIndex = 0, 1, 2…
         new Log("checkpoint saved"))           // literal message, Info severity by default
     .WithSchema(stats)
     .Build();
@@ -549,7 +553,9 @@ Result result = graph.ToStateMachine(observer)      // Log lands in the observer
     .Execute();
 ```
 
-Every field is a `BlackboardValue<T>` — literal and key convert implicitly, and any scope binds (Node scratch included: behavior bindings resolve within one visit, so the ports restriction doesn't apply). `Log` emits `"[{severity}] {message}"` through the node's **report channel** (observer `OnLogReport`, never the console — and no string is even formatted on observer-less machines). The standard set is deliberately tiny — `Log` and `SetValue<T>`, each one class implementing both behavior interfaces so a single instance authors either runtime.
+Every field is a `BlackboardValue<T>` — literal and key convert implicitly, and any scope binds (Node scratch included: behavior bindings resolve within one visit, so the ports restriction doesn't apply). `Log` emits `"[{severity}] {message}"` through the node's **report channel** (observer `OnLogReport`, never the console — and no string is even formatted on observer-less machines). The standard set is deliberately tiny — `Log`, `SetValue<T>`, and `Repeat`, each implementing both behavior interfaces so a single instance authors either runtime (`AsyncRepeat` is the async-body twin, and `Repeat<TAgent>`/`AsyncRepeat<TAgent>` deliver the agent to typed body entries per iteration).
+
+`Repeat` is the one control-flow behavior — a bounded, leaf-level For: the trip count (literal or key-bound) is resolved **once at entry**, a key-bound count of zero or less runs nothing and succeeds, the optional index key is written 0-based before each iteration, and each iteration walks the body in order, fail-fast. The node fault model is untouched — a `.Retry` re-runs **all** iterations, so the idempotency note compounds with the trip count — and only the async paths can observe cancellation between iterations. Anything condition-driven (`While`, guards) stays at the node level: use a condition director plus a `.Goto` back-edge, which validators, Mermaid, and snapshots can see.
 
 Custom behaviors implement `IBehavior` (sync), `IAsyncBehavior` (async), or both. Agent-typed behaviors (`IBehavior<TAgent>` / `IAsyncBehavior<TAgent>`) receive the machine-bound agent **as a call parameter per execution** via the typed composites (`.ToBehaviors<TAgent>(...)`), which participate in the standard agent stamping — behaviors themselves are never stamped, so instances stay shareable across graphs and machines. Untyped composites reject agent-typed entries at wiring time; typed composites accept a mix and run plain entries agent-blind.
 
@@ -1143,6 +1149,7 @@ Notes:
 - nested machines, history/parallel composites, and token fork/join nodes serialize out of the box; dynamic parallel composites need a `GraphSerializerOptions.SelectorRegistry` (the selector delegate rides as a named key — author graphs with the delegate instance `RegionSelectorRegistry.Register` returns), and custom `ISubGraphProvider` containers need a `GraphSerializerOptions.ContainerCodec` (you own the reconstruction recipe; the serializer recurses into `SubGraphs` for you, order-preserving)
 - event entry dispatchers serialize out of the box (payload version 7): the dispatch table — key names, runtime-stable event type names, targets, and the `Otherwise` target — is plain structure. Blackboard keys never ride the graph payload (schemas are code), so a deserialized graph raises by resolving the event's type name and the delivery key by name against the machine's bound Graph board, with targeted errors on a missing name or a changed value type
 - behavior composites serialize out of the box for the standard set (payload version 8): `Log` and `SetValue<T>` ride as self-describing field lists with **zero options configured** — the default `BehaviorRegistry` reconstructs them, closing `SetValue<T>` (and `BehaviorState<TAgent>`'s agent type) from runtime-stable type names. Key bindings ride by name and rebind against the machine's bound boards at execution. Custom behaviors implement `ISerializableBehavior` (writing through the small neutral field model: strings, bools, numerics, enums, bindings) and register a reconstruction factory on `GraphSerializerOptions.BehaviorRegistry`; a behavior that does neither fails with a targeted error naming that option. The agent never rides — re-attach it via `SetAgent`/`WithAgent`
+- `Repeat` bodies ride as nested behavior entry lists (payload version 9): all four repeat forms serialize with zero options via the default registry, bodies encode recursively under exactly the top-level entry rules (user behaviors nested in a body follow the same `ISerializableBehavior` + factory contract), the count binding and index key rebind by name, and read-side nesting is capped at 32 as a crafted-payload guard. Pre-v9 payloads read unchanged
 
 ---
 


### PR DESCRIPTION
## Summary

Three stacked features on the behaviors line of work (payload versions 7–9):

- **Typed event entry points**: `GraphBuilder.StartWithEvents()` builds one graph responding to several externally-raised typed events — `.On(key, e => chain)` binds a CLR event type to an entry chain through a Graph-scoped blackboard key (dispatch identity and delivery slot), with raise overloads on both machines, an `Otherwise` default, validator lints, and a sparse `EventEntryDto` payload section (v7). One event = one run; payload durability falls out of the blackboard artifacts, so snapshots are untouched.
- **Declarative behaviors**: a node authored as an in-order, fail-fast sequence of small data-shaped behaviors (`BehaviorState`/`AsyncBehaviorState` + `<TAgent>` twins). `BlackboardValue<T>` is the one binding primitive (literal or key, any scope), the agent is a call parameter delivered per execution (never stamped), output goes through the report channel, and the standard set (`Log`, `SetValue<T>`) rides graph payloads with zero options via the default `BehaviorRegistry` (v8).
- **Bounded repetition**: `Repeat`/`AsyncRepeat` (+ `<TAgent>` twins) run an inner behavior list a bounded, fixed number of times inside one node execution — trip count resolved once at entry (a key-bound count of ≤ 0 is vacuous success; the body cannot extend its own loop), optional 0-based index key, fail-fast iterations under the untouched node fault model, cancellation observed between iterations on the async paths. Bodies ride as nested behavior entry lists (v9) encoded recursively through a per-session entry codec, reconstructed by the default registry with zero options, read-side nesting capped at 32. Deliberately the only control-flow behavior — anything condition-driven stays in director nodes.

## Notes

- Pre-v9 payloads read unchanged; the MessagePack behavior field value grew a seventh (`Entries`) slot and the reader accepts both shapes.
- Public API baselines regenerated for the new surface; README examples mirrored compile-checked under `NxFSM.Examples/ReadmeExamples/`.

## Testing

- Full gate green via `dotnet run --project NxGraph.Build -- ci`: NxGraph.Tests 637/637, NxGraph.Serialization.Tests 193/193, coverage 80.67% line (threshold 70).
- New suites: `EventEntryTests`, `BehaviorTests`, `RepeatBehaviorTests`, `BehaviorSerializationTests`, `RepeatSerializationTests`; AllocationGate cases for behavior and repeat nodes at 0 B steady-state in both runtimes.