### PR TITLE
Harden machine lifecycle, bridge State.Log across runtimes, and add a parity conformance suite

### DIFF
--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -729,6 +729,44 @@ public class AllocationGateTests
         AssertZeroAlloc(token.ToStateMachine(new NoopSyncObserver()));
     }
 
+    // ── Cross-runtime log-report bridge: State.Log under the async machine ──
+
+    /// <summary>A sync state that calls Log every run — the bridge's hot path.</summary>
+    private sealed class GateLoggingState : State
+    {
+        protected override Result OnRun()
+        {
+            Log("gate-log");
+            return Result.Success;
+        }
+    }
+
+    [Test]
+    public async Task async_sync_state_log_without_observer_is_allocation_free()
+    {
+        // Observer-less async machine: both report slots are wired null, so Log must cost
+        // exactly its two null checks.
+        Graph graph = GraphBuilder
+            .StartWith(new GateLoggingState())
+            .To(() => Result.Success)
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine());
+    }
+
+    [Test]
+    public async Task async_sync_state_log_with_observer_is_allocation_free()
+    {
+        // Bridged delivery: Log falls back to the machine-wired async callback and waits it
+        // out on the completed-successfully fast path — no task materialization.
+        Graph graph = GraphBuilder
+            .StartWith(new GateLoggingState())
+            .To(() => Result.Success)
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine(new NoopAsyncObserver()));
+    }
+
     // ── Event entry points (spec 013): typed raise + run ────────────────
 
     private readonly record struct GatePing(int Value);

--- a/NxGraph.Tests/Blackboards/BlackboardFsmIntegrationTests.cs
+++ b/NxGraph.Tests/Blackboards/BlackboardFsmIntegrationTests.cs
@@ -597,6 +597,65 @@ public class BlackboardFsmIntegrationTests
             Is.True, "Expected a Warning about the conflicting child schema.");
     }
 
+    // ── Lifecycle hardening: stamp-time throws at run start ──────────────
+
+    [Test]
+    public void sync_stamp_time_throw_at_run_start_does_not_leak_the_execute_gate()
+    {
+        // A run-start throw can also happen before any status transition: OnEnter's
+        // ApplyExecutionContext re-stamps the machine's boards onto the graph, and a nested
+        // child validating a conflicting Graph-scoped schema throws with the status still
+        // Created. The run-start catch must release the execute gate (and Reset() clears it
+        // defensively on the Created/Ready path) so a corrected rebind can execute —
+        // previously the machine was permanently locked, every Execute() throwing
+        // "already executing" and Reset() returning Success without unlocking.
+        BlackboardSchema childSchema = new("child");
+        childSchema.Register<int>("x");
+        Graph child = GraphBuilder
+            .StartWith(() => Result.Success)
+            .WithSchema(childSchema)
+            .Build();
+
+        // The parent declares no Graph schema of its own, so a bound board is validated only
+        // by the nested child during the stamping walk.
+        Graph parent = GraphBuilder
+            .StartWith(() => Result.Success)
+            .SubGraph(ParallelStepMode.RunToJoin, child)
+            .Build();
+
+        StateMachine machine = parent.ToStateMachine();
+
+        BlackboardSchema wrongSchema = new("wrong");
+        wrongSchema.Register<int>("y");
+        // The bind-time stamp already walks into the child and hits the conflict; the board
+        // stays in the machine's context (bound before the walk), so run start re-throws.
+        Assert.Throws<InvalidOperationException>(() => machine.SetBlackboard(new Blackboard(wrongSchema)));
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(() => machine.Execute());
+        Assert.Multiple(() =>
+        {
+            Assert.That(ex!.Message, Does.Contain("does not match"),
+                "The run-start throw is the schema conflict, not a leaked-gate 'already executing'.");
+            Assert.That(machine.Status, Is.EqualTo(ExecutionStatus.Created),
+                "The throw happened before any status transition.");
+        });
+
+        Assert.That(machine.Reset(), Is.EqualTo(Result.Success),
+            "Reset() on the Created/Ready path reports Success (and defensively clears the gate).");
+
+        // Correct the binding: a board with the child's declared schema stamps cleanly...
+        machine.SetBlackboard(new Blackboard(childSchema));
+
+        // ...and the machine executes to completion — the gate was not leaked.
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
+
     private sealed class RawLogic : IAsyncLogic
     {
         public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => ResultHelpers.Success;

--- a/NxGraph.Tests/LogReportBridgeTests.cs
+++ b/NxGraph.Tests/LogReportBridgeTests.cs
@@ -1,0 +1,320 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Codifies the cross-runtime log-report bridge: <see cref="State"/>.<c>Log</c> must reach
+/// the observer under all four machines — the sync machines wire the sync callback, the
+/// async machines wire the async slot and <c>Log</c> falls back to it, waiting a genuinely
+/// asynchronous observer out so delivery completes before <c>Log</c> returns. Also codifies
+/// the per-visit reassignment contract across machines sharing one graph: both report slots
+/// are machine-owned per visit, so reports never leak to a previously-running machine's
+/// observer (in either direction, with or without an observer on the current machine).
+/// </summary>
+[TestFixture]
+public class LogReportBridgeTests
+{
+    // ── Four-runtime delivery (the spec-017 repro as a regression) ──────
+
+    /// <summary>Two named sync states, each emitting one message via State.Log.</summary>
+    private static Graph LoggingChain()
+    {
+        return GraphBuilder
+            .StartWith(new LoggingState("from-a")).SetName("a")
+            .To(new LoggingState("from-b")).SetName("b")
+            .Build();
+    }
+
+    [Test]
+    public void sync_state_log_reaches_the_sync_machine_observer()
+    {
+        RecordingSyncObserver observer = new();
+        StateMachine machine = LoggingChain().ToStateMachine(observer);
+
+        Result result = RunToEnd(machine);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(observer.Messages, Is.EqualTo(new[] { "from-a", "from-b" }));
+            Assert.That(observer.NodeNames, Is.EqualTo(new[] { "a", "b" }));
+        });
+    }
+
+    [Test]
+    public async Task sync_state_log_reaches_the_async_machine_observer()
+    {
+        // The original repro: before the bridge the async machine wired only the async
+        // slot, State.Log read only the sync one, and the message was silently dropped.
+        RecordingAsyncObserver observer = new();
+        AsyncStateMachine machine = LoggingChain().ToAsyncStateMachine(observer);
+
+        Result result = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(observer.Messages, Is.EqualTo(new[] { "from-a", "from-b" }));
+            Assert.That(observer.NodeNames, Is.EqualTo(new[] { "a", "b" }));
+        });
+    }
+
+    [Test]
+    public void sync_state_log_reaches_the_token_machine_observer()
+    {
+        RecordingTokenObserver observer = new();
+        TokenMachine machine = LoggingChain().ToTokenMachine(observer);
+        machine.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = machine.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(observer.Messages, Is.EqualTo(new[] { "from-a", "from-b" }));
+            Assert.That(observer.NodeNames, Is.EqualTo(new[] { "a", "b" }));
+            Assert.That(observer.TokenIds, Is.EqualTo(new[] { 0, 0 }));
+        });
+    }
+
+    [Test]
+    public async Task sync_state_log_reaches_the_async_token_machine_observer()
+    {
+        RecordingAsyncTokenObserver observer = new();
+        AsyncTokenMachine machine = LoggingChain().ToAsyncTokenMachine(observer);
+
+        Result result = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(observer.Messages, Is.EqualTo(new[] { "from-a", "from-b" }));
+            Assert.That(observer.NodeNames, Is.EqualTo(new[] { "a", "b" }));
+            Assert.That(observer.TokenIds, Is.EqualTo(new[] { 0, 0 }));
+        });
+    }
+
+    // ── Delivery-before-return for genuinely asynchronous observers ─────
+
+    [Test]
+    public async Task async_observer_delivery_completes_before_log_returns()
+    {
+        YieldingAsyncObserver observer = new();
+        DeliveryProbeState probe = new(observer);
+        AsyncStateMachine machine = GraphBuilder
+            .StartWith(probe)
+            .ToAsyncStateMachine(observer);
+
+        Result result = await machine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(probe.MessagesSeenAfterLog, Is.EqualTo(1),
+                "An observer completing asynchronously must still have recorded the report " +
+                "before State.Log returned (delivery-before-return).");
+        });
+    }
+
+    // ── Observer-less machines: Log is a no-op ──────────────────────────
+
+    [Test]
+    public async Task log_from_sync_state_is_a_noop_on_an_observer_less_async_machine()
+    {
+        AsyncStateMachine machine = LoggingChain().ToAsyncStateMachine();
+
+        Result result = await machine.ExecuteAsync();
+
+        Assert.That(result, Is.EqualTo(Result.Success));
+    }
+
+    // ── Machines sharing one graph: per-visit reassignment contract ─────
+
+    [Test]
+    public async Task interleaved_async_machines_sharing_one_graph_attribute_reports_to_their_own_observer()
+    {
+        Graph shared = LoggingChain();
+        RecordingAsyncObserver first = new();
+        RecordingAsyncObserver second = new();
+        AsyncStateMachine machineA = shared.ToAsyncStateMachine(first);
+        AsyncStateMachine machineB = shared.ToAsyncStateMachine(second);
+
+        await machineA.ExecuteAsync();
+        await machineB.ExecuteAsync();
+        await machineA.ExecuteAsync();
+        await machineB.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.Messages, Has.Count.EqualTo(4),
+                "Two runs over the two-node chain report twice each to this machine's observer.");
+            Assert.That(second.Messages, Has.Count.EqualTo(4));
+        });
+    }
+
+    [Test]
+    public async Task interleaved_sync_and_async_machines_sharing_one_graph_attribute_reports_to_their_own_observer()
+    {
+        Graph shared = LoggingChain();
+        RecordingSyncObserver syncObserver = new();
+        RecordingAsyncObserver asyncObserver = new();
+        StateMachine syncMachine = shared.ToStateMachine(syncObserver);
+        AsyncStateMachine asyncMachine = shared.ToAsyncStateMachine(asyncObserver);
+
+        RunToEnd(syncMachine);
+        await asyncMachine.ExecuteAsync();
+        RunToEnd(syncMachine);
+        await asyncMachine.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(syncObserver.Messages, Has.Count.EqualTo(4));
+            Assert.That(asyncObserver.Messages, Has.Count.EqualTo(4));
+        });
+    }
+
+    [Test]
+    public async Task observer_less_sync_machine_does_not_leak_reports_to_a_previous_async_machines_observer()
+    {
+        // Without the per-visit clearing of the async slot, the observer-less sync machine
+        // would null only SyncLogReport and State.Log would fall back to the async callback
+        // the async machine left behind — delivering this run's reports to that machine's
+        // observer with stale attribution.
+        Graph shared = LoggingChain();
+        RecordingAsyncObserver asyncObserver = new();
+        AsyncStateMachine asyncMachine = shared.ToAsyncStateMachine(asyncObserver);
+        StateMachine observerLess = shared.ToStateMachine();
+
+        await asyncMachine.ExecuteAsync();
+        RunToEnd(observerLess);
+
+        Assert.That(asyncObserver.Messages, Has.Count.EqualTo(2),
+            "The observer-less sync run must not deliver through the stale async callback.");
+    }
+
+    [Test]
+    public async Task observer_less_async_machine_does_not_leak_reports_to_a_previous_sync_machines_observer()
+    {
+        // Mirror case: the observer-less async machine nulls the async slot and must also
+        // clear the sync callback the sync machine left behind, or State.Log would prefer it.
+        Graph shared = LoggingChain();
+        RecordingSyncObserver syncObserver = new();
+        StateMachine syncMachine = shared.ToStateMachine(syncObserver);
+        AsyncStateMachine observerLess = shared.ToAsyncStateMachine();
+
+        RunToEnd(syncMachine);
+        await observerLess.ExecuteAsync();
+
+        Assert.That(syncObserver.Messages, Has.Count.EqualTo(2),
+            "The observer-less async run must not deliver through the stale sync callback.");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private static Result RunToEnd(StateMachine machine)
+    {
+        Result result = machine.Execute();
+        while (result == Result.InProgress)
+        {
+            result = machine.Execute();
+        }
+
+        return result;
+    }
+
+    /// <summary>A sync state that emits one log message per run via State.Log.</summary>
+    private sealed class LoggingState(string message) : State
+    {
+        protected override Result OnRun()
+        {
+            Log(message);
+            return Result.Success;
+        }
+    }
+
+    /// <summary>
+    /// Logs once, then captures how many reports the observer had recorded at the moment
+    /// Log returned — the delivery-before-return probe.
+    /// </summary>
+    private sealed class DeliveryProbeState(YieldingAsyncObserver observer) : State
+    {
+        public int MessagesSeenAfterLog = -1;
+
+        protected override Result OnRun()
+        {
+            Log("bridged");
+            MessagesSeenAfterLog = observer.Messages.Count;
+            return Result.Success;
+        }
+    }
+
+    private sealed class RecordingSyncObserver : IStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+        public readonly List<string> NodeNames = [];
+
+        void IStateMachineObserver.OnLogReport(NodeId nodeId, string message)
+        {
+            Messages.Add(message);
+            NodeNames.Add(nodeId.Name);
+        }
+    }
+
+    private sealed class RecordingAsyncObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+        public readonly List<string> NodeNames = [];
+
+        public ValueTask OnLogReport(NodeId nodeId, string message, CancellationToken ct = default)
+        {
+            Messages.Add(message);
+            NodeNames.Add(nodeId.Name);
+            return default;
+        }
+    }
+
+    /// <summary>Records on a thread-pool hop so recording genuinely completes asynchronously.</summary>
+    private sealed class YieldingAsyncObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+
+        public async ValueTask OnLogReport(NodeId nodeId, string message, CancellationToken ct = default)
+        {
+            await Task.Yield();
+            Messages.Add(message);
+        }
+    }
+
+    private sealed class RecordingTokenObserver : ITokenMachineObserver
+    {
+        public readonly List<string> Messages = [];
+        public readonly List<string> NodeNames = [];
+        public readonly List<int> TokenIds = [];
+
+        void ITokenMachineObserver.OnLogReport(int tokenId, NodeId nodeId, string message)
+        {
+            Messages.Add(message);
+            NodeNames.Add(nodeId.Name);
+            TokenIds.Add(tokenId);
+        }
+    }
+
+    private sealed class RecordingAsyncTokenObserver : IAsyncTokenMachineObserver
+    {
+        public readonly List<string> Messages = [];
+        public readonly List<string> NodeNames = [];
+        public readonly List<int> TokenIds = [];
+
+        public ValueTask OnLogReport(int tokenId, NodeId nodeId, string message, CancellationToken ct = default)
+        {
+            Messages.Add(message);
+            NodeNames.Add(nodeId.Name);
+            TokenIds.Add(tokenId);
+            return default;
+        }
+    }
+}

--- a/NxGraph.Tests/ObserverExceptionTests.cs
+++ b/NxGraph.Tests/ObserverExceptionTests.cs
@@ -2,6 +2,7 @@ using NxGraph.Authoring;
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
+using NxGraph.Tokens;
 
 namespace NxGraph.Tests;
 
@@ -146,5 +147,204 @@ public class ObserverExceptionTests
             Assert.That(fsm.Status, Is.EqualTo(ExecutionStatus.Completed),
                 "A successful run must not be flipped to Failed by an observer throw.");
         });
+    }
+
+    // ── Sync mirrors of the run-start regression (spec: sync machine lifecycle hardening) ──
+
+    private sealed class SyncThrowOnceOnStartedObserver : IStateMachineObserver
+    {
+        private bool _thrown;
+
+        public void OnStateMachineStarted(NodeId graphId)
+        {
+            if (!_thrown)
+            {
+                _thrown = true;
+                throw new InvalidOperationException("observer started boom");
+            }
+        }
+    }
+
+    [Test]
+    public void sync_observer_exception_at_run_start_does_not_permanently_lock_the_machine()
+    {
+        // Regression (sync mirror of the async fix): an observer throwing during Execute()'s
+        // run-start sequence escaped with the execute gate still held and the status stuck at
+        // Starting, so every later Execute()/Reset() threw forever with no recovery API.
+        StateMachine fsm = GraphBuilder
+            .StartWith(() => Result.Success)
+            .ToStateMachine(new SyncThrowOnceOnStartedObserver());
+
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(() => fsm.Execute());
+        Assert.That(ex!.Message, Does.Contain("observer started boom"),
+            "The first Execute() must rethrow the observer exception itself.");
+
+        Result result = fsm.Execute();
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success),
+                "The machine must stay usable after an observer throw at run start.");
+            Assert.That(fsm.Status, Is.EqualTo(ExecutionStatus.Ready),
+                "RestartPolicy.Auto resets the machine to Ready after the successful run.");
+        });
+    }
+
+    [Test]
+    public void sync_reset_after_a_run_start_throw_returns_success_and_unlocks()
+    {
+        // After a run-start throw the status is repaired to Ready and the gate is released;
+        // Reset() must take the Created/Ready early-return, report Success, and leave the
+        // machine executable (that path also defensively clears the gate).
+        StateMachine fsm = GraphBuilder
+            .StartWith(() => Result.Success)
+            .ToStateMachine(new SyncThrowOnceOnStartedObserver());
+
+        Assert.Throws<InvalidOperationException>(() => fsm.Execute());
+
+        Assert.That(fsm.Reset(), Is.EqualTo(Result.Success),
+            "Reset() after a repaired run-start throw reports Success.");
+        Assert.That(fsm.Execute(), Is.EqualTo(Result.Success),
+            "The gate must not be leaked: the next Execute() runs to completion.");
+    }
+
+    private sealed class ResetCountingThrowOnceObserver : IStateMachineObserver
+    {
+        public int ResetCount;
+        private bool _thrown;
+
+        public void OnStateMachineReset(NodeId graphId)
+        {
+            ResetCount++;
+            if (!_thrown)
+            {
+                _thrown = true;
+                throw new InvalidOperationException("observer reset boom");
+            }
+        }
+    }
+
+    [Test]
+    public void sync_reset_is_idempotent_after_an_observer_interrupted_a_previous_reset()
+    {
+        // Parity with AsyncStateMachine.ResetCore: Reset() finding the machine already at
+        // Resetting (reachable only when an observer threw out of a previous reset's
+        // OnStateMachineReset notification) returns Success without re-entering the reset.
+        // Re-transitioning Resetting -> Resetting would trip TransitionTo's debug assert in
+        // DEBUG builds and must never fire a duplicate OnStateMachineReset.
+        ResetCountingThrowOnceObserver observer = new();
+        StateMachine fsm = GraphBuilder
+            .StartWith(() => Result.Success)
+            .ToStateMachine(observer);
+        fsm.SetRestartPolicy(RestartPolicy.Manual);
+
+        Assert.That(fsm.Execute(), Is.EqualTo(Result.Success));
+        Assert.Throws<InvalidOperationException>(() => fsm.Reset());
+        Assert.That(fsm.Status, Is.EqualTo(ExecutionStatus.Resetting),
+            "The interrupted reset leaves the machine at Resetting.");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fsm.Reset(), Is.EqualTo(Result.Success),
+                "A Reset() finding Resetting must be idempotent.");
+            Assert.That(observer.ResetCount, Is.EqualTo(1),
+                "OnStateMachineReset must not fire a second time.");
+        });
+
+        Assert.That(fsm.Execute(), Is.EqualTo(Result.Success),
+            "The machine must remain runnable after the idempotent reset.");
+    }
+
+    // ── TokenMachine twins ──────────────────────────────────────────────
+
+    private sealed class TokenThrowOnceAtRunStartObserver(bool onStarted) : ITokenMachineObserver
+    {
+        private bool _thrown;
+
+        public void OnTokenMachineStarted(NodeId graphId)
+        {
+            if (onStarted && !_thrown)
+            {
+                _thrown = true;
+                throw new InvalidOperationException("token observer started boom");
+            }
+        }
+
+        public void OnTokenSpawned(int tokenId, int parentTokenId, NodeId at)
+        {
+            if (!onStarted && !_thrown)
+            {
+                _thrown = true;
+                throw new InvalidOperationException("token observer spawned boom");
+            }
+        }
+    }
+
+    [TestCase(true, Description = "throw from OnTokenMachineStarted — before ClearRunState")]
+    [TestCase(false, Description = "throw from OnTokenSpawned — after ClearRunState/Alloc")]
+    public void token_machine_observer_exception_at_run_start_does_not_permanently_lock_the_machine(bool onStarted)
+    {
+        // Sync token twin of the run-start regression: a throw from the Starting notification
+        // or the root-token spawn escaped OnEnter with the execute gate held and the status
+        // stuck at Starting. Whatever ClearRunState/SpawnRootToken already did is benign —
+        // the next run start clears the run state again.
+        TokenMachine machine = GraphBuilder
+            .StartWith(() => Result.Success)
+            .Build()
+            .ToTokenMachine(new TokenThrowOnceAtRunStartObserver(onStarted));
+
+        Assert.Throws<InvalidOperationException>(() => machine.Execute());
+
+        Result result = machine.Execute();
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success),
+                "The machine must stay usable after an observer throw at run start.");
+            Assert.That(machine.Status, Is.EqualTo(ExecutionStatus.Ready),
+                "RestartPolicy.Auto resets the machine to Ready after the successful run.");
+        });
+    }
+
+    private sealed class TokenResetCountingThrowOnceObserver : ITokenMachineObserver
+    {
+        public int ResetCount;
+        private bool _thrown;
+
+        public void OnTokenMachineReset(NodeId graphId)
+        {
+            ResetCount++;
+            if (!_thrown)
+            {
+                _thrown = true;
+                throw new InvalidOperationException("token observer reset boom");
+            }
+        }
+    }
+
+    [Test]
+    public void token_machine_reset_is_idempotent_after_an_observer_interrupted_a_previous_reset()
+    {
+        // TokenMachine twin of the Resetting-idempotence convergence with the async machines.
+        TokenResetCountingThrowOnceObserver observer = new();
+        TokenMachine machine = GraphBuilder
+            .StartWith(() => Result.Success)
+            .Build()
+            .ToTokenMachine(observer);
+        machine.SetRestartPolicy(RestartPolicy.Manual);
+
+        Assert.That(machine.Execute(), Is.EqualTo(Result.Success));
+        Assert.Throws<InvalidOperationException>(() => machine.Reset());
+        Assert.That(machine.Status, Is.EqualTo(ExecutionStatus.Resetting),
+            "The interrupted reset leaves the machine at Resetting.");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(machine.Reset(), Is.EqualTo(Result.Success),
+                "A Reset() finding Resetting must be idempotent.");
+            Assert.That(observer.ResetCount, Is.EqualTo(1),
+                "OnTokenMachineReset must not fire a second time.");
+        });
+
+        Assert.That(machine.Execute(), Is.EqualTo(Result.Success),
+            "The machine must remain runnable after the idempotent reset.");
     }
 }

--- a/NxGraph.Tests/Parity/ParityConformanceTests.cs
+++ b/NxGraph.Tests/Parity/ParityConformanceTests.cs
@@ -1,0 +1,455 @@
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests.Parity;
+
+/// <summary>
+/// Cross-runtime parity conformance matrix for the FSM runtimes: every scenario runs through
+/// the four adapters (sync RunToJoin, sync stepped, async ExecuteAsync, async StepAsync) and
+/// must produce the same observable trace, order-exact and unnormalized — stepped ≡ full-run
+/// within each runtime, sync ≡ async across them. The per-feature fixtures stay the
+/// authoritative spec of each feature's details; this suite pins only the cross-runtime
+/// equivalence, so future drift is caught by CI instead of by review. New features should
+/// add a scenario here alongside their twin fixtures.
+/// </summary>
+[TestFixture]
+public class ParityConformanceTests
+{
+    // ── Recipes (invoked fresh per adapter so closure state resets) ─────
+
+    private static ParityScenario LinearChain()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("a")
+            .To(() => Result.Success).SetName("b")
+            .To(() => Result.Success).SetName("c")
+            .Build();
+        return new ParityScenario { Graph = graph };
+    }
+
+    private static ParityScenario TerminalFailure()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("a")
+            .To(() => Result.Failure).SetName("boom")
+            .Build();
+        return new ParityScenario { Graph = graph };
+    }
+
+    private static ParityScenario FailureEdgeReroute()
+    {
+        StateToken faulty = GraphBuilder.StartWith(() => Result.Failure).SetName("faulty");
+        NodeId rescueId = faulty.Builder.AddNode(new RelayState(() => Result.Success));
+        StateToken rescue = faulty.Builder.TokenFor(rescueId).SetName("rescue");
+        faulty.OnError(rescue);
+        return new ParityScenario { Graph = faulty.Build() };
+    }
+
+    private static ParityScenario RetryThenSucceed()
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() =>
+            {
+                executions++;
+                return executions < 3 ? Result.Failure : Result.Success;
+            })
+            .SetName("flaky").Retry(3) // zero backoff: timing never enters the trace
+            .To(() => Result.Success).SetName("after")
+            .Build();
+        ParityScenario scenario = new() { Graph = graph };
+        scenario.Probes.Add(("flaky-executions", () => executions));
+        return scenario;
+    }
+
+    private static ParityScenario RetryExhaustedThenEdge()
+    {
+        int executions = 0;
+        StateToken doomed = GraphBuilder
+            .StartWith(() =>
+            {
+                executions++;
+                return Result.Failure;
+            })
+            .SetName("doomed").Retry(2);
+        NodeId rescueId = doomed.Builder.AddNode(new RelayState(() => Result.Success));
+        doomed.OnError(doomed.Builder.TokenFor(rescueId).SetName("rescue"));
+        ParityScenario scenario = new() { Graph = doomed.Build() };
+        scenario.Probes.Add(("doomed-executions", () => executions));
+        return scenario;
+    }
+
+    private static ParityScenario GotoLoop()
+    {
+        int laps = 0;
+        StateToken top = GraphBuilder.StartWith(() => Result.Success).SetName("top");
+        StateToken work = top.To(() =>
+        {
+            laps++;
+            return Result.Success;
+        }).SetName("work");
+        Dsl.BranchBuilder thenBranch = work.If(() => laps < 3)
+            .Then(() => Result.Success).SetName("again");
+        thenBranch.Builder.TokenFor(thenBranch.Tip).Goto("top");
+        Dsl.BranchEnd done = thenBranch.Else(() => Result.Success).SetName("done");
+        ParityScenario scenario = new() { Graph = done.Build() };
+        scenario.Probes.Add(("laps", () => laps));
+        return scenario;
+    }
+
+    private static ParityScenario IfBranch(bool takeThen)
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("ask")
+            .If(() => takeThen)
+            .Then(() => Result.Success).SetName("yes")
+            .Else(() => Result.Success).SetName("no")
+            .Build();
+        return new ParityScenario { Graph = graph };
+    }
+
+    private static ParityScenario SwitchRouting()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("pick")
+            .Switch(() => "beta")
+            .Case("alpha", () => Result.Success)
+            .Case("beta", () => Result.Success)
+            .Default(() => Result.Failure)
+            .End().SetName("switch")
+            .Build();
+        return new ParityScenario { Graph = graph };
+    }
+
+    private static ParityScenario OutcomeCodes()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("work")
+            .To(() => Result.Success).SetName("finish").WithOutcome(42, "Done")
+            .Build();
+        return new ParityScenario { Graph = graph };
+    }
+
+    private static ParityScenario EnterExitActions()
+    {
+        int flakyEntered = 0, flakyExited = 0, executions = 0, afterEntered = 0, afterExited = 0;
+        Graph graph = GraphBuilder
+            .StartWith(() =>
+            {
+                executions++;
+                return executions < 3 ? Result.Failure : Result.Success;
+            })
+            .SetName("flaky").Retry(3)
+            .OnEnter(() => flakyEntered++).OnExit(() => flakyExited++)
+            .To(() => Result.Success).SetName("after")
+            .OnEnter(() => afterEntered++).OnExit(() => afterExited++)
+            .Build();
+        ParityScenario scenario = new() { Graph = graph };
+        scenario.Probes.Add(("flaky-entered", () => flakyEntered));
+        scenario.Probes.Add(("flaky-exited", () => flakyExited));
+        scenario.Probes.Add(("flaky-executions", () => executions));
+        scenario.Probes.Add(("after-entered", () => afterEntered));
+        scenario.Probes.Add(("after-exited", () => afterExited));
+        return scenario;
+    }
+
+    /// <summary>A sync state emitting one message per run via State.Log (the spec-017 bridge).</summary>
+    private sealed class ChattyState(string message) : State
+    {
+        protected override Result OnRun()
+        {
+            Log(message);
+            return Result.Success;
+        }
+    }
+
+    private static ParityScenario StateLogChain()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(new ChattyState("hello-from-a")).SetName("a")
+            .To(new ChattyState("hello-from-b")).SetName("b")
+            .Build();
+        return new ParityScenario { Graph = graph };
+    }
+
+    // ── Scenario matrix ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task linear_success_chain_runs_identically()
+    {
+        List<string> baseline = await ParityRunner.AssertFsmParityAsync(LinearChain, ParityDrives.OneRunAsync);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("run-result Success"));
+            Assert.That(baseline, Does.Contain("final-status Ready"), "RestartPolicy.Auto resets to Ready.");
+        });
+    }
+
+    [Test]
+    public async Task terminal_failure_without_failure_edge_runs_identically()
+    {
+        List<string> baseline =
+            await ParityRunner.AssertFsmParityAsync(TerminalFailure, ParityDrives.OneRunAsync);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("run-result Failure"));
+            Assert.That(baseline, Does.Contain("machine-completed Failure"));
+        });
+    }
+
+    [Test]
+    public async Task failure_edge_reroute_runs_identically()
+    {
+        List<string> baseline =
+            await ParityRunner.AssertFsmParityAsync(FailureEdgeReroute, ParityDrives.OneRunAsync);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("failed faulty result"),
+                "The failure-edge reroute announces the failure before transitioning.");
+            Assert.That(baseline, Does.Contain("transition faulty->rescue"));
+            Assert.That(baseline, Does.Contain("run-result Success"));
+        });
+    }
+
+    [Test]
+    public async Task retry_then_succeed_runs_identically()
+    {
+        List<string> baseline =
+            await ParityRunner.AssertFsmParityAsync(RetryThenSucceed, ParityDrives.OneRunAsync);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("run-result Success"));
+            Assert.That(baseline, Does.Contain("probe flaky-executions=3"),
+                "The retry policy re-runs the node in place until it succeeds.");
+        });
+    }
+
+    [Test]
+    public async Task retry_exhausted_then_failure_edge_runs_identically()
+    {
+        List<string> baseline =
+            await ParityRunner.AssertFsmParityAsync(RetryExhaustedThenEdge, ParityDrives.OneRunAsync);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("probe doomed-executions=2"),
+                "Retries are consumed before the failure edge is taken.");
+            Assert.That(baseline, Does.Contain("transition doomed->rescue"));
+            Assert.That(baseline, Does.Contain("run-result Success"));
+        });
+    }
+
+    [Test]
+    public async Task goto_back_edge_loop_with_bounded_exit_runs_identically()
+    {
+        List<string> baseline = await ParityRunner.AssertFsmParityAsync(GotoLoop, ParityDrives.OneRunAsync);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("probe laps=3"));
+            Assert.That(baseline, Does.Contain("entered done"));
+            Assert.That(baseline, Does.Contain("run-result Success"));
+        });
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task if_branching_runs_identically(bool takeThen)
+    {
+        List<string> baseline =
+            await ParityRunner.AssertFsmParityAsync(() => IfBranch(takeThen), ParityDrives.OneRunAsync);
+        Assert.That(baseline, Does.Contain(takeThen ? "entered yes" : "entered no"));
+    }
+
+    [Test]
+    public async Task switch_routing_runs_identically()
+    {
+        List<string> baseline =
+            await ParityRunner.AssertFsmParityAsync(SwitchRouting, ParityDrives.OneRunAsync);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("transition switch->#2"),
+                "The 'beta' case node (index 2) is selected by the director.");
+            Assert.That(baseline, Does.Contain("run-result Success"));
+        });
+    }
+
+    [Test]
+    public async Task outcome_codes_and_last_outcome_run_identically()
+    {
+        List<string> baseline =
+            await ParityRunner.AssertFsmParityAsync(OutcomeCodes, ParityDrives.OneRunAsync);
+        Assert.That(baseline, Does.Contain("last-outcome 42 name=Done"),
+            "LastOutcome/LastOutcomeName must report the terminal node's declared outcome.");
+    }
+
+    [Test]
+    public async Task enter_exit_action_counts_run_identically()
+    {
+        List<string> baseline =
+            await ParityRunner.AssertFsmParityAsync(EnterExitActions, ParityDrives.OneRunAsync);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("probe flaky-entered=1"),
+                "Enter actions fire once per visit — in-place retries do not re-fire them.");
+            Assert.That(baseline, Does.Contain("probe flaky-exited=1"));
+            Assert.That(baseline, Does.Contain("probe flaky-executions=3"));
+            Assert.That(baseline, Does.Contain("probe after-entered=1"));
+            Assert.That(baseline, Does.Contain("probe after-exited=1"));
+        });
+    }
+
+    [Test]
+    public async Task state_log_delivery_runs_identically()
+    {
+        // Pins the State.Log report bridge (spec 017): the sync machines wire the sync
+        // callback, the async machines wire the async slot and Log falls back to it —
+        // delivery and attribution must be identical either way.
+        List<string> baseline =
+            await ParityRunner.AssertFsmParityAsync(StateLogChain, ParityDrives.OneRunAsync);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("log a hello-from-a"));
+            Assert.That(baseline, Does.Contain("log b hello-from-b"));
+        });
+    }
+
+    [Test]
+    public async Task observer_throw_at_run_start_recovers_identically()
+    {
+        // Pins the run-start gate-repair hardening (spec 016) on all four surfaces: the
+        // observer throw escapes to the caller, the machine repairs to Ready with the gate
+        // released, and the next run completes with a full clean trace.
+        List<string> baseline = await ParityRunner.AssertFsmParityAsync(
+            LinearChain,
+            static async (machine, trace) =>
+            {
+                try
+                {
+                    await machine.RunToEndAsync();
+                    trace.Add("no-throw");
+                }
+                catch (Exception ex)
+                {
+                    trace.Add($"threw {ex.GetType().Name}");
+                }
+
+                trace.Add($"status-after-throw {machine.Status}");
+                Result result = await machine.RunToEndAsync();
+                ParityDrives.AppendSurface(machine, trace, result);
+            },
+            observerThrowOnceAt: "machine-started");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("threw InvalidOperationException"));
+            Assert.That(baseline, Does.Contain("status-after-throw Ready"),
+                "Both runtimes must repair the transient status and release the gate.");
+            Assert.That(baseline, Does.Contain("run-result Success"));
+        });
+    }
+
+    [Test]
+    public async Task suspend_mid_run_resume_and_complete_runs_identically()
+    {
+        // The stepped adapters step once, suspend, resume onto a fresh machine over the same
+        // graph, and finish; the full-run adapters provide the uninterrupted baseline.
+        // Resume replays nothing, so the stitched trace must equal the uninterrupted one.
+        List<string> baseline = await ParityRunner.AssertSuspendResumeParityAsync(LinearChain);
+        Assert.That(baseline, Does.Contain("run-result Success"));
+    }
+
+    // ── Restart policies ────────────────────────────────────────────────
+
+    [Test]
+    public async Task restart_policy_auto_reruns_identically()
+    {
+        List<string> baseline = await ParityRunner.AssertFsmParityAsync(
+            LinearChain,
+            static async (machine, trace) =>
+            {
+                await ParityDrives.OneRunAsync(machine, trace);
+                await ParityDrives.OneRunAsync(machine, trace);
+            });
+
+        Assert.That(baseline.Count(line => line == "machine-completed Success"), Is.EqualTo(2),
+            "Auto restart re-runs the machine from scratch on the second call.");
+    }
+
+    [Test]
+    public async Task restart_policy_manual_throws_identically()
+    {
+        List<string> baseline = await ParityRunner.AssertFsmParityAsync(
+            LinearChain,
+            static async (machine, trace) =>
+            {
+                machine.SetRestartPolicy(RestartPolicy.Manual);
+                await ParityDrives.OneRunAsync(machine, trace);
+                await ParityDrives.RunExpectingThrowAsync(machine, trace);
+                trace.Add($"status-after-throw {machine.Status}");
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("final-status Completed"),
+                "Manual restart keeps the terminal status until Reset().");
+            Assert.That(baseline, Does.Contain("threw InvalidOperationException"));
+            Assert.That(baseline, Does.Contain("status-after-throw Completed"));
+        });
+    }
+
+    [Test]
+    public async Task restart_policy_ignore_returns_cached_result_identically()
+    {
+        List<string> baseline = await ParityRunner.AssertFsmParityAsync(
+            TerminalFailure,
+            static async (machine, trace) =>
+            {
+                machine.SetRestartPolicy(RestartPolicy.Ignore);
+                await ParityDrives.OneRunAsync(machine, trace);
+                // The second attempt must return the cached terminal result while
+                // producing zero observer events on every adapter.
+                await ParityDrives.OneRunAsync(machine, trace);
+            });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline.Count(line => line == "run-result Failure"), Is.EqualTo(2),
+                "The ignored attempt reports the cached terminal result.");
+            Assert.That(baseline.Count(line => line == "machine-completed Failure"), Is.EqualTo(1),
+                "The ignored attempt fires no lifecycle events.");
+            Assert.That(baseline, Does.Contain("final-status Failed"));
+        });
+    }
+
+    // ── Composites (one shallow scenario; deep composite parity is covered
+    //    by the dedicated suspend/history fixtures) ───────────────────────
+
+    private static ParityScenario SubGraphComposite()
+    {
+        Graph child = GraphBuilder
+            .StartWith(() => Result.Success).SetName("child-a")
+            .To(() => Result.Success).SetName("child-b")
+            .Build();
+        Graph parent = GraphBuilder
+            .StartWith(() => Result.Success).SetName("before")
+            .SubGraph(ParallelStepMode.RunToJoin, child).SetName("nested")
+            .To(() => Result.Success).SetName("after")
+            .Build();
+        return new ParityScenario { Graph = parent };
+    }
+
+    [Test]
+    public async Task shallow_subgraph_composite_runs_identically()
+    {
+        // A sync RunToJoin child machine is executable from both runtimes (via the
+        // sync-logic adapter under the async machine), so one recipe serves all adapters.
+        List<string> baseline =
+            await ParityRunner.AssertFsmParityAsync(SubGraphComposite, ParityDrives.OneRunAsync);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("entered nested"));
+            Assert.That(baseline, Does.Contain("exited nested"));
+            Assert.That(baseline, Does.Contain("run-result Success"));
+        });
+    }
+}

--- a/NxGraph.Tests/Parity/ParityHarness.cs
+++ b/NxGraph.Tests/Parity/ParityHarness.cs
@@ -1,0 +1,803 @@
+using System.Text.RegularExpressions;
+using NxGraph.Authoring;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Tests.Parity;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cross-runtime parity conformance harness (spec: runtime dedup + parity).
+//
+// A scenario is a graph-builder recipe plus probes; per runtime an adapter runs
+// it and produces a normalized ordered trace collected from a recording
+// observer, with surface-level facts (terminal result, final status,
+// LastOutcome, thrown exception types, probe counters) appended as ordinary
+// trace lines. Traces are compared with order-exact equality; the only
+// normalizations applied are the documented mechanical differences between the
+// runtimes, each encoded exactly once in TraceNormalizer / the drive helpers
+// with a comment naming its source.
+//
+// Timing is excluded from traces by construction: no line ever carries a
+// timestamp or duration, because the time domain legitimately differs between
+// the runtimes (CLAUDE.md: "Backoff applies to the async runtime only; the
+// sync runtime retries next tick"). The matrix compares sequences, never
+// durations, and retry scenarios use zero backoff.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>Canonical event-line formatting shared by all recording observers.</summary>
+internal static class TraceFormat
+{
+    public static string Node(NodeId id) => string.IsNullOrEmpty(id.Name) ? $"#{id.Index}" : id.Name;
+
+    public static string Failed(NodeId id, Exception? ex) =>
+        ex is null ? $"failed {Node(id)} result" : $"failed {Node(id)} ex:{ex.GetType().Name}";
+}
+
+/// <summary>A graph recipe instantiation plus named probe counters read after the drive.</summary>
+internal sealed class ParityScenario
+{
+    public required Graph Graph { get; init; }
+
+    /// <summary>Read after the drive completes, appended to the trace in declaration order.</summary>
+    public List<(string Name, Func<int> Read)> Probes { get; } = [];
+}
+
+// ── Recording observers ─────────────────────────────────────────────────────
+
+/// <summary>
+/// Sync FSM recorder. <paramref name="throwOnceAt"/> makes the observer throw a single
+/// <see cref="InvalidOperationException"/> right after recording the first line starting
+/// with that prefix — used to pin the run-start gate-repair behavior identically across
+/// runtimes (the event is recorded first, so all adapters share the same trace prefix).
+/// Note the sync observer surface has no OnStateMachineCancelled — see
+/// <see cref="ParityAssert"/> normalization N3.
+/// </summary>
+internal sealed class SyncFsmRecorder(List<string> trace, string? throwOnceAt = null) : IStateMachineObserver
+{
+    private bool _thrown;
+
+    private void Record(string line)
+    {
+        trace.Add(line);
+        if (throwOnceAt is not null && !_thrown && line.StartsWith(throwOnceAt, StringComparison.Ordinal))
+        {
+            _thrown = true;
+            throw new InvalidOperationException("parity observer boom");
+        }
+    }
+
+    void IStateMachineObserver.OnStateEntered(NodeId id) => Record($"entered {TraceFormat.Node(id)}");
+
+    void IStateMachineObserver.OnStateExited(NodeId id) => Record($"exited {TraceFormat.Node(id)}");
+
+    void IStateMachineObserver.OnTransition(NodeId from, NodeId to) =>
+        Record($"transition {TraceFormat.Node(from)}->{TraceFormat.Node(to)}");
+
+    void IStateMachineObserver.OnStateFailed(NodeId id, Exception? ex) => Record(TraceFormat.Failed(id, ex));
+
+    void IStateMachineObserver.OnStateMachineReset(NodeId graphId) => Record("machine-reset");
+
+    void IStateMachineObserver.OnStateMachineStarted(NodeId graphId) => Record("machine-started");
+
+    void IStateMachineObserver.OnStateMachineCompleted(NodeId graphId, Result result) =>
+        Record($"machine-completed {result.Code}");
+
+    void IStateMachineObserver.StateMachineStatusChanged(NodeId graphId, ExecutionStatus prev,
+        ExecutionStatus next) => Record($"status {prev}->{next}");
+
+    void IStateMachineObserver.OnLogReport(NodeId nodeId, string message) =>
+        Record($"log {TraceFormat.Node(nodeId)} {message}");
+}
+
+/// <summary>Async FSM recorder — the <see cref="SyncFsmRecorder"/> twin over the async surface.</summary>
+internal sealed class AsyncFsmRecorder(List<string> trace, string? throwOnceAt = null) : IAsyncStateMachineObserver
+{
+    private bool _thrown;
+
+    private void Record(string line)
+    {
+        trace.Add(line);
+        if (throwOnceAt is not null && !_thrown && line.StartsWith(throwOnceAt, StringComparison.Ordinal))
+        {
+            _thrown = true;
+            throw new InvalidOperationException("parity observer boom");
+        }
+    }
+
+    public ValueTask OnStateEntered(NodeId id, CancellationToken ct = default)
+    {
+        Record($"entered {TraceFormat.Node(id)}");
+        return default;
+    }
+
+    public ValueTask OnStateExited(NodeId id, CancellationToken ct = default)
+    {
+        Record($"exited {TraceFormat.Node(id)}");
+        return default;
+    }
+
+    public ValueTask OnTransition(NodeId from, NodeId to, CancellationToken ct = default)
+    {
+        Record($"transition {TraceFormat.Node(from)}->{TraceFormat.Node(to)}");
+        return default;
+    }
+
+    public ValueTask OnStateFailed(NodeId id, Exception? ex, CancellationToken ct = default)
+    {
+        Record(TraceFormat.Failed(id, ex));
+        return default;
+    }
+
+    public ValueTask OnStateMachineReset(NodeId graphId, CancellationToken ct = default)
+    {
+        Record("machine-reset");
+        return default;
+    }
+
+    public ValueTask OnStateMachineStarted(NodeId graphId, CancellationToken ct = default)
+    {
+        Record("machine-started");
+        return default;
+    }
+
+    public ValueTask OnStateMachineCompleted(NodeId graphId, Result result, CancellationToken ct = default)
+    {
+        Record($"machine-completed {result.Code}");
+        return default;
+    }
+
+    public ValueTask OnStateMachineCancelled(NodeId graphId, CancellationToken ct = default)
+    {
+        Record("machine-cancelled");
+        return default;
+    }
+
+    public ValueTask StateMachineStatusChanged(NodeId graphId, ExecutionStatus prev, ExecutionStatus next,
+        CancellationToken ct = default)
+    {
+        Record($"status {prev}->{next}");
+        return default;
+    }
+
+    public ValueTask OnLogReport(NodeId nodeId, string message, CancellationToken ct = default)
+    {
+        Record($"log {TraceFormat.Node(nodeId)} {message}");
+        return default;
+    }
+}
+
+/// <summary>Sync token recorder — node events carry the token-id dimension (spec 007).</summary>
+internal sealed class SyncTokenRecorder(List<string> trace) : ITokenMachineObserver
+{
+    void ITokenMachineObserver.OnTokenSpawned(int tokenId, int parentTokenId, NodeId at) =>
+        trace.Add($"spawned t{tokenId} parent {parentTokenId} at {TraceFormat.Node(at)}");
+
+    void ITokenMachineObserver.OnTokenRetired(int tokenId, NodeId at, TokenRetireReason reason) =>
+        trace.Add($"retired t{tokenId} at {TraceFormat.Node(at)} {reason}");
+
+    void ITokenMachineObserver.OnJoinFired(NodeId joinNode, int survivingTokenId) =>
+        trace.Add($"join-fired {TraceFormat.Node(joinNode)} survivor t{survivingTokenId}");
+
+    void ITokenMachineObserver.OnStateEntered(int tokenId, NodeId id) =>
+        trace.Add($"entered t{tokenId} {TraceFormat.Node(id)}");
+
+    void ITokenMachineObserver.OnStateExited(int tokenId, NodeId id) =>
+        trace.Add($"exited t{tokenId} {TraceFormat.Node(id)}");
+
+    void ITokenMachineObserver.OnTransition(int tokenId, NodeId from, NodeId to) =>
+        trace.Add($"transition t{tokenId} {TraceFormat.Node(from)}->{TraceFormat.Node(to)}");
+
+    void ITokenMachineObserver.OnStateFailed(int tokenId, NodeId id, Exception? ex) =>
+        trace.Add(ex is null
+            ? $"failed t{tokenId} {TraceFormat.Node(id)} result"
+            : $"failed t{tokenId} {TraceFormat.Node(id)} ex:{ex.GetType().Name}");
+
+    void ITokenMachineObserver.OnLogReport(int tokenId, NodeId nodeId, string message) =>
+        trace.Add($"log t{tokenId} {TraceFormat.Node(nodeId)} {message}");
+
+    void ITokenMachineObserver.OnTokenMachineReset(NodeId graphId) => trace.Add("machine-reset");
+
+    void ITokenMachineObserver.OnTokenMachineStarted(NodeId graphId) => trace.Add("machine-started");
+
+    void ITokenMachineObserver.OnTokenMachineCompleted(NodeId graphId, Result result) =>
+        trace.Add($"machine-completed {result.Code}");
+
+    void ITokenMachineObserver.TokenMachineStatusChanged(NodeId graphId, ExecutionStatus prev,
+        ExecutionStatus next) => trace.Add($"status {prev}->{next}");
+}
+
+/// <summary>Async token recorder — the <see cref="SyncTokenRecorder"/> twin.</summary>
+internal sealed class AsyncTokenRecorder(List<string> trace) : IAsyncTokenMachineObserver
+{
+    public ValueTask OnTokenSpawned(int tokenId, int parentTokenId, NodeId at, CancellationToken ct = default)
+    {
+        trace.Add($"spawned t{tokenId} parent {parentTokenId} at {TraceFormat.Node(at)}");
+        return default;
+    }
+
+    public ValueTask OnTokenRetired(int tokenId, NodeId at, TokenRetireReason reason,
+        CancellationToken ct = default)
+    {
+        trace.Add($"retired t{tokenId} at {TraceFormat.Node(at)} {reason}");
+        return default;
+    }
+
+    public ValueTask OnJoinFired(NodeId joinNode, int survivingTokenId, CancellationToken ct = default)
+    {
+        trace.Add($"join-fired {TraceFormat.Node(joinNode)} survivor t{survivingTokenId}");
+        return default;
+    }
+
+    public ValueTask OnStateEntered(int tokenId, NodeId id, CancellationToken ct = default)
+    {
+        trace.Add($"entered t{tokenId} {TraceFormat.Node(id)}");
+        return default;
+    }
+
+    public ValueTask OnStateExited(int tokenId, NodeId id, CancellationToken ct = default)
+    {
+        trace.Add($"exited t{tokenId} {TraceFormat.Node(id)}");
+        return default;
+    }
+
+    public ValueTask OnTransition(int tokenId, NodeId from, NodeId to, CancellationToken ct = default)
+    {
+        trace.Add($"transition t{tokenId} {TraceFormat.Node(from)}->{TraceFormat.Node(to)}");
+        return default;
+    }
+
+    public ValueTask OnStateFailed(int tokenId, NodeId id, Exception? ex, CancellationToken ct = default)
+    {
+        trace.Add(ex is null
+            ? $"failed t{tokenId} {TraceFormat.Node(id)} result"
+            : $"failed t{tokenId} {TraceFormat.Node(id)} ex:{ex.GetType().Name}");
+        return default;
+    }
+
+    public ValueTask OnLogReport(int tokenId, NodeId nodeId, string message, CancellationToken ct = default)
+    {
+        trace.Add($"log t{tokenId} {TraceFormat.Node(nodeId)} {message}");
+        return default;
+    }
+
+    public ValueTask OnTokenMachineReset(NodeId graphId, CancellationToken ct = default)
+    {
+        trace.Add("machine-reset");
+        return default;
+    }
+
+    public ValueTask OnTokenMachineStarted(NodeId graphId, CancellationToken ct = default)
+    {
+        trace.Add("machine-started");
+        return default;
+    }
+
+    public ValueTask OnTokenMachineCompleted(NodeId graphId, Result result, CancellationToken ct = default)
+    {
+        trace.Add($"machine-completed {result.Code}");
+        return default;
+    }
+
+    public ValueTask OnTokenMachineCancelled(NodeId graphId, CancellationToken ct = default)
+    {
+        trace.Add("machine-cancelled");
+        return default;
+    }
+
+    public ValueTask TokenMachineStatusChanged(NodeId graphId, ExecutionStatus prev, ExecutionStatus next,
+        CancellationToken ct = default)
+    {
+        trace.Add($"status {prev}->{next}");
+        return default;
+    }
+}
+
+// ── Runtime adapters ────────────────────────────────────────────────────────
+
+/// <summary>
+/// Uniform driving surface over the four FSM adapters. All members are surface forwarding
+/// only — the adapters add no behavior of their own, so any trace divergence is the
+/// runtimes', not the harness's.
+/// </summary>
+internal interface IParityMachine
+{
+    /// <summary>One whole run through this adapter's surface (a stepped adapter loops).</summary>
+    ValueTask<Result> RunToEndAsync();
+
+    /// <summary>Exactly one step/tick. Stepped adapters only.</summary>
+    ValueTask<Result> StepOnceAsync();
+
+    void SetRestartPolicy(RestartPolicy policy);
+
+    ExecutionStatus Status { get; }
+
+    int LastOutcome { get; }
+
+    string? LastOutcomeName { get; }
+
+    StateMachineSnapshot Suspend();
+
+    void Resume(StateMachineSnapshot snapshot);
+}
+
+internal sealed record FsmAdapter(string Name, bool Stepped,
+    Func<Graph, List<string>, string?, IParityMachine> Create);
+
+/// <summary>Sync StateMachine, RunToJoin: one Execute() completes the run.</summary>
+internal sealed class SyncFullMachine : IParityMachine
+{
+    private readonly StateMachine _machine;
+
+    public SyncFullMachine(Graph graph, List<string> trace, string? throwOnceAt)
+    {
+        _machine = graph.ToStateMachine(new SyncFsmRecorder(trace, throwOnceAt));
+        _machine.SetStepMode(ParallelStepMode.RunToJoin);
+    }
+
+    public ValueTask<Result> RunToEndAsync() => new(_machine.Execute());
+
+    public ValueTask<Result> StepOnceAsync() =>
+        throw new NotSupportedException("RunToJoin completes a run per Execute(); use the stepped adapter.");
+
+    public void SetRestartPolicy(RestartPolicy policy) => _machine.SetRestartPolicy(policy);
+
+    public ExecutionStatus Status => _machine.Status;
+
+    public int LastOutcome => _machine.LastOutcome;
+
+    public string? LastOutcomeName => _machine.LastOutcomeName;
+
+    public StateMachineSnapshot Suspend() => _machine.Suspend();
+
+    public void Resume(StateMachineSnapshot snapshot) => _machine.Resume(snapshot);
+}
+
+/// <summary>Sync StateMachine, default RoundPerTick: Execute() advances one node per call.</summary>
+internal sealed class SyncSteppedMachine(Graph graph, List<string> trace, string? throwOnceAt) : IParityMachine
+{
+    private readonly StateMachine _machine = graph.ToStateMachine(new SyncFsmRecorder(trace, throwOnceAt));
+
+    public ValueTask<Result> RunToEndAsync()
+    {
+        Result result = _machine.Execute();
+        while (result == Result.InProgress)
+        {
+            result = _machine.Execute();
+        }
+
+        return new ValueTask<Result>(result);
+    }
+
+    public ValueTask<Result> StepOnceAsync() => new(_machine.Execute());
+
+    public void SetRestartPolicy(RestartPolicy policy) => _machine.SetRestartPolicy(policy);
+
+    public ExecutionStatus Status => _machine.Status;
+
+    public int LastOutcome => _machine.LastOutcome;
+
+    public string? LastOutcomeName => _machine.LastOutcomeName;
+
+    public StateMachineSnapshot Suspend() => _machine.Suspend();
+
+    public void Resume(StateMachineSnapshot snapshot) => _machine.Resume(snapshot);
+}
+
+/// <summary>AsyncStateMachine, full-run ExecuteAsync.</summary>
+internal sealed class AsyncFullMachine(Graph graph, List<string> trace, string? throwOnceAt) : IParityMachine
+{
+    private readonly AsyncStateMachine _machine =
+        graph.ToAsyncStateMachine(new AsyncFsmRecorder(trace, throwOnceAt));
+
+    public ValueTask<Result> RunToEndAsync() => _machine.ExecuteAsync();
+
+    public ValueTask<Result> StepOnceAsync() =>
+        throw new NotSupportedException("ExecuteAsync completes a run per call; use the stepped adapter.");
+
+    public void SetRestartPolicy(RestartPolicy policy) => _machine.SetRestartPolicy(policy);
+
+    public ExecutionStatus Status => _machine.Status;
+
+    public int LastOutcome => _machine.LastOutcome;
+
+    public string? LastOutcomeName => _machine.LastOutcomeName;
+
+    public StateMachineSnapshot Suspend() => _machine.Suspend();
+
+    public void Resume(StateMachineSnapshot snapshot) => _machine.Resume(snapshot);
+}
+
+/// <summary>AsyncStateMachine, StepAsync loop: one node per call.</summary>
+internal sealed class AsyncSteppedMachine(Graph graph, List<string> trace, string? throwOnceAt) : IParityMachine
+{
+    private readonly AsyncStateMachine _machine =
+        graph.ToAsyncStateMachine(new AsyncFsmRecorder(trace, throwOnceAt));
+
+    public async ValueTask<Result> RunToEndAsync()
+    {
+        Result result = await _machine.StepAsync();
+        while (result == Result.InProgress)
+        {
+            result = await _machine.StepAsync();
+        }
+
+        return result;
+    }
+
+    public ValueTask<Result> StepOnceAsync() => _machine.StepAsync();
+
+    public void SetRestartPolicy(RestartPolicy policy) => _machine.SetRestartPolicy(policy);
+
+    public ExecutionStatus Status => _machine.Status;
+
+    public int LastOutcome => _machine.LastOutcome;
+
+    public string? LastOutcomeName => _machine.LastOutcomeName;
+
+    public StateMachineSnapshot Suspend() => _machine.Suspend();
+
+    public void Resume(StateMachineSnapshot snapshot) => _machine.Resume(snapshot);
+}
+
+/// <summary>Uniform driving surface over the four token-machine adapters.</summary>
+internal interface ITokenParityMachine
+{
+    ValueTask<Result> RunToEndAsync();
+
+    void SetRestartPolicy(RestartPolicy policy);
+
+    ExecutionStatus Status { get; }
+}
+
+internal sealed record TokenAdapter(string Name, Func<Graph, List<string>, ITokenParityMachine> Create);
+
+/// <summary>Sync TokenMachine, RunToJoin: one Execute() drains the whole flow.</summary>
+internal sealed class SyncTokenFullMachine : ITokenParityMachine
+{
+    private readonly TokenMachine _machine;
+
+    public SyncTokenFullMachine(Graph graph, List<string> trace)
+    {
+        _machine = graph.ToTokenMachine(new SyncTokenRecorder(trace));
+        _machine.SetStepMode(ParallelStepMode.RunToJoin);
+    }
+
+    public ValueTask<Result> RunToEndAsync() => new(_machine.Execute());
+
+    public void SetRestartPolicy(RestartPolicy policy) => _machine.SetRestartPolicy(policy);
+
+    public ExecutionStatus Status => _machine.Status;
+}
+
+/// <summary>Sync TokenMachine, default RoundPerTick: Execute() advances one round per call.</summary>
+internal sealed class SyncTokenSteppedMachine(Graph graph, List<string> trace) : ITokenParityMachine
+{
+    private readonly TokenMachine _machine = graph.ToTokenMachine(new SyncTokenRecorder(trace));
+
+    public ValueTask<Result> RunToEndAsync()
+    {
+        Result result = _machine.Execute();
+        while (result == Result.InProgress)
+        {
+            result = _machine.Execute();
+        }
+
+        return new ValueTask<Result>(result);
+    }
+
+    public void SetRestartPolicy(RestartPolicy policy) => _machine.SetRestartPolicy(policy);
+
+    public ExecutionStatus Status => _machine.Status;
+}
+
+/// <summary>AsyncTokenMachine, full-run ExecuteAsync.</summary>
+internal sealed class AsyncTokenFullMachine(Graph graph, List<string> trace) : ITokenParityMachine
+{
+    private readonly AsyncTokenMachine _machine = graph.ToAsyncTokenMachine(new AsyncTokenRecorder(trace));
+
+    public ValueTask<Result> RunToEndAsync() => _machine.ExecuteAsync();
+
+    public void SetRestartPolicy(RestartPolicy policy) => _machine.SetRestartPolicy(policy);
+
+    public ExecutionStatus Status => _machine.Status;
+}
+
+/// <summary>AsyncTokenMachine, StepAsync loop: one scheduling round per call.</summary>
+internal sealed class AsyncTokenSteppedMachine(Graph graph, List<string> trace) : ITokenParityMachine
+{
+    private readonly AsyncTokenMachine _machine = graph.ToAsyncTokenMachine(new AsyncTokenRecorder(trace));
+
+    public async ValueTask<Result> RunToEndAsync()
+    {
+        Result result = await _machine.StepAsync();
+        while (result == Result.InProgress)
+        {
+            result = await _machine.StepAsync();
+        }
+
+        return result;
+    }
+
+    public void SetRestartPolicy(RestartPolicy policy) => _machine.SetRestartPolicy(policy);
+
+    public ExecutionStatus Status => _machine.Status;
+}
+
+internal static class ParityAdapters
+{
+    /// <summary>The four FSM adapters: sync/async × full-run/stepped.</summary>
+    public static readonly FsmAdapter[] Fsm =
+    [
+        new("sync/run-to-join", Stepped: false, (g, t, x) => new SyncFullMachine(g, t, x)),
+        new("sync/stepped", Stepped: true, (g, t, x) => new SyncSteppedMachine(g, t, x)),
+        new("async/execute", Stepped: false, (g, t, x) => new AsyncFullMachine(g, t, x)),
+        new("async/stepped", Stepped: true, (g, t, x) => new AsyncSteppedMachine(g, t, x)),
+    ];
+
+    /// <summary>The four token-machine adapters: sync/async × full-run/stepped.</summary>
+    public static readonly TokenAdapter[] Token =
+    [
+        new("token-sync/run-to-join", (g, t) => new SyncTokenFullMachine(g, t)),
+        new("token-sync/stepped", (g, t) => new SyncTokenSteppedMachine(g, t)),
+        new("token-async/execute", (g, t) => new AsyncTokenFullMachine(g, t)),
+        new("token-async/stepped", (g, t) => new AsyncTokenSteppedMachine(g, t)),
+    ];
+}
+
+// ── Normalizer ──────────────────────────────────────────────────────────────
+
+/// <summary>
+/// The documented mechanical differences between the runtime families, each encoded exactly
+/// once. Within a family (FSM×FSM, token×token) traces are compared raw — no normalization —
+/// so any drift in event structure fails the suite. Normalizations apply only to the
+/// cross-family comparison of plain (fork/join-free) graphs.
+/// </summary>
+internal static class TraceNormalizer
+{
+    /// <summary>
+    /// N1 — source: CLAUDE.md/AGENTS.md token-runtime bullet (spec 007): the token machines
+    /// move tokens inside a scheduling round without the machine-wide
+    /// Running → Transitioning → Running status hop the FSM machines make per node move, so
+    /// they never report the Transitioning status. Dropping both lines of each hop from an
+    /// FSM trace makes it comparable with a token-family trace.
+    /// </summary>
+    public static List<string> WithoutTransitioningStatus(List<string> trace) =>
+        trace.Where(static line => !line.Contains("Transitioning", StringComparison.Ordinal)).ToList();
+
+    /// <summary>
+    /// N2 — source: spec 007 / CLAUDE.md ("Observers ... carry a token-id dimension"): the
+    /// token observers add token-pool bookkeeping events (spawned/retired/join-fired) and a
+    /// t{id} attribution on node events that the FSM observers do not have. A plain graph
+    /// runs single-token, so stripping the dimension yields the FSM-shaped trace. Only
+    /// single-token traces may be normalized this way.
+    /// </summary>
+    public static List<string> WithoutTokenDimension(List<string> trace) =>
+        trace.Where(static line =>
+                !line.StartsWith("spawned ", StringComparison.Ordinal) &&
+                !line.StartsWith("retired ", StringComparison.Ordinal) &&
+                !line.StartsWith("join-fired ", StringComparison.Ordinal))
+            .Select(static line => Regex.Replace(line, @" t\d+ ", " "))
+            .ToList();
+}
+
+// ── Assertion + drive helpers ───────────────────────────────────────────────
+
+internal static class ParityAssert
+{
+    /// <summary>
+    /// Order-exact equality of every trace against the first (the baseline adapter);
+    /// returns the baseline so scenario tests can additionally pin driver-agnostic expected
+    /// content (terminal result, outcome lines, probe values).
+    /// Also enforces normalization N3 — source: CLAUDE.md ("sync has no Cancelled surface";
+    /// the sync observer interface lacks OnStateMachineCancelled and the sync machine merely
+    /// tolerates the status): cancellation is not comparable across the runtimes, so no
+    /// scenario in this matrix may produce it. There is nothing to normalize away — the
+    /// guard fails loudly if a scenario ever cancels.
+    /// </summary>
+    public static List<string> AllEqual(IReadOnlyList<(string Adapter, List<string> Trace)> runs)
+    {
+        Assert.That(runs, Has.Count.GreaterThanOrEqualTo(2), "A parity comparison needs at least two runs.");
+
+        foreach ((string adapter, List<string> trace) in runs)
+        {
+            foreach (string line in trace)
+            {
+                if (line.Contains("Cancelled", StringComparison.Ordinal) ||
+                    line.Contains("machine-cancelled", StringComparison.Ordinal))
+                {
+                    Assert.Fail(
+                        $"Adapter '{adapter}' produced a cancellation event ('{line}'), but the sync runtime " +
+                        "has no Cancelled surface — cancellation scenarios cannot be part of the " +
+                        "cross-runtime matrix (normalization N3).");
+                }
+            }
+        }
+
+        (string baseline, List<string> expected) = runs[0];
+        for (int i = 1; i < runs.Count; i++)
+        {
+            Assert.That(runs[i].Trace, Is.EqualTo(expected),
+                $"Trace divergence: adapter '{runs[i].Adapter}' does not match baseline '{baseline}'.");
+        }
+
+        return expected;
+    }
+}
+
+internal static class ParityDrives
+{
+    /// <summary>One full run; surface facts appended as trace lines.</summary>
+    public static async ValueTask OneRunAsync(IParityMachine machine, List<string> trace)
+    {
+        Result result = await machine.RunToEndAsync();
+        AppendSurface(machine, trace, result);
+    }
+
+    /// <summary>
+    /// One run expected to throw out of the machine surface. Normalization N4 — source: the
+    /// machines name their own concrete type in guidance messages ("StateMachine is in
+    /// terminal state ..." vs "AsyncStateMachine is in terminal state ..."): parity is
+    /// asserted on the exception type, never on message text, so only the type is recorded.
+    /// </summary>
+    public static async ValueTask RunExpectingThrowAsync(IParityMachine machine, List<string> trace)
+    {
+        try
+        {
+            await machine.RunToEndAsync();
+            trace.Add("no-throw");
+        }
+        catch (Exception ex)
+        {
+            trace.Add($"threw {ex.GetType().Name}");
+        }
+    }
+
+    public static void AppendSurface(IParityMachine machine, List<string> trace, Result result)
+    {
+        trace.Add($"run-result {result.Code}");
+        trace.Add($"final-status {machine.Status}");
+        trace.Add($"last-outcome {machine.LastOutcome} name={machine.LastOutcomeName ?? "-"}");
+    }
+}
+
+// ── Runners ─────────────────────────────────────────────────────────────────
+
+internal static class ParityRunner
+{
+    /// <summary>
+    /// Runs the scenario through all four FSM adapters and asserts order-exact trace
+    /// equality (raw — no normalization within the FSM family). The recipe is invoked per
+    /// adapter so closure state (counters) starts fresh.
+    /// </summary>
+    public static async Task<List<string>> AssertFsmParityAsync(Func<ParityScenario> recipe,
+        Func<IParityMachine, List<string>, ValueTask> drive, string? observerThrowOnceAt = null)
+    {
+        List<(string Adapter, List<string> Trace)> runs = [];
+        foreach (FsmAdapter adapter in ParityAdapters.Fsm)
+        {
+            ParityScenario scenario = recipe();
+            List<string> trace = [];
+            IParityMachine machine = adapter.Create(scenario.Graph, trace, observerThrowOnceAt);
+            await drive(machine, trace);
+            AppendProbes(scenario, trace);
+            runs.Add((adapter.Name, trace));
+        }
+
+        return ParityAssert.AllEqual(runs);
+    }
+
+    /// <summary>
+    /// Suspend/resume parity: the full-run adapters contribute the uninterrupted baseline;
+    /// each stepped adapter steps once, suspends, resumes the snapshot onto a fresh machine
+    /// over the same graph (recording into the same trace list), and completes the run.
+    /// Resume replays no observer events, so the stitched trace must equal the
+    /// uninterrupted one exactly — across the boundary and across the runtimes.
+    /// </summary>
+    public static async Task<List<string>> AssertSuspendResumeParityAsync(Func<ParityScenario> recipe)
+    {
+        List<(string Adapter, List<string> Trace)> runs = [];
+        foreach (FsmAdapter adapter in ParityAdapters.Fsm)
+        {
+            ParityScenario scenario = recipe();
+            List<string> trace = [];
+            IParityMachine first = adapter.Create(scenario.Graph, trace, null);
+
+            if (!adapter.Stepped)
+            {
+                Result result = await first.RunToEndAsync();
+                ParityDrives.AppendSurface(first, trace, result);
+            }
+            else
+            {
+                Result step = await first.StepOnceAsync();
+                Assert.That(step, Is.EqualTo(Result.InProgress),
+                    $"[{adapter.Name}] the scenario must span more than one step to suspend mid-run.");
+
+                StateMachineSnapshot snapshot = first.Suspend();
+                IParityMachine second = adapter.Create(scenario.Graph, trace, null);
+                second.Resume(snapshot);
+                Result result = await second.RunToEndAsync();
+                ParityDrives.AppendSurface(second, trace, result);
+            }
+
+            AppendProbes(scenario, trace);
+            runs.Add((adapter.Name, trace));
+        }
+
+        return ParityAssert.AllEqual(runs);
+    }
+
+    /// <summary>
+    /// Runs the scenario through all token-machine adapters and asserts order-exact trace
+    /// equality (raw — no normalization within the token family).
+    /// </summary>
+    public static async Task<List<string>> AssertTokenParityAsync(Func<ParityScenario> recipe,
+        Action<ITokenParityMachine>? configure = null)
+    {
+        List<(string Adapter, List<string> Trace)> runs = [];
+        foreach (TokenAdapter adapter in ParityAdapters.Token)
+        {
+            ParityScenario scenario = recipe();
+            List<string> trace = [];
+            ITokenParityMachine machine = adapter.Create(scenario.Graph, trace);
+            configure?.Invoke(machine);
+            Result result = await machine.RunToEndAsync();
+            trace.Add($"run-result {result.Code}");
+            trace.Add($"final-status {machine.Status}");
+            AppendProbes(scenario, trace);
+            runs.Add((adapter.Name, trace));
+        }
+
+        return ParityAssert.AllEqual(runs);
+    }
+
+    /// <summary>
+    /// Cross-family parity for plain (fork/join-free) graphs — pins the documented claim
+    /// that such graphs "run identically under either family". FSM traces are normalized
+    /// with N1 (<see cref="TraceNormalizer.WithoutTransitioningStatus"/>), token traces with
+    /// N2 (<see cref="TraceNormalizer.WithoutTokenDimension"/>); the LastOutcome surface is
+    /// FSM-only, so the shared trailer carries run-result and final-status only.
+    /// </summary>
+    public static async Task<List<string>> AssertCrossFamilyParityAsync(Func<ParityScenario> recipe)
+    {
+        List<(string Adapter, List<string> Trace)> runs = [];
+
+        foreach (FsmAdapter adapter in ParityAdapters.Fsm)
+        {
+            ParityScenario scenario = recipe();
+            List<string> trace = [];
+            IParityMachine machine = adapter.Create(scenario.Graph, trace, null);
+            Result result = await machine.RunToEndAsync();
+            List<string> normalized = TraceNormalizer.WithoutTransitioningStatus(trace);
+            normalized.Add($"run-result {result.Code}");
+            normalized.Add($"final-status {machine.Status}");
+            AppendProbes(scenario, normalized);
+            runs.Add((adapter.Name, normalized));
+        }
+
+        foreach (TokenAdapter adapter in ParityAdapters.Token)
+        {
+            ParityScenario scenario = recipe();
+            List<string> trace = [];
+            ITokenParityMachine machine = adapter.Create(scenario.Graph, trace);
+            Result result = await machine.RunToEndAsync();
+            List<string> normalized = TraceNormalizer.WithoutTokenDimension(trace);
+            normalized.Add($"run-result {result.Code}");
+            normalized.Add($"final-status {machine.Status}");
+            AppendProbes(scenario, normalized);
+            runs.Add((adapter.Name, normalized));
+        }
+
+        return ParityAssert.AllEqual(runs);
+    }
+
+    private static void AppendProbes(ParityScenario scenario, List<string> trace)
+    {
+        foreach ((string name, Func<int> read) in scenario.Probes)
+        {
+            trace.Add($"probe {name}={read()}");
+        }
+    }
+}

--- a/NxGraph.Tests/Parity/TokenParityConformanceTests.cs
+++ b/NxGraph.Tests/Parity/TokenParityConformanceTests.cs
@@ -1,0 +1,139 @@
+using NxGraph.Authoring;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Tests.Parity;
+
+/// <summary>
+/// Parity conformance matrix for the token runtimes: every scenario runs through the four
+/// token adapters (sync RunToJoin, sync stepped, async ExecuteAsync, async StepAsync) and
+/// must produce the same observable trace, order-exact and unnormalized. Fork/join graphs
+/// are compared between <see cref="TokenMachine"/> and <see cref="AsyncTokenMachine"/> only —
+/// the FSM runtimes throw on fork/join nodes by design. Plain graphs are additionally
+/// compared across the families (see the cross-family test), which is where the documented
+/// normalizations N1/N2 apply.
+/// </summary>
+[TestFixture]
+public class TokenParityConformanceTests
+{
+    // ── Recipes ─────────────────────────────────────────────────────────
+
+    /// <summary>load → fork(a | b) → join(All 2) → finish.</summary>
+    private static ParityScenario Diamond()
+    {
+        JoinState join = new(JoinPolicy.All(2));
+        StateToken load = GraphBuilder.StartWith(() => Result.Success).SetName("load");
+        ForkToken fork = load.ForkTo(
+            b => b.To(() => Result.Success).SetName("a")
+                .To(join).SetName("join")
+                .To(() => Result.Success).SetName("finish"),
+            b => b.To(() => Result.Success).SetName("b")
+                .To(join));
+        return new ParityScenario { Graph = fork.SetName("fork").Build() };
+    }
+
+    /// <summary>
+    /// load → fork(a | b | c) → join(Quorum 2) → finish: the third token arrives after the
+    /// join already fired this run and must absorb benignly (quorum leftovers).
+    /// </summary>
+    private static ParityScenario QuorumLeftover()
+    {
+        JoinState join = new(JoinPolicy.Quorum(2));
+        StateToken load = GraphBuilder.StartWith(() => Result.Success).SetName("load");
+        ForkToken fork = load.ForkTo(
+            b => b.To(() => Result.Success).SetName("a")
+                .To(join).SetName("join")
+                .To(() => Result.Success).SetName("finish"),
+            b => b.To(() => Result.Success).SetName("b")
+                .To(join),
+            b => b.To(() => Result.Success).SetName("c")
+                .To(join));
+        return new ParityScenario { Graph = fork.SetName("fork").Build() };
+    }
+
+    /// <summary>
+    /// load → fork(dies | waits → join(All 2)): the first branch's token dies (failure, no
+    /// retry, no failure edge), so the waiting token starves at the join that never fires.
+    /// </summary>
+    private static ParityScenario Starvation()
+    {
+        JoinState join = new(JoinPolicy.All(2));
+        StateToken load = GraphBuilder.StartWith(() => Result.Success).SetName("load");
+        ForkToken fork = load.ForkTo(
+            b => b.To(() => Result.Failure).SetName("dies"),
+            b => b.To(() => Result.Success).SetName("waits")
+                .To(join).SetName("join"));
+        return new ParityScenario { Graph = fork.SetName("fork").Build() };
+    }
+
+    /// <summary>Plain three-node chain — no fork/join, runnable by every runtime family.</summary>
+    private static ParityScenario PlainChain()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("a")
+            .To(() => Result.Success).SetName("b")
+            .To(() => Result.Success).SetName("c")
+            .Build();
+        return new ParityScenario { Graph = graph };
+    }
+
+    // ── Token matrix ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task fork_join_diamond_runs_identically()
+    {
+        List<string> baseline = await ParityRunner.AssertTokenParityAsync(Diamond);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("join-fired join survivor t1"),
+                "Branch order is deterministic: t0 parks first, t1 arrives second and fires the join.");
+            Assert.That(baseline, Does.Contain("retired t0 at join Joined"));
+            Assert.That(baseline, Does.Contain("run-result Success"));
+        });
+    }
+
+    [Test]
+    public async Task quorum_leftover_absorbs_identically()
+    {
+        List<string> baseline = await ParityRunner.AssertTokenParityAsync(QuorumLeftover);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("retired t2 at join Absorbed"),
+                "A token parked at a join that already fired this run absorbs benignly.");
+            Assert.That(baseline, Does.Contain("run-result Success"));
+        });
+    }
+
+    [Test]
+    public async Task starvation_fails_identically()
+    {
+        List<string> baseline = await ParityRunner.AssertTokenParityAsync(Starvation);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("retired t0 at dies Failed"),
+                "The failing branch's token dies after exhausting the (absent) fault handling.");
+            Assert.That(baseline, Does.Contain("retired t1 at join Starved"),
+                "The waiting token starves at the join that never fired.");
+            Assert.That(baseline, Does.Contain("run-result Failure"));
+        });
+    }
+
+    // ── Cross-family: plain graphs run identically under either family ──
+
+    [Test]
+    public async Task plain_graph_runs_identically_under_fsm_and_token_machines()
+    {
+        // Pins the documented claim that graphs without fork/join nodes run identically
+        // under either runtime family. This is the one comparison that needs the
+        // documented normalizations: N1 strips the FSM machines' Transitioning status
+        // hops, N2 strips the token machines' token-id dimension (see TraceNormalizer).
+        List<string> baseline = await ParityRunner.AssertCrossFamilyParityAsync(PlainChain);
+        Assert.Multiple(() =>
+        {
+            Assert.That(baseline, Does.Contain("entered a"));
+            Assert.That(baseline, Does.Contain("transition b->c"));
+            Assert.That(baseline, Does.Contain("machine-completed Success"));
+            Assert.That(baseline, Does.Contain("run-result Success"));
+        });
+    }
+}

--- a/NxGraph.Tests/SuspendResumeTests.cs
+++ b/NxGraph.Tests/SuspendResumeTests.cs
@@ -122,6 +122,19 @@ public class SuspendResumeTests
     }
 
     [Test]
+    public void resume_rejects_undefined_status_value()
+    {
+        // A corrupted or hand-crafted snapshot must not write an undefined value into the
+        // machine's status field — every later status switch would misbehave silently.
+        Graph graph = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success).Build();
+        AsyncStateMachine machine = graph.ToAsyncStateMachine();
+
+        StateMachineSnapshot bogus = new(0, (ExecutionStatus)99, 0, false, false, 0);
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(() => machine.Resume(bogus));
+        Assert.That(ex!.Message, Does.Contain("Snapshot status value 99 is not a defined ExecutionStatus"));
+    }
+
+    [Test]
     public async Task suspend_of_an_idle_machine_roundtrips_through_execute()
     {
         List<int> executed = [];

--- a/NxGraph.Tests/SyncSuspendResumeTests.cs
+++ b/NxGraph.Tests/SyncSuspendResumeTests.cs
@@ -124,6 +124,19 @@ public class SyncSuspendResumeTests
     }
 
     [Test]
+    public void resume_rejects_undefined_status_value()
+    {
+        // A corrupted or hand-crafted snapshot must not write an undefined value into the
+        // machine's status field — every later status switch would misbehave silently.
+        Graph graph = GraphBuilder.StartWith(() => Result.Success).Build();
+        StateMachine machine = graph.ToStateMachine();
+
+        StateMachineSnapshot bogus = new(0, (ExecutionStatus)99, 0, false, false, 0);
+        InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(() => machine.Resume(bogus));
+        Assert.That(ex!.Message, Does.Contain("Snapshot status value 99 is not a defined ExecutionStatus"));
+    }
+
+    [Test]
     public void suspend_of_an_idle_machine_roundtrips_through_execute()
     {
         List<int> executed = [];

--- a/NxGraph.Tests/Tokens/TokenSnapshotTests.cs
+++ b/NxGraph.Tests/Tokens/TokenSnapshotTests.cs
@@ -218,6 +218,22 @@ public class TokenSnapshotTests
     }
 
     [Test]
+    public void resume_rejects_undefined_status_value([Values] bool sync)
+    {
+        // A corrupted or hand-crafted snapshot must not write an undefined value into the
+        // machine's status field — every later status switch would misbehave silently.
+        // One parameterized test for both token runtimes: they share the snapshot contract.
+        Graph graph = GraphBuilder.StartWith(() => Result.Success).Build();
+        TokenMachineSnapshot bogus = new((ExecutionStatus)99, false, 0, [], []);
+
+        InvalidOperationException? ex = sync
+            ? Assert.Throws<InvalidOperationException>(() => graph.ToTokenMachine().Resume(bogus))
+            : Assert.Throws<InvalidOperationException>(() => graph.ToAsyncTokenMachine().Resume(bogus));
+
+        Assert.That(ex!.Message, Does.Contain("Snapshot status value 99 is not a defined ExecutionStatus"));
+    }
+
+    [Test]
     public void suspend_from_inside_node_logic_is_rejected()
     {
         TokenMachine? machineRef = null;

--- a/NxGraph/Behaviors/AsyncBehaviorState.cs
+++ b/NxGraph/Behaviors/AsyncBehaviorState.cs
@@ -68,7 +68,7 @@ public sealed class AsyncBehaviorState : AsyncState, IBehaviorComposite, IBehavi
     {
         if (LogReport is { } report)
         {
-            BehaviorComposition.Await(report(message, _reportCt));
+            ValueTaskSync.Await(report(message, _reportCt));
         }
     }
 }
@@ -141,7 +141,7 @@ public sealed class AsyncBehaviorState<TAgent> : AsyncState<TAgent>, IBehaviorCo
     {
         if (LogReport is { } report)
         {
-            BehaviorComposition.Await(report(message, _reportCt));
+            ValueTaskSync.Await(report(message, _reportCt));
         }
     }
 }

--- a/NxGraph/Behaviors/BehaviorState.cs
+++ b/NxGraph/Behaviors/BehaviorState.cs
@@ -204,18 +204,7 @@ internal static class BehaviorComposition
 
         if (((ILogReporter)state).LogReport is { } asyncReport)
         {
-            Await(asyncReport(message, CancellationToken.None));
+            ValueTaskSync.Await(asyncReport(message, CancellationToken.None));
         }
-    }
-
-    internal static void Await(ValueTask task)
-    {
-        if (task.IsCompletedSuccessfully)
-        {
-            task.GetAwaiter().GetResult();
-            return;
-        }
-
-        task.AsTask().GetAwaiter().GetResult();
     }
 }

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -448,46 +448,11 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                     "A stepped run is in progress. Finish it with StepAsync or Reset() before calling ExecuteAsync.");
             }
 
-            // If we're terminal, apply reset policy.
-            ExecutionStatus status = Status;
-            if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
-            {
-                switch (_restartPolicy)
-                {
-                    case RestartPolicy.Ignore:
-                        // Ignore further execution attempts until a manual Reset() occurs.
-                        // Keep the gate held so a concurrent caller cannot enter while this
-                        // ExecuteAsync is still on its way to OnRunAsync (which returns the
-                        // cached terminal result) and OnExitAsync (which releases the gate).
-                        return Result.InProgress;
-                    case RestartPolicy.Manual:
-                        throw new InvalidOperationException(
-                            $"AsyncStateMachine is in terminal state '{status}'. Call Reset() before executing again.");
-                    default:
-                        // Auto: tolerate unexpected terminal state by resetting on entry.
-                        // ResetCore (not Reset) because OnEnterAsync already holds the gate.
-                        await ResetCore(ct).ConfigureAwait(false);
-                        break;
-                }
-            }
-
-            // Re-stamp this machine's context onto the (potentially shared) graph before running.
-            ApplyExecutionContext();
-            StampPendingEntry();
-
-            // First entry or re-entry after Ready: Starting -> (enter first node) -> Running
-            await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
-            _current = _initial;
-            _attempts = 0;
-            _nodeEntered = false;
-            _nodeBoard?.ResetToDefaults();
-            LastOutcome = 0;
-            if (_observer is not null)
-            {
-                await _observer.OnStateEntered(_current, ct).ConfigureAwait(false);
-            }
-
-            await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
+            // Ignore policy returns false: the init is skipped, but the gate is kept held so
+            // a concurrent caller cannot enter while this ExecuteAsync is still on its way to
+            // OnRunAsync (which returns the cached terminal result) and OnExitAsync (which
+            // releases the gate). Either way OnEnterAsync hands off with InProgress.
+            _ = await TryBeginRunAsync(stepped: false, ct).ConfigureAwait(false);
 
             return Result.InProgress;
         }
@@ -497,6 +462,66 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             Volatile.Write(ref _executeGate, 0);
             throw;
         }
+    }
+
+    /// <summary>
+    /// The run-start init shared by <see cref="OnEnterAsync"/> and the first
+    /// <see cref="StepAsync"/> of a stepped run: applies the restart policy to a terminal
+    /// machine, re-stamps the execution context, and moves the machine
+    /// Starting → (enter first node) → Running. Returns <c>false</c> for the
+    /// <see cref="RestartPolicy.Ignore"/> early-out — the callers translate that into their
+    /// distinct surface results (full-run: <see cref="Result.InProgress"/> with the gate held
+    /// so OnRunAsync returns the cached terminal result; stepped: the cached result
+    /// directly). Must run inside the caller's gate-repair try/catch: observer callbacks
+    /// fired here may throw, and which exceptions repair status and release the gate is
+    /// caller-specific behavior.
+    /// </summary>
+    private async ValueTask<bool> TryBeginRunAsync(bool stepped, CancellationToken ct)
+    {
+        // If we're terminal, apply reset policy.
+        ExecutionStatus status = Status;
+        if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+        {
+            switch (_restartPolicy)
+            {
+                case RestartPolicy.Ignore:
+                    // Ignore further execution attempts until a manual Reset() occurs.
+                    return false;
+                case RestartPolicy.Manual:
+                    throw new InvalidOperationException(
+                        $"AsyncStateMachine is in terminal state '{status}'. Call Reset() before " +
+                        $"{(stepped ? "stepping" : "executing")} again.");
+                default:
+                    // Auto: tolerate unexpected terminal state by resetting on entry.
+                    // ResetCore (not Reset) because the caller already holds the gate.
+                    await ResetCore(ct).ConfigureAwait(false);
+                    break;
+            }
+        }
+
+        // Re-stamp this machine's context onto the (potentially shared) graph before running.
+        ApplyExecutionContext();
+        StampPendingEntry();
+
+        // First entry or re-entry after Ready: Starting -> (enter first node) -> Running
+        await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
+        _current = _initial;
+        _attempts = 0;
+        _nodeEntered = false;
+        _nodeBoard?.ResetToDefaults();
+        LastOutcome = 0;
+        if (_observer is not null)
+        {
+            await _observer.OnStateEntered(_current, ct).ConfigureAwait(false);
+        }
+
+        await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
+        if (stepped)
+        {
+            _stepping = true;
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -530,66 +555,101 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
         try
         {
             Result result = await InternalRunAsync(ct).ConfigureAwait(false);
-            _terminalResult = result;
 
             // If we get here, loop has returned a terminal result already.
-            // Machine completion notification + optional auto-reset-to-Ready.
-            await TransitionTo(result == Result.Success ? ExecutionStatus.Completed : ExecutionStatus.Failed)
-                .ConfigureAwait(false);
-
-            if (_restartPolicy == RestartPolicy.Auto)
-            {
-                // ResetCore (not Reset) because the gate is held by the surrounding ExecuteAsync.
-                await ResetCore(ct).ConfigureAwait(false);
-            }
+            await CompleteRunAsync(result, ct).ConfigureAwait(false);
 
             return result;
         }
         catch (OperationCanceledException)
         {
-            // Skip the terminal cascade when the run already reached a terminal status —
-            // e.g. an observer threw inside the Completed notification. Re-transitioning
-            // would fire OnStateMachineCompleted twice and flip a successful run to
-            // Cancelled/Failed. Mirrors sync StateMachine.Finalise's idempotence guard.
-            if (!IsTerminal)
-            {
-                // TransitionTo(Cancelled) already fires OnStateMachineCancelled via NotifyMachineStatusChangeAsync.
-                await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
-
-                _terminalResult = Result.Failure;
-
-                if (_restartPolicy == RestartPolicy.Auto)
-                {
-                    // CancellationToken.None: ct is already cancelled; passing it would make
-                    // any cancellable await inside the reset throw, stranding status at Resetting.
-                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
-                }
-            }
-
+            // The `throw;` stays here (not in the handler) so the stack trace is unchanged.
+            await HandleRunCancelledAsync().ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
         {
-            // Same idempotence guard as the cancellation path above.
-            if (!IsTerminal)
-            {
-                // Unexpected error outside node execution (node failures are returned as Failure below)
-                if (_observer is not null)
-                    await _observer.OnStateFailed(_current, ex, ct).ConfigureAwait(false);
-
-                // TransitionTo(Failed) already fires OnStateMachineCompleted(Failure) via NotifyMachineStatusChangeAsync.
-                await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
-
-                _terminalResult = Result.Failure;
-
-                if (_restartPolicy == RestartPolicy.Auto)
-                {
-                    // CancellationToken.None: ct may already be cancelled/faulted; reset must complete cleanly.
-                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
-                }
-            }
-
+            await HandleRunFaultAsync(ex, ct).ConfigureAwait(false);
             throw;
+        }
+    }
+
+    /// <summary>
+    /// The terminal cascade shared by <see cref="OnRunAsync"/> and <see cref="StepAsync"/>:
+    /// caches the terminal result, transitions to Completed/Failed (machine completion
+    /// notification), and applies the optional auto-reset-to-Ready. ResetCore (not Reset)
+    /// because the gate is held by the surrounding ExecuteAsync/StepAsync frame.
+    /// </summary>
+    private async ValueTask CompleteRunAsync(Result result, CancellationToken ct)
+    {
+        _terminalResult = result;
+
+        await TransitionTo(result == Result.Success ? ExecutionStatus.Completed : ExecutionStatus.Failed)
+            .ConfigureAwait(false);
+
+        if (_restartPolicy == RestartPolicy.Auto)
+        {
+            await ResetCore(ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Fault cascade for a cancellation escaping the run loop, shared by
+    /// <see cref="OnRunAsync"/> and <see cref="StepAsync"/> — the callers keep their own
+    /// <c>throw;</c> so the original stack trace is preserved. The <see cref="IsTerminal"/>
+    /// guard skips the cascade when the run already reached a terminal status — e.g. an
+    /// observer threw inside the Completed notification. Re-transitioning would fire
+    /// OnStateMachineCompleted twice and flip a successful run to Cancelled/Failed.
+    /// Mirrors sync StateMachine.Finalise's idempotence guard.
+    /// </summary>
+    private async ValueTask HandleRunCancelledAsync()
+    {
+        if (IsTerminal)
+        {
+            return;
+        }
+
+        // TransitionTo(Cancelled) already fires OnStateMachineCancelled via NotifyMachineStatusChangeAsync.
+        await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
+
+        _terminalResult = Result.Failure;
+
+        if (_restartPolicy == RestartPolicy.Auto)
+        {
+            // CancellationToken.None: ct is already cancelled; passing it would make
+            // any cancellable await inside the reset throw, stranding status at Resetting.
+            await ResetCore(CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Fault cascade for an unexpected exception escaping the run loop (node failures are
+    /// returned as <see cref="Result.Failure"/> from the step core, not thrown), shared by
+    /// <see cref="OnRunAsync"/> and <see cref="StepAsync"/> — the callers keep their own
+    /// <c>throw;</c> so the original stack trace is preserved. Same
+    /// <see cref="IsTerminal"/> idempotence guard as <see cref="HandleRunCancelledAsync"/>.
+    /// </summary>
+    private async ValueTask HandleRunFaultAsync(Exception ex, CancellationToken ct)
+    {
+        if (IsTerminal)
+        {
+            return;
+        }
+
+        if (_observer is not null)
+        {
+            await _observer.OnStateFailed(_current, ex, ct).ConfigureAwait(false);
+        }
+
+        // TransitionTo(Failed) already fires OnStateMachineCompleted(Failure) via NotifyMachineStatusChangeAsync.
+        await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
+
+        _terminalResult = Result.Failure;
+
+        if (_restartPolicy == RestartPolicy.Auto)
+        {
+            // CancellationToken.None: ct may already be cancelled/faulted; reset must complete cleanly.
+            await ResetCore(CancellationToken.None).ConfigureAwait(false);
         }
     }
 
@@ -752,38 +812,11 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                 // which may throw; repair transient status so the machine stays usable.
                 try
                 {
-                    ExecutionStatus status = Status;
-                    if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+                    if (!await TryBeginRunAsync(stepped: true, ct).ConfigureAwait(false))
                     {
-                        switch (_restartPolicy)
-                        {
-                            case RestartPolicy.Ignore:
-                                return _terminalResult;
-                            case RestartPolicy.Manual:
-                                throw new InvalidOperationException(
-                                    $"AsyncStateMachine is in terminal state '{status}'. Call Reset() before stepping again.");
-                            default:
-                                await ResetCore(ct).ConfigureAwait(false);
-                                break;
-                        }
+                        // Ignore policy: the stepped surface returns the cached result directly.
+                        return _terminalResult;
                     }
-
-                    ApplyExecutionContext();
-                    StampPendingEntry();
-
-                    await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
-                    _current = _initial;
-                    _attempts = 0;
-                    _nodeEntered = false;
-                    _nodeBoard?.ResetToDefaults();
-                    LastOutcome = 0;
-                    if (_observer is not null)
-                    {
-                        await _observer.OnStateEntered(_current, ct).ConfigureAwait(false);
-                    }
-
-                    await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
-                    _stepping = true;
                 }
                 catch
                 {
@@ -800,38 +833,13 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             catch (OperationCanceledException)
             {
                 _stepping = false;
-                // Idempotence guard: don't re-fire the terminal cascade when the status is
-                // already terminal (mirrors sync StateMachine.Finalise).
-                if (!IsTerminal)
-                {
-                    await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
-                    _terminalResult = Result.Failure;
-                    if (_restartPolicy == RestartPolicy.Auto)
-                    {
-                        await ResetCore(CancellationToken.None).ConfigureAwait(false);
-                    }
-                }
-
+                await HandleRunCancelledAsync().ConfigureAwait(false);
                 throw;
             }
             catch (Exception ex)
             {
                 _stepping = false;
-                if (!IsTerminal)
-                {
-                    if (_observer is not null)
-                    {
-                        await _observer.OnStateFailed(_current, ex, ct).ConfigureAwait(false);
-                    }
-
-                    await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
-                    _terminalResult = Result.Failure;
-                    if (_restartPolicy == RestartPolicy.Auto)
-                    {
-                        await ResetCore(CancellationToken.None).ConfigureAwait(false);
-                    }
-                }
-
+                await HandleRunFaultAsync(ex, ct).ConfigureAwait(false);
                 throw;
             }
 
@@ -841,14 +849,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             }
 
             _stepping = false;
-            _terminalResult = result;
-            await TransitionTo(result == Result.Success ? ExecutionStatus.Completed : ExecutionStatus.Failed)
-                .ConfigureAwait(false);
-
-            if (_restartPolicy == RestartPolicy.Auto)
-            {
-                await ResetCore(ct).ConfigureAwait(false);
-            }
+            await CompleteRunAsync(result, ct).ConfigureAwait(false);
 
             return result;
         }

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -652,6 +652,8 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
 
         try
         {
+            ExecutionStatusValidation.ThrowIfUndefined(snapshot.Status);
+
             if (snapshot.Status is ExecutionStatus.Starting or ExecutionStatus.Transitioning
                 or ExecutionStatus.Resetting)
             {

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -891,6 +891,15 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                 // observer, so nodes that gate report formatting on a wired callback
                 // (behavior composites) pay nothing on observer-less machines.
                 reporter.LogReport = _observer is null ? null : _cachedLogReportCallback;
+
+                // Sync states read both slots (State.Log prefers the sync one), so the sync
+                // slot is cleared too: a callback left by a sync machine that ran this shared
+                // graph earlier must neither shadow this machine's observer nor receive
+                // reports from this run.
+                if (reporter is State syncState)
+                {
+                    syncState.SyncLogReport = null;
+                }
             }
 
             LogicNode logic = (LogicNode)node;

--- a/NxGraph/Fsm/ExecutionStatus.cs
+++ b/NxGraph/Fsm/ExecutionStatus.cs
@@ -42,3 +42,36 @@ public enum ExecutionStatus : byte
     /// </summary>
     Ready // reset done; equivalent to Created, but AFTER the first run
 }
+
+/// <summary>
+/// Shared lifecycle-hardening checks for <see cref="ExecutionStatus"/> values that enter a
+/// machine from the outside (deserialized snapshots), used by every machine's <c>Resume</c>.
+/// </summary>
+internal static class ExecutionStatusValidation
+{
+    /// <summary>
+    /// Rejects status values that are not defined <see cref="ExecutionStatus"/> members, so a
+    /// corrupted or hand-crafted snapshot fails loudly instead of writing an undefined value
+    /// into a machine's status field. Implemented as a plain switch over the defined members —
+    /// not <see cref="Enum.IsDefined(Type, object)"/>, which boxes on netstandard2.1.
+    /// </summary>
+    internal static void ThrowIfUndefined(ExecutionStatus status)
+    {
+        switch (status)
+        {
+            case ExecutionStatus.Created:
+            case ExecutionStatus.Starting:
+            case ExecutionStatus.Running:
+            case ExecutionStatus.Transitioning:
+            case ExecutionStatus.Completed:
+            case ExecutionStatus.Failed:
+            case ExecutionStatus.Cancelled:
+            case ExecutionStatus.Resetting:
+            case ExecutionStatus.Ready:
+                return;
+            default:
+                throw new InvalidOperationException(
+                    $"Snapshot status value {(int)status} is not a defined ExecutionStatus");
+        }
+    }
+}

--- a/NxGraph/Fsm/IAsyncStateMachineObserver.cs
+++ b/NxGraph/Fsm/IAsyncStateMachineObserver.cs
@@ -86,7 +86,7 @@ public interface IAsyncStateMachineObserver
         return default;
     }
 
-    ValueTask OnLogReport(NodeId nodeId, string message, CancellationToken ct)
+    ValueTask OnLogReport(NodeId nodeId, string message, CancellationToken ct = default)
     {
         return default;
     }

--- a/NxGraph/Fsm/State.cs
+++ b/NxGraph/Fsm/State.cs
@@ -28,13 +28,18 @@ public abstract class State : ILogic, ILogReporter, IBlackboardSettable
     void IBlackboardSettable.SetBlackboards(in BlackboardContext context) => Bb = context;
 
     /// <summary>
-    /// Callback set by the sync runtime so the state can emit log messages.
+    /// Callback set by the sync runtimes so the state can emit log messages.
     /// Uses <see cref="Action{String}"/> instead of an async delegate.
+    /// Machine-owned while the state runs under any machine: every machine reassigns both
+    /// report slots per visit (its own from the observer, the other family's to null), so
+    /// machines sharing a graph each attribute reports to their own observer.
     /// </summary>
     public Action<string>? SyncLogReport { get; set; }
 
     /// <summary>
-    /// Async log report callback (used when the state is executed via the async <see cref="AsyncStateMachine"/>).
+    /// Async log report callback (wired when the state is executed via the async machines,
+    /// which resolve the state behind its <see cref="SyncLogicAdapter"/>). Machine-owned per
+    /// visit, like <see cref="SyncLogReport"/>.
     /// </summary>
     Func<string, CancellationToken, ValueTask>? ILogReporter.LogReport { get; set; }
 
@@ -84,10 +89,29 @@ public abstract class State : ILogic, ILogReporter, IBlackboardSettable
     }
 
 
+    /// <summary>
+    /// Emits a log message through the machine-wired report channel (observer
+    /// <c>OnLogReport</c>): the sync callback when a sync machine wired it, else the async
+    /// callback (the async machines wire that slot when this state runs behind the
+    /// sync-logic adapter). Under an async machine a genuinely asynchronous observer is
+    /// waited out synchronously, so delivery completes before <c>Log</c> returns on both
+    /// runtimes — the same contract as the behavior composites' report channel. The
+    /// callbacks are machine-wired <c>null</c> on observer-less machines, so <c>Log</c>
+    /// costs two null checks and nothing else there.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected void Log(string message)
     {
-        SyncLogReport?.Invoke(message);
+        if (SyncLogReport is { } sync)
+        {
+            sync(message);
+            return;
+        }
+
+        if (((ILogReporter)this).LogReport is { } asyncReport)
+        {
+            ValueTaskSync.Await(asyncReport(message, CancellationToken.None));
+        }
     }
 
     protected virtual void OnEnter() { }

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -387,14 +387,24 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
             case ExecutionStatus.Running:
             case ExecutionStatus.Transitioning:
             case ExecutionStatus.Starting:
+                // The gate is deliberately left alone here: a mid-run RoundPerTick machine
+                // legitimately holds it between ticks.
                 throw new InvalidOperationException("Cannot reset while starting, running, or transitioning.");
             case ExecutionStatus.Created:
             case ExecutionStatus.Ready:
+                // Defensive gate release: under correct operation the gate is never held at
+                // these statuses, so this is belt-and-braces against an enter-path throw
+                // leaking it — Reset() must never report Success on a machine that would
+                // still refuse to execute.
+                _executeGate = false;
+                return Result.Success;
+            case ExecutionStatus.Resetting:
+                // Another reset is already in flight — be idempotent rather than firing
+                // duplicate notifications. Mirrors AsyncStateMachine.ResetCore.
                 return Result.Success;
             case ExecutionStatus.Completed:
             case ExecutionStatus.Failed:
             case ExecutionStatus.Cancelled:
-            case ExecutionStatus.Resetting:
                 break;
             default:
                 throw new IndexOutOfRangeException(nameof(status));
@@ -451,6 +461,8 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         {
             throw new InvalidOperationException("Cannot resume from inside node logic.");
         }
+
+        ExecutionStatusValidation.ThrowIfUndefined(snapshot.Status);
 
         if (snapshot.Status is ExecutionStatus.Starting or ExecutionStatus.Transitioning
             or ExecutionStatus.Resetting)
@@ -571,18 +583,47 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
 
         _executeGate = true;
 
-        // Re-stamp this machine's context onto the (potentially shared) graph before running.
-        ApplyExecutionContext();
-        StampPendingEntry();
+        // Everything after the gate acquisition can throw (ApplyExecutionContext's stamp-time
+        // validation, and observer callbacks firing from TransitionTo/OnStateEntered — observer
+        // exceptions bubble by design). State.Execute's enter-catch resets HasEntered but knows
+        // nothing about the gate, so the gate must be released here or the machine is
+        // permanently locked. Mirrors AsyncStateMachine.OnEnterAsync.
+        try
+        {
+            // Re-stamp this machine's context onto the (potentially shared) graph before running.
+            ApplyExecutionContext();
+            StampPendingEntry();
 
-        TransitionTo(ExecutionStatus.Starting);
-        _current = _initial;
-        _attempts = 0;
-        _nodeEntered = false;
-        _nodeBoard?.ResetToDefaults();
-        LastOutcome = 0;
-        _observer?.OnStateEntered(_current);
-        TransitionTo(ExecutionStatus.Running);
+            TransitionTo(ExecutionStatus.Starting);
+            _current = _initial;
+            _attempts = 0;
+            _nodeEntered = false;
+            _nodeBoard?.ResetToDefaults();
+            LastOutcome = 0;
+            _observer?.OnStateEntered(_current);
+            TransitionTo(ExecutionStatus.Running);
+        }
+        catch
+        {
+            RepairTransientStatus();
+            _executeGate = false;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// If an observer threw while the machine was in a transient status (Starting/Resetting/
+    /// Transitioning), restore Ready without notifications so the machine stays usable —
+    /// Suspend/Reset reject transient statuses and a redundant re-transition would trip the
+    /// debug assert in <see cref="TransitionTo"/>.
+    /// </summary>
+    private void RepairTransientStatus()
+    {
+        ExecutionStatus status = _status;
+        if (status is ExecutionStatus.Starting or ExecutionStatus.Resetting or ExecutionStatus.Transitioning)
+        {
+            _status = ExecutionStatus.Ready;
+        }
     }
 
     protected override Result OnRun()

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using NxGraph.Blackboards;
 using NxGraph.Compatibility;
+using NxGraph.Diagnostics.Replay;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
 
@@ -695,6 +696,12 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         if (stateForLog is not null)
         {
             stateForLog.SyncLogReport = _observer is null ? null : _cachedLogReportCallback;
+
+            // Both slots are machine-owned per visit: State.Log (and the behavior-composite
+            // report bridge) falls back to the async slot when the sync one is null, so a
+            // callback left by an async machine that ran this shared graph earlier must not
+            // receive reports from this run.
+            ((ILogReporter)stateForLog).LogReport = null;
         }
 
         // Execute the node synchronously.

--- a/NxGraph/Tokens/AsyncTokenMachine.cs
+++ b/NxGraph/Tokens/AsyncTokenMachine.cs
@@ -823,6 +823,14 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
         if (reporter is not null)
         {
             reporter.LogReport = _observer is null ? null : _cachedLogReportCallback;
+
+            // Sync states read both slots (State.Log prefers the sync one), so the sync slot
+            // is cleared too — a callback left by a sync machine that ran this shared graph
+            // earlier must neither shadow this machine's observer nor receive its reports.
+            if (reporter is State syncState)
+            {
+                syncState.SyncLogReport = null;
+            }
         }
 
         if (!t.NodeEntered)

--- a/NxGraph/Tokens/AsyncTokenMachine.cs
+++ b/NxGraph/Tokens/AsyncTokenMachine.cs
@@ -384,6 +384,8 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
 
         try
         {
+            ExecutionStatusValidation.ThrowIfUndefined(snapshot.Status);
+
             if (snapshot.Status is ExecutionStatus.Starting or ExecutionStatus.Transitioning
                 or ExecutionStatus.Resetting)
             {

--- a/NxGraph/Tokens/AsyncTokenMachine.cs
+++ b/NxGraph/Tokens/AsyncTokenMachine.cs
@@ -499,30 +499,11 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                     "A stepped run is in progress. Finish it with StepAsync or Reset() before calling ExecuteAsync.");
             }
 
-            ExecutionStatus status = Status;
-            if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
-            {
-                switch (_restartPolicy)
-                {
-                    case RestartPolicy.Ignore:
-                        // Gate stays held; OnRunAsync returns the cached terminal result and
-                        // OnExitAsync releases the gate — mirrors AsyncStateMachine.
-                        return Result.InProgress;
-                    case RestartPolicy.Manual:
-                        throw new InvalidOperationException(
-                            $"AsyncTokenMachine is in terminal state '{status}'. Call Reset() before executing again.");
-                    default:
-                        await ResetCore(ct).ConfigureAwait(false);
-                        break;
-                }
-            }
-
-            ApplyExecutionContext();
-
-            await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
-            ClearRunState();
-            await SpawnRootTokenAsync(ct).ConfigureAwait(false);
-            await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
+            // Ignore policy returns false: the init is skipped, but the gate stays held so
+            // OnRunAsync returns the cached terminal result and OnExitAsync releases the
+            // gate — mirrors AsyncStateMachine. Either way OnEnterAsync hands off with
+            // InProgress.
+            _ = await TryBeginRunAsync(stepped: false, ct).ConfigureAwait(false);
 
             return Result.InProgress;
         }
@@ -532,6 +513,52 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             Volatile.Write(ref _executeGate, 0);
             throw;
         }
+    }
+
+    /// <summary>
+    /// The run-start init shared by <see cref="OnEnterAsync"/> and the first
+    /// <see cref="StepAsync"/> of a stepped run: applies the restart policy to a terminal
+    /// machine, re-stamps the execution context, and moves the machine
+    /// Starting → (spawn root token) → Running. Returns <c>false</c> for the
+    /// <see cref="RestartPolicy.Ignore"/> early-out — the callers translate that into their
+    /// distinct surface results (full-run: <see cref="Result.InProgress"/> with the gate held
+    /// so OnRunAsync returns the cached terminal result; stepped: the cached result
+    /// directly). Must run inside the caller's gate-repair try/catch: observer callbacks
+    /// fired here may throw, and which exceptions repair status and release the gate is
+    /// caller-specific behavior.
+    /// </summary>
+    private async ValueTask<bool> TryBeginRunAsync(bool stepped, CancellationToken ct)
+    {
+        ExecutionStatus status = Status;
+        if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+        {
+            switch (_restartPolicy)
+            {
+                case RestartPolicy.Ignore:
+                    return false;
+                case RestartPolicy.Manual:
+                    throw new InvalidOperationException(
+                        $"AsyncTokenMachine is in terminal state '{status}'. Call Reset() before " +
+                        $"{(stepped ? "stepping" : "executing")} again.");
+                default:
+                    // Auto: ResetCore (not Reset) because the caller already holds the gate.
+                    await ResetCore(ct).ConfigureAwait(false);
+                    break;
+            }
+        }
+
+        ApplyExecutionContext();
+
+        await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
+        ClearRunState();
+        await SpawnRootTokenAsync(ct).ConfigureAwait(false);
+        await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
+        if (stepped)
+        {
+            _stepping = true;
+        }
+
+        return true;
     }
 
     private async ValueTask SpawnRootTokenAsync(CancellationToken ct)
@@ -574,50 +601,91 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                 result = await RunRoundAsync(ct).ConfigureAwait(false);
             } while (!result.IsCompleted);
 
-            _terminalResult = result;
-
-            await TransitionTo(result == Result.Success ? ExecutionStatus.Completed : ExecutionStatus.Failed)
-                .ConfigureAwait(false);
-
-            if (_restartPolicy == RestartPolicy.Auto)
-            {
-                await ResetCore(ct).ConfigureAwait(false);
-            }
+            await CompleteRunAsync(result, ct).ConfigureAwait(false);
 
             return result;
         }
         catch (OperationCanceledException)
         {
-            if (!IsTerminal)
-            {
-                await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
-                _terminalResult = Result.Failure;
-                if (_restartPolicy == RestartPolicy.Auto)
-                {
-                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
-                }
-            }
-
+            // The `throw;` stays here (not in the handler) so the stack trace is unchanged.
+            await HandleRunCancelledAsync().ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
         {
-            if (!IsTerminal)
-            {
-                if (_observer is not null)
-                {
-                    await _observer.OnStateFailed(_steppingTokenId, _steppingNodeId, ex, ct).ConfigureAwait(false);
-                }
-
-                await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
-                _terminalResult = Result.Failure;
-                if (_restartPolicy == RestartPolicy.Auto)
-                {
-                    await ResetCore(CancellationToken.None).ConfigureAwait(false);
-                }
-            }
-
+            await HandleRunFaultAsync(ex, ct).ConfigureAwait(false);
             throw;
+        }
+    }
+
+    /// <summary>
+    /// The terminal cascade shared by <see cref="OnRunAsync"/> and <see cref="StepAsync"/>:
+    /// caches the terminal result, transitions to Completed/Failed (machine completion
+    /// notification), and applies the optional auto-reset-to-Ready. ResetCore (not Reset)
+    /// because the gate is held by the surrounding ExecuteAsync/StepAsync frame.
+    /// </summary>
+    private async ValueTask CompleteRunAsync(Result result, CancellationToken ct)
+    {
+        _terminalResult = result;
+
+        await TransitionTo(result == Result.Success ? ExecutionStatus.Completed : ExecutionStatus.Failed)
+            .ConfigureAwait(false);
+
+        if (_restartPolicy == RestartPolicy.Auto)
+        {
+            await ResetCore(ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Fault cascade for a cancellation escaping the round loop, shared by
+    /// <see cref="OnRunAsync"/> and <see cref="StepAsync"/> — the callers keep their own
+    /// <c>throw;</c> so the original stack trace is preserved. The <see cref="IsTerminal"/>
+    /// guard skips the cascade when the run already reached a terminal status (e.g. an
+    /// observer threw inside the Completed notification) so the completion notification is
+    /// never re-fired — mirrors AsyncStateMachine.
+    /// </summary>
+    private async ValueTask HandleRunCancelledAsync()
+    {
+        if (IsTerminal)
+        {
+            return;
+        }
+
+        await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
+        _terminalResult = Result.Failure;
+        if (_restartPolicy == RestartPolicy.Auto)
+        {
+            // CancellationToken.None: ct is already cancelled; reset must complete cleanly.
+            await ResetCore(CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Fault cascade for an unexpected exception escaping the round loop (per-token
+    /// failures are aggregated into the round result, not thrown), shared by
+    /// <see cref="OnRunAsync"/> and <see cref="StepAsync"/> — the callers keep their own
+    /// <c>throw;</c> so the original stack trace is preserved. Same
+    /// <see cref="IsTerminal"/> idempotence guard as <see cref="HandleRunCancelledAsync"/>.
+    /// </summary>
+    private async ValueTask HandleRunFaultAsync(Exception ex, CancellationToken ct)
+    {
+        if (IsTerminal)
+        {
+            return;
+        }
+
+        if (_observer is not null)
+        {
+            await _observer.OnStateFailed(_steppingTokenId, _steppingNodeId, ex, ct).ConfigureAwait(false);
+        }
+
+        await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
+        _terminalResult = Result.Failure;
+        if (_restartPolicy == RestartPolicy.Auto)
+        {
+            // CancellationToken.None: ct may already be cancelled/faulted; reset must complete cleanly.
+            await ResetCore(CancellationToken.None).ConfigureAwait(false);
         }
     }
 
@@ -647,31 +715,15 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
         {
             if (!_stepping)
             {
+                // Run-start init fires observer callbacks which may throw; repair transient
+                // status so the machine stays usable.
                 try
                 {
-                    ExecutionStatus status = Status;
-                    if (status is ExecutionStatus.Completed or ExecutionStatus.Failed or ExecutionStatus.Cancelled)
+                    if (!await TryBeginRunAsync(stepped: true, ct).ConfigureAwait(false))
                     {
-                        switch (_restartPolicy)
-                        {
-                            case RestartPolicy.Ignore:
-                                return _terminalResult;
-                            case RestartPolicy.Manual:
-                                throw new InvalidOperationException(
-                                    $"AsyncTokenMachine is in terminal state '{status}'. Call Reset() before stepping again.");
-                            default:
-                                await ResetCore(ct).ConfigureAwait(false);
-                                break;
-                        }
+                        // Ignore policy: the stepped surface returns the cached result directly.
+                        return _terminalResult;
                     }
-
-                    ApplyExecutionContext();
-
-                    await TransitionTo(ExecutionStatus.Starting).ConfigureAwait(false);
-                    ClearRunState();
-                    await SpawnRootTokenAsync(ct).ConfigureAwait(false);
-                    await TransitionTo(ExecutionStatus.Running).ConfigureAwait(false);
-                    _stepping = true;
                 }
                 catch
                 {
@@ -688,37 +740,13 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             catch (OperationCanceledException)
             {
                 _stepping = false;
-                if (!IsTerminal)
-                {
-                    await TransitionTo(ExecutionStatus.Cancelled).ConfigureAwait(false);
-                    _terminalResult = Result.Failure;
-                    if (_restartPolicy == RestartPolicy.Auto)
-                    {
-                        await ResetCore(CancellationToken.None).ConfigureAwait(false);
-                    }
-                }
-
+                await HandleRunCancelledAsync().ConfigureAwait(false);
                 throw;
             }
             catch (Exception ex)
             {
                 _stepping = false;
-                if (!IsTerminal)
-                {
-                    if (_observer is not null)
-                    {
-                        await _observer.OnStateFailed(_steppingTokenId, _steppingNodeId, ex, ct)
-                            .ConfigureAwait(false);
-                    }
-
-                    await TransitionTo(ExecutionStatus.Failed).ConfigureAwait(false);
-                    _terminalResult = Result.Failure;
-                    if (_restartPolicy == RestartPolicy.Auto)
-                    {
-                        await ResetCore(CancellationToken.None).ConfigureAwait(false);
-                    }
-                }
-
+                await HandleRunFaultAsync(ex, ct).ConfigureAwait(false);
                 throw;
             }
 
@@ -728,14 +756,7 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             }
 
             _stepping = false;
-            _terminalResult = result;
-            await TransitionTo(result == Result.Success ? ExecutionStatus.Completed : ExecutionStatus.Failed)
-                .ConfigureAwait(false);
-
-            if (_restartPolicy == RestartPolicy.Auto)
-            {
-                await ResetCore(ct).ConfigureAwait(false);
-            }
+            await CompleteRunAsync(result, ct).ConfigureAwait(false);
 
             return result;
         }

--- a/NxGraph/Tokens/TokenMachine.cs
+++ b/NxGraph/Tokens/TokenMachine.cs
@@ -294,14 +294,24 @@ public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
             case ExecutionStatus.Running:
             case ExecutionStatus.Transitioning:
             case ExecutionStatus.Starting:
+                // The gate is deliberately left alone here: a mid-run RoundPerTick machine
+                // legitimately holds it between ticks.
                 throw new InvalidOperationException("Cannot reset while starting, running, or transitioning.");
             case ExecutionStatus.Created:
             case ExecutionStatus.Ready:
+                // Defensive gate release: under correct operation the gate is never held at
+                // these statuses, so this is belt-and-braces against an enter-path throw
+                // leaking it — Reset() must never report Success on a machine that would
+                // still refuse to execute.
+                _executeGate = false;
+                return Result.Success;
+            case ExecutionStatus.Resetting:
+                // Another reset is already in flight — be idempotent rather than firing
+                // duplicate notifications. Mirrors AsyncTokenMachine.ResetCore.
                 return Result.Success;
             case ExecutionStatus.Completed:
             case ExecutionStatus.Failed:
             case ExecutionStatus.Cancelled:
-            case ExecutionStatus.Resetting:
                 break;
             default:
                 throw new IndexOutOfRangeException(nameof(status));
@@ -397,6 +407,8 @@ public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         {
             throw new InvalidOperationException("Cannot resume from inside node logic.");
         }
+
+        ExecutionStatusValidation.ThrowIfUndefined(snapshot.Status);
 
         if (snapshot.Status is ExecutionStatus.Starting or ExecutionStatus.Transitioning
             or ExecutionStatus.Resetting)
@@ -514,13 +526,28 @@ public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
 
         _executeGate = true;
 
-        // Re-stamp this machine's context onto the (potentially shared) graph before running.
-        ApplyExecutionContext();
+        // Everything after the gate acquisition can throw (ApplyExecutionContext's stamp-time
+        // validation, and observer callbacks firing from TransitionTo/OnTokenSpawned — observer
+        // exceptions bubble by design). State.Execute's enter-catch resets HasEntered but knows
+        // nothing about the gate, so the gate must be released here or the machine is
+        // permanently locked. Whatever ClearRunState/SpawnRootToken already did is left as-is —
+        // the next run start calls ClearRunState() again. Mirrors AsyncTokenMachine.OnEnterAsync.
+        try
+        {
+            // Re-stamp this machine's context onto the (potentially shared) graph before running.
+            ApplyExecutionContext();
 
-        TransitionTo(ExecutionStatus.Starting);
-        ClearRunState();
-        SpawnRootToken();
-        TransitionTo(ExecutionStatus.Running);
+            TransitionTo(ExecutionStatus.Starting);
+            ClearRunState();
+            SpawnRootToken();
+            TransitionTo(ExecutionStatus.Running);
+        }
+        catch
+        {
+            RepairTransientStatus();
+            _executeGate = false;
+            throw;
+        }
     }
 
     private void SpawnRootToken()
@@ -528,6 +555,15 @@ public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         Token root = Alloc();
         _observer?.OnTokenSpawned(root.Id, -1, Graph.StartNode.Id);
         ArriveAt(root, Graph.StartNode.Id.Index, 0);
+    }
+
+    private void RepairTransientStatus()
+    {
+        ExecutionStatus status = _status;
+        if (status is ExecutionStatus.Starting or ExecutionStatus.Resetting or ExecutionStatus.Transitioning)
+        {
+            _status = ExecutionStatus.Ready;
+        }
     }
 
     protected override Result OnRun()

--- a/NxGraph/Tokens/TokenMachine.cs
+++ b/NxGraph/Tokens/TokenMachine.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using NxGraph.Blackboards;
 using NxGraph.Compatibility;
+using NxGraph.Diagnostics.Replay;
 using NxGraph.Fsm;
 using NxGraph.Graphs;
 
@@ -688,6 +689,12 @@ public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         if (stateForLog is not null)
         {
             stateForLog.SyncLogReport = _observer is null ? null : _cachedLogReportCallback;
+
+            // Both slots are machine-owned per visit: State.Log (and the behavior-composite
+            // report bridge) falls back to the async slot when the sync one is null, so a
+            // callback left by an async machine that ran this shared graph earlier must not
+            // receive reports from this run.
+            ((ILogReporter)stateForLog).LogReport = null;
         }
 
         ILogic syncLogic = logicNode.Logic!;

--- a/NxGraph/ValueTaskSync.cs
+++ b/NxGraph/ValueTaskSync.cs
@@ -1,0 +1,27 @@
+namespace NxGraph;
+
+/// <summary>
+/// Synchronous completion helper for <see cref="ValueTask"/>-returning callbacks that must
+/// finish before a sync caller returns (delivery-before-return). The single shared body used
+/// by the sync-side log-report bridges (<c>State.Log</c>, the behavior composites): the
+/// completed-successfully fast path costs nothing, and only a genuinely asynchronous
+/// callback pays the blocking <c>AsTask()</c> fallback.
+/// </summary>
+internal static class ValueTaskSync
+{
+    /// <summary>
+    /// Waits the task out synchronously: observe the result directly when it already
+    /// completed successfully; otherwise block on the materialized task (propagating
+    /// faults/cancellation like any awaited task).
+    /// </summary>
+    internal static void Await(ValueTask task)
+    {
+        if (task.IsCompletedSuccessfully)
+        {
+            task.GetAwaiter().GetResult();
+            return;
+        }
+
+        task.AsTask().GetAwaiter().GetResult();
+    }
+}


### PR DESCRIPTION
## What this does

**Fixes a machine-bricking lifecycle bug.** An exception thrown during sync run-start (an observer callback or context stamping) permanently locked `StateMachine` and `TokenMachine` — every later `Execute()`/`Reset()` threw. Both sync machines now mirror the async machines' existing repair: run-start init is wrapped so a throw repairs the transient status back to Ready (plain field write, no notifications) and releases the execute gate. `Reset()` additionally clears the gate on its Created/Ready early-return and treats `Resetting` as idempotent (matching async `ResetCore`), and all four machines' `Resume` now reject snapshot statuses that are not defined `ExecutionStatus` members via one shared internal helper.

**Bridges `State.Log` across runtimes.** A sync state's `Log(message)` was silently dropped under `AsyncStateMachine`/`AsyncTokenMachine`. `Log` now prefers the sync callback and falls back to the machine-wired async slot through a single shared `ValueTaskSync.Await` (delivery completes before `Log` returns, matching the behavior-composite contract). The wiring audit also found and fixed a cross-family leak: all four machines now treat both report slots as machine-owned per visit, clearing the other family's callback, so machines sharing one graph can never deliver reports to a previous machine's observer (regression-tested in both directions).

**Deduplicates the async machines' run-start/terminal/fault blocks.** The init block and the terminal/fault cascades existed twice inside each async machine (full-run vs stepped path) — the structural reason an earlier async-only fix never reached the sync twins. Each file now holds one private copy (`TryBeginRunAsync`, `CompleteRunAsync`, `HandleRunCancelledAsync`/`HandleRunFaultAsync`); `throw;` stays in the callers so stack traces are unchanged, and the entire pre-existing suite passed unmodified at that commit.

**Adds a cross-runtime parity conformance suite** (`NxGraph.Tests/Parity/`): 18 FSM scenarios run through sync RunToJoin, sync stepped, async full-run, and async stepped adapters plus a token-machine matrix, compared as order-exact normalized traces. Each documented mechanical difference is normalized exactly once with a comment naming its source; timing never enters a trace. Drift detection was verified during development: suppressing one `OnStateEntered` locally failed 16 of 18 scenarios.

## Verification

Full Release suite green at every commit (682 + 193 at the branch tip, 0 skipped); AllocationGate 0 B including two new log-bridge cases; public API baseline unchanged; the dedup commit touched only the two async machine files and passed the pre-existing suite without a single test edit.

## Merge notes

Independent of the other open hardening PRs (validated combined locally). The build/test hardening PR should land last.
