### PR TITLE
Harden serialization read paths and codify Skip-policy data safety

### DIFF
--- a/NxGraph.Serialization.Abstraction/IBlackboardSerializer.cs
+++ b/NxGraph.Serialization.Abstraction/IBlackboardSerializer.cs
@@ -16,7 +16,15 @@ public enum BlackboardMismatchPolicy
     Strict = 0,
 
     /// <summary>
-    /// Skip entries that don't fit the schema (schema evolution). Corrupt values still throw.
+    /// Skip entries that don't fit the schema (schema evolution): the matching subset is
+    /// restored over defaults, mismatched entries are dropped. Corrupt values still throw.
+    /// <para>
+    /// Data safety: a restore that would apply <b>zero</b> entries — mismatched header, every
+    /// entry skipped, or an entry-less payload — leaves the target board completely untouched
+    /// (live values preserved). Skip never resets a board to defaults without restoring at
+    /// least one value; the documented "defaults + payload" post-state applies only once at
+    /// least one payload entry matches the live schema.
+    /// </para>
     /// </summary>
     Skip = 1,
 }

--- a/NxGraph.Serialization.Abstraction/IContainerCodec.cs
+++ b/NxGraph.Serialization.Abstraction/IContainerCodec.cs
@@ -20,7 +20,10 @@ public interface IContainerCodec;
 /// Order contract (normative): <see cref="ISubGraphProvider.SubGraphs"/> enumeration order
 /// = wire order = the <c>children</c> order passed to
 /// <see cref="Deserialize"/> — order is identity, exactly as region order is for
-/// <c>RegionMask</c> bits. The rebuilt container must surface the <b>new</b>
+/// <c>RegionMask</c> bits. This leans on the hard <see cref="ISubGraphProvider.SubGraphs"/>
+/// requirement that enumeration is stable and deterministic (identical sequence every time);
+/// a container backed by an unordered collection corrupts reconstruction silently, and the
+/// graph serializer verifies the requirement in DEBUG builds with a second enumeration. The rebuilt container must surface the <b>new</b>
 /// <see cref="Graph"/> instances via its own <c>SubGraphs</c> and keep
 /// <c>IBlackboardSettable</c> forwarding — those walks are what agent stamping and
 /// blackboard binding reach (the standing user-container contract). A container that hides

--- a/NxGraph.Serialization.Tests/BlackboardSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/BlackboardSerializationTests.cs
@@ -307,6 +307,122 @@ public class BlackboardSerializationTests
     }
 
     [Test]
+    public async Task skip_restore_that_stages_nothing_leaves_live_values_untouched()
+    {
+        // The header matches but every payload entry mismatches (value type changed): under
+        // Skip the restore stages zero entries and must leave the board untouched — wiping
+        // live values to defaults while applying no payload data would be pure data loss,
+        // the same conclusion as a header mismatch.
+        BlackboardSchema saved = NewSchema();
+        BlackboardKey<int> savedScore = saved.Register<int>("score");
+        Blackboard source = new(saved);
+        source.Set(savedScore, 9);
+
+        BlackboardSchema live = NewSchema();
+        BlackboardKey<string> liveScore = live.Register<string>("score", "default");
+
+        await using (MemoryStream jsonStream = await SaveJson(_serializer, source))
+        {
+            Blackboard target = new(live);
+            target.Set(liveScore, "live");
+            await _serializer.RestoreFromJsonAsync(target, jsonStream, BlackboardMismatchPolicy.Skip);
+            Assert.That(target.Get(liveScore), Is.EqualTo("live"),
+                "A JSON Skip restore that applies nothing must leave live values untouched.");
+        }
+
+        await using (MemoryStream binaryStream = await SaveBinary(_serializer, source))
+        {
+            Blackboard target = new(live);
+            target.Set(liveScore, "live");
+            await _serializer.RestoreFromBinaryAsync(target, binaryStream, BlackboardMismatchPolicy.Skip);
+            Assert.That(target.Get(liveScore), Is.EqualTo("live"),
+                "A binary Skip restore that applies nothing must leave live values untouched.");
+        }
+    }
+
+    [Test]
+    public async Task entryless_payload_no_ops_under_skip_and_restores_defaults_under_strict()
+    {
+        // A legitimately entry-less payload (saved from a schema with zero keys). Codified
+        // rule: Skip mutates the target only when at least one entry stages, so it no-ops;
+        // Strict has nothing to mismatch and keeps the documented "defaults + payload"
+        // post-state — all defaults.
+        BlackboardSchema saved = NewSchema(); // zero keys registered
+        Blackboard source = new(saved);
+
+        BlackboardSchema live = NewSchema();
+        BlackboardKey<int> liveKey = live.Register<int>("value", 100);
+
+        await using (MemoryStream jsonSkip = await SaveJson(_serializer, source))
+        {
+            Blackboard target = new(live);
+            target.Set(liveKey, 55);
+            await _serializer.RestoreFromJsonAsync(target, jsonSkip, BlackboardMismatchPolicy.Skip);
+            Assert.That(target.Get(liveKey), Is.EqualTo(55),
+                "Skip: an entry-less payload stages nothing and must not touch the board (JSON).");
+        }
+
+        await using (MemoryStream binarySkip = await SaveBinary(_serializer, source))
+        {
+            Blackboard target = new(live);
+            target.Set(liveKey, 55);
+            await _serializer.RestoreFromBinaryAsync(target, binarySkip, BlackboardMismatchPolicy.Skip);
+            Assert.That(target.Get(liveKey), Is.EqualTo(55),
+                "Skip: an entry-less payload stages nothing and must not touch the board (binary).");
+        }
+
+        await using (MemoryStream jsonStrict = await SaveJson(_serializer, source))
+        {
+            Blackboard target = new(live);
+            target.Set(liveKey, 55);
+            await _serializer.RestoreFromJsonAsync(target, jsonStrict);
+            Assert.That(target.Get(liveKey), Is.EqualTo(100),
+                "Strict: defaults + payload — an entry-less payload restores all defaults (JSON).");
+        }
+
+        await using (MemoryStream binaryStrict = await SaveBinary(_serializer, source))
+        {
+            Blackboard target = new(live);
+            target.Set(liveKey, 55);
+            await _serializer.RestoreFromBinaryAsync(target, binaryStrict);
+            Assert.That(target.Get(liveKey), Is.EqualTo(100),
+                "Strict: defaults + payload — an entry-less payload restores all defaults (binary).");
+        }
+    }
+
+    [Test]
+    public async Task skip_partial_match_still_resets_unmatched_live_keys_to_defaults()
+    {
+        // With at least one staged entry, Skip keeps the documented reset-then-apply
+        // semantics: post-state is defaults + the matching subset, so live values on keys
+        // the payload cannot restore land back on their registered defaults.
+        BlackboardSchema saved = NewSchema();
+        BlackboardKey<int> savedKept = saved.Register<int>("kept");
+        saved.Register<int>("removed");
+
+        Blackboard source = new(saved);
+        source.Set(savedKept, 5);
+
+        BlackboardSchema live = NewSchema();
+        BlackboardKey<int> liveKept = live.Register<int>("kept");
+        BlackboardKey<int> liveOther = live.Register<int>("other", 7);
+
+        await using MemoryStream stream = await SaveJson(_serializer, source);
+        Blackboard target = new(live);
+        target.Set(liveKept, 111);
+        target.Set(liveOther, 222);
+        await _serializer.RestoreFromJsonAsync(target, stream, BlackboardMismatchPolicy.Skip);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(target.Get(liveKept), Is.EqualTo(5), "The matching subset restores.");
+            Assert.That(target.Get(liveOther), Is.EqualTo(7),
+                "Keys outside the staged subset land on their defaults — reset-then-apply is " +
+                "unchanged once at least one entry stages.");
+        });
+    }
+
+    [Test]
     public void newer_payload_version_is_rejected()
     {
         BlackboardSchema schema = NewSchema();

--- a/NxGraph.Serialization.Tests/ContainerCodecSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/ContainerCodecSerializationTests.cs
@@ -474,4 +474,55 @@ public class ContainerCodecSerializationTests
         public string Serialize(ISubGraphProvider container) => "null";
         public IAsyncLogic Deserialize(string payload, IReadOnlyList<Graph> children) => null!;
     }
+
+#if DEBUG
+    /// <summary>
+    /// Deliberately violates the SubGraphs ordering contract: every enumeration alternates
+    /// between forward and reversed child order, so any two consecutive enumerations differ
+    /// (an unordered backing collection would misbehave the same way). Alternation — rather
+    /// than "reverse from the second enumeration on" — keeps the violation visible no matter
+    /// how many times validation walked SubGraphs before the serializer does.
+    /// </summary>
+    private sealed class UnstableOrderContainer(params Graph[] children) : IAsyncLogic, ISubGraphProvider
+    {
+        private int _enumerations;
+
+        public IEnumerable<Graph> SubGraphs
+        {
+            get
+            {
+                bool reverse = _enumerations++ % 2 == 1;
+                for (int i = 0; i < children.Length; i++)
+                {
+                    yield return children[reverse ? children.Length - 1 - i : i];
+                }
+            }
+        }
+
+        public ValueTask<Result> ExecuteAsync(CancellationToken ct = default) => ResultHelpers.Success;
+    }
+
+    [Test]
+    public void Unstable_subgraph_enumeration_order_is_caught_by_the_debug_check()
+    {
+        // DEBUG builds double-enumerate SubGraphs in the serializer's container path and fail
+        // loud on an unstable sequence — wire order is reconstruction identity, so an
+        // unordered backing collection would otherwise corrupt the rebuilt children silently.
+        // (Release builds compile the check out; this test only exists in DEBUG.)
+        RegistryCodec codec = new();
+        Graph c0 = GraphBuilder
+            .StartWithAsync(codec.Register("c0", new KeyedState("c0", () => Result.Success)))
+            .Build();
+        Graph c1 = GraphBuilder
+            .StartWithAsync(codec.Register("c1", new KeyedState("c1", () => Result.Success)))
+            .Build();
+        Graph parent = GraphBuilder
+            .StartWithAsync(new UnstableOrderContainer(c0, c1))
+            .Build();
+
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await SerializerWith(codec).ToJsonAsync(parent, new MemoryStream()));
+        Assert.That(ex!.Message, Does.Contain("stable, deterministic order"));
+    }
+#endif
 }

--- a/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
+++ b/NxGraph.Serialization.Tests/GraphSerializerTestsTextCodec.cs
@@ -1,4 +1,6 @@
+using System.Buffers;
 using System.Text;
+using MessagePack;
 using NxGraph.Authoring;
 using NxGraph.Fsm.Async;
 using NxGraph.Graphs;
@@ -293,6 +295,259 @@ public class GraphSerializerTestsTextCodec
             Assert.That(((DummyState)((LogicNode)roundTripped.StartNode).AsyncLogic).Data, Is.EqualTo("Default"));
             Assert.That(((DummyState)((LogicNode)roundTripped.GetNodeByIndex(1)).AsyncLogic).Data,
                 Is.EqualTo("StateMachine"));
+        });
+    }
+
+    // ── Consistency-pass guards: duplicate subgraph claims, version floor, canonical order ──
+
+    private const string DummyLogicJson = "\"{\\\"Data\\\":\\\"x\\\"}\"";
+
+    [Test]
+    public void FromJsonAsync_rejects_payload_with_duplicate_subgraph_owner()
+    {
+        // Two subgraph payloads claiming the same owner node: the first used to be silently
+        // dropped (HashSet dedup on the claims pass, dictionary overwrite on the rebuild
+        // pass); the SubGraphs section now has the same duplicate-claim guard as every
+        // sibling section.
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": {{DummyLogicJson}} },
+                { "$type": "txt", "index": 1, "name": "sub", "logic": "StateMachine" }
+              ],
+              "transitions": [ { "destination": 1 }, { "destination": -1 } ],
+              "subGraphs": [
+                { "ownerIndex": 1,
+                  "graph": { "version": {{SerializationVersion.Version}},
+                             "nodes": [ { "$type": "txt", "index": 0, "name": "c0", "logic": {{DummyLogicJson}} } ],
+                             "transitions": [ { "destination": -1 } ],
+                             "subGraphs": [], "name": null, "index": -1 } },
+                { "ownerIndex": 1,
+                  "graph": { "version": {{SerializationVersion.Version}},
+                             "nodes": [ { "$type": "txt", "index": 0, "name": "c1", "logic": {{DummyLogicJson}} } ],
+                             "transitions": [ { "destination": -1 } ],
+                             "subGraphs": [], "name": null, "index": -1 } }
+              ],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _serializer.FromJsonAsync(source));
+        Assert.That(ex!.Message, Does.Contain("Subgraph DTO owner index 1 is duplicated"));
+    }
+
+    [Test]
+    public void FromJsonAsync_rejects_payload_without_a_version()
+    {
+        // No "version" property at all: GraphDto.Version defaults to 0 (not the current
+        // version), so a version-stripped payload cannot pass as current and sail past the
+        // newer-than-supported gate.
+        string json = $$"""
+            {
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": {{DummyLogicJson}} } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _serializer.FromJsonAsync(source));
+        Assert.That(ex!.Message, Does.Contain("carries no version"));
+    }
+
+    [Test]
+    public void FromJsonAsync_rejects_payload_with_version_zero()
+    {
+        string json = $$"""
+            {
+              "version": 0,
+              "nodes": [ { "$type": "txt", "index": 0, "name": "a", "logic": {{DummyLogicJson}} } ],
+              "transitions": [ { "destination": -1 } ],
+              "subGraphs": [],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _serializer.FromJsonAsync(source));
+        Assert.That(ex!.Message, Does.Contain("carries no version"));
+    }
+
+    [Test]
+    public void FromJsonAsync_rejects_nested_subgraph_payload_without_a_version()
+    {
+        // The version floor is enforced per nesting level, like the newer-than gate: a child
+        // graph with its "version" stripped must not read as current just because the parent
+        // carries one.
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 0, "name": "a", "logic": {{DummyLogicJson}} },
+                { "$type": "txt", "index": 1, "name": "sub", "logic": "StateMachine" }
+              ],
+              "transitions": [ { "destination": 1 }, { "destination": -1 } ],
+              "subGraphs": [
+                { "ownerIndex": 1,
+                  "graph": { "nodes": [ { "$type": "txt", "index": 0, "name": "c0", "logic": {{DummyLogicJson}} } ],
+                             "transitions": [ { "destination": -1 } ],
+                             "subGraphs": [], "name": null, "index": -1 } }
+              ],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _serializer.FromJsonAsync(source));
+        Assert.That(ex!.Message, Does.Contain("carries no version"));
+    }
+
+    [Test]
+    public void FromJsonAsync_rejects_payload_with_non_canonical_node_order()
+    {
+        // Positions swapped: logic would still land correctly (it is installed by Index), but
+        // the rebuild passes re-read node names positionally (dto.Nodes[ownerIndex]), so
+        // canonical order (Nodes[i].Index == i) is required for the payload to be sound.
+        string json = $$"""
+            {
+              "version": {{SerializationVersion.Version}},
+              "nodes": [
+                { "$type": "txt", "index": 1, "name": "b", "logic": {{DummyLogicJson}} },
+                { "$type": "txt", "index": 0, "name": "a", "logic": {{DummyLogicJson}} }
+              ],
+              "transitions": [ { "destination": -1 }, { "destination": -1 } ],
+              "subGraphs": [],
+              "name": null,
+              "index": -1
+            }
+            """;
+
+        using MemoryStream source = new(Encoding.UTF8.GetBytes(json));
+        InvalidOperationException? ex = Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await _serializer.FromJsonAsync(source));
+        Assert.That(ex!.Message, Does.Contain("canonical order"));
+    }
+
+    [Test]
+    public void Serialization_version_only_moves_with_a_deliberate_format_addition()
+    {
+        // Read-side hardening (duplicate-claim guards, version floor, canonical order, header
+        // drains) must never move the payload version — the project bumps it only for
+        // structural format additions. Update this pin consciously, together with the
+        // changelog comment in SerializationVersion.cs, when such an addition ships.
+        Assert.That(SerializationVersion.Version, Is.EqualTo(9));
+    }
+
+    // ── Crafted MessagePack: inflated header counts must drain, not desync ──
+
+    private static void WriteTextNode(ref MessagePackWriter writer, int index, string name, string logic)
+    {
+        writer.WriteArrayHeader(4); // [Type, Index, Name, Logic]
+        writer.Write(0); // 0 = text node
+        writer.Write(index);
+        writer.Write(name);
+        writer.Write(logic);
+    }
+
+    private static void WriteTransition(ref MessagePackWriter writer, int destination)
+    {
+        writer.WriteArrayHeader(2); // [Destination, FailureDestination]
+        writer.Write(destination);
+        writer.Write(-1);
+    }
+
+    /// <summary>
+    /// A parent graph whose nested subgraph's GraphDto array header declares one element more
+    /// than the current 16-element shape (the 16 known fields plus one trailing nil). The
+    /// parent carries a retry policy <i>after</i> the subgraph section, so its reads only stay
+    /// aligned if the child read drains the extra element instead of leaving it in the stream.
+    /// </summary>
+    private static byte[] CraftBinaryPayloadWithInflatedChildHeader()
+    {
+        ArrayBufferWriter<byte> buffer = new();
+        MessagePackWriter writer = new(buffer);
+
+        // Parent GraphDto: the regular 16-element v9 shape.
+        writer.WriteArrayHeader(16);
+        writer.Write(SerializationVersion.Version); // 0. version
+        writer.Write(-1); // 1. index
+        writer.WriteNil(); // 2. name
+        writer.WriteArrayHeader(2); // 3. nodes
+        WriteTextNode(ref writer, 0, "a", "{\"Data\":\"a\"}");
+        WriteTextNode(ref writer, 1, "sub", "StateMachine");
+        writer.WriteArrayHeader(2); // 4. transitions
+        WriteTransition(ref writer, 1);
+        WriteTransition(ref writer, -1);
+        writer.WriteArrayHeader(1); // 5. subGraphs
+        writer.WriteArrayHeader(2); //    SubGraphDto: [OwnerIndex, GraphDto]
+        writer.Write(1);
+
+        // Child GraphDto with an inflated header: 17 declared elements.
+        writer.WriteArrayHeader(17);
+        writer.Write(SerializationVersion.Version);
+        writer.Write(-1);
+        writer.WriteNil();
+        writer.WriteArrayHeader(1); // nodes
+        WriteTextNode(ref writer, 0, "c", "{\"Data\":\"c\"}");
+        writer.WriteArrayHeader(1); // transitions
+        WriteTransition(ref writer, -1);
+        for (int section = 0; section < 11; section++)
+        {
+            writer.WriteArrayHeader(0); // subGraphs .. behaviors, all empty
+        }
+
+        writer.WriteNil(); // the unknown 17th element the reader must drain
+
+        // Parent sections 6..15: a real retry policy first, then the rest empty. Without the
+        // child drain, this policy would be read one slot late and misparse.
+        writer.WriteArrayHeader(1); // 6. retryPolicies
+        writer.WriteArrayHeader(4); //    [Index, MaxAttempts, BackoffTicks, BackoffKind]
+        writer.Write(0);
+        writer.Write(2);
+        writer.Write(0L);
+        writer.Write(0);
+        for (int section = 0; section < 9; section++)
+        {
+            writer.WriteArrayHeader(0); // 7. outcomeCodes .. 15. behaviors, all empty
+        }
+
+        writer.Flush();
+        return buffer.WrittenSpan.ToArray();
+    }
+
+    [Test]
+    public async Task Crafted_binary_payload_with_inflated_child_header_is_drained_not_desynced()
+    {
+        // A header count above the known shape (while the version is still current) used to
+        // leave the reader mid-array after the nested graph, desyncing every subsequent read
+        // of the parent. The reader now drains unknown trailing elements, so the parent's
+        // sections after the subgraph still parse correctly.
+        byte[] payload = CraftBinaryPayloadWithInflatedChildHeader();
+
+        using MemoryStream source = new(payload);
+        Graph rebuilt = await _serializer.FromBinaryAsync(source);
+
+        LogicNode owner = (LogicNode)rebuilt.GetNodeByIndex(1);
+        Assert.Multiple(() =>
+        {
+            Assert.That(rebuilt.NodeCount, Is.EqualTo(2));
+            Assert.That(owner.AsyncLogic, Is.InstanceOf<AsyncStateMachine>(),
+                "The nested-machine claim must still resolve after the child read.");
+            Assert.That(((AsyncStateMachine)owner.AsyncLogic).Graph.NodeCount, Is.EqualTo(1));
+            Assert.That(rebuilt.RetryPolicies, Is.Not.Null,
+                "The parent's post-subgraph sections must still line up — no reader desync.");
+            Assert.That(rebuilt.RetryPolicies![0].MaxAttempts, Is.EqualTo(2));
         });
     }
 }

--- a/NxGraph.Serialization/BlackboardSerializer.cs
+++ b/NxGraph.Serialization/BlackboardSerializer.cs
@@ -87,7 +87,7 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
         // a payload missing "values" would otherwise surface as a NullReferenceException.
         if (dto.Values is null)
         {
-            throw new InvalidOperationException("Failed to parse Blackboard JSON.");
+            throw new InvalidOperationException("Blackboard JSON payload has no 'values' array.");
         }
 
         if (dto.Version > PayloadVersion)
@@ -109,7 +109,8 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
         {
             if (entry.Key is null)
             {
-                throw new InvalidOperationException("Failed to parse Blackboard JSON.");
+                throw new InvalidOperationException(
+                    "Blackboard JSON payload contains an entry with a null key.");
             }
 
             if (!TryMatchEntry(target, entry.Key, entry.Type, policy, out BlackboardKeyDescriptor? descriptor))
@@ -130,6 +131,17 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
             }
 
             staged.Add((descriptor!, value));
+        }
+
+        // Skip data safety: a restore that staged nothing must not zero the board. Either
+        // every payload entry was skipped (all unknown or type-changed) or the payload was
+        // legitimately entry-less — both mean "no data for this schema", the same conclusion
+        // as a header mismatch, so the target keeps its live values. Strict reaches this
+        // point with an empty staged set only for an entry-less payload (it throws on the
+        // first mismatch otherwise) and keeps the documented defaults + payload post-state.
+        if (policy == BlackboardMismatchPolicy.Skip && staged.Count == 0)
+        {
+            return;
         }
 
         // Deterministic post-state: defaults + payload. Keys absent from the payload land on
@@ -268,6 +280,13 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
             reader.Skip(); // forward compatibility: ignore future header elements
         }
 
+        // Skip data safety, mirroring the JSON path: zero staged entries — all skipped or an
+        // entry-less payload — leave the target untouched instead of zeroing it to defaults.
+        if (policy == BlackboardMismatchPolicy.Skip && staged.Count == 0)
+        {
+            return;
+        }
+
         target.ResetToDefaults();
         foreach ((BlackboardKeyDescriptor descriptor, object? value) in staged)
         {
@@ -280,6 +299,15 @@ public sealed class BlackboardSerializer : IBlackboardJsonSerializer, IBlackboar
     /// <summary>
     /// Verifies the payload header against the live schema. Returns <see langword="false"/>
     /// to skip the whole restore (Skip policy); throws under Strict.
+    /// <para>
+    /// Null-name wildcard (intended): the name check only fires when <b>both</b> sides are
+    /// named — a <see langword="null"/> schema name on either side matches anything, and scope
+    /// alone decides. Unnamed schemas are common (the name is optional presentation data), so
+    /// an unnamed board accepts payloads saved from named schemas and vice versa; tightening
+    /// this to a mismatch would make naming a previously unnamed schema break every existing
+    /// payload. Scope must always match exactly, and per-entry key/type verification still
+    /// applies either way.
+    /// </para>
     /// </summary>
     private static bool HeaderMatches(Blackboard target, string? payloadSchemaName, int payloadScope,
         BlackboardMismatchPolicy policy)

--- a/NxGraph.Serialization/GraphDto.cs
+++ b/NxGraph.Serialization/GraphDto.cs
@@ -36,12 +36,14 @@ internal sealed class GraphDto
     }
 
     /// <summary>
-    /// Serialized payload version. Defaults to <see cref="SerializationVersion.Version"/> for
-    /// freshly-constructed DTOs so the JSON/MessagePack writers emit a version on the wire,
-    /// and is overwritten by the deserializer when reading an existing payload so callers can
-    /// detect version mismatches.
+    /// Serialized payload version. Defaults to <c>0</c> ("no version seen"): the writer stamps
+    /// <see cref="SerializationVersion.Version"/> explicitly when building a payload
+    /// (<c>GraphSerializer.ToDto</c>), and the readers overwrite it with the payload's value.
+    /// Defaulting to the current version instead would make a JSON payload with its
+    /// <c>version</c> property stripped indistinguishable from a current one and sail past the
+    /// read-path version gates; <c>0</c> makes it detectable and rejectable.
     /// </summary>
-    public int Version { get; set; } = SerializationVersion.Version;
+    public int Version { get; set; }
 
     public INodeDto[] Nodes { get; set; }
     public TransitionDto[] Transitions { get; set; }

--- a/NxGraph.Serialization/GraphDtoFormatter.cs
+++ b/NxGraph.Serialization/GraphDtoFormatter.cs
@@ -64,6 +64,13 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
         {
             case > SerializationVersion.Version:
                 throw new InvalidOperationException($"GraphDto: version {version} is not supported.");
+            // The writer always emits a positive version (the field is positional), so a
+            // non-positive one is a crafted or corrupt payload. Rejecting it here also keeps
+            // the per-version minimum-count checks below exhaustive.
+            case <= 0:
+                throw new InvalidOperationException(
+                    "GraphDto: payload carries no version (or a non-positive one); a graph payload " +
+                    "must declare the serializer version it was written with.");
             case 1 when count < VersionOneHeaderCount:
                 throw new InvalidOperationException(
                     $"GraphDto: expected at least {VersionOneHeaderCount} elements, got {count}");
@@ -96,6 +103,10 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
         SubGraphDto[] subGraphs =
             options.Resolver.GetFormatterWithVerify<SubGraphDto[]>().Deserialize(ref reader, options);
 
+        // Elements consumed so far; every conditional block below adds what it reads, and the
+        // drain loop at the end skips whatever the header declared beyond the known shape.
+        int consumed = VersionOneHeaderCount;
+
         // Version-1 payloads end after SubGraphs; retry policies and outcomes arrived with version 2.
         RetryPolicyDto[] retryPolicies = [];
         OutcomeCodeDto[] outcomeCodes = [];
@@ -108,6 +119,7 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
                 .Deserialize(ref reader, options);
             outcomeNames = options.Resolver.GetFormatterWithVerify<OutcomeNameDto[]>()
                 .Deserialize(ref reader, options);
+            consumed = VersionTwoHeaderCount;
         }
 
         // Pre-v4 payloads end after OutcomeNames; the composite section arrived with version 4.
@@ -116,6 +128,7 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
         {
             composites = options.Resolver.GetFormatterWithVerify<CompositeDto[]>()
                 .Deserialize(ref reader, options);
+            consumed = VersionFourHeaderCount;
         }
 
         // Pre-v5 payloads end after Composites; the uid section arrived with version 5.
@@ -124,6 +137,7 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
         {
             uids = options.Resolver.GetFormatterWithVerify<UidDto[]>()
                 .Deserialize(ref reader, options);
+            consumed = VersionFiveHeaderCount;
         }
 
         // Pre-v6 payloads end after Uids; forks, joins, and containers arrived with version 6.
@@ -138,6 +152,7 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
                 .Deserialize(ref reader, options);
             containers = options.Resolver.GetFormatterWithVerify<ContainerDto[]>()
                 .Deserialize(ref reader, options);
+            consumed = VersionSixHeaderCount;
         }
 
         // Pre-v7 payloads end after Containers; the event entry section arrived with version 7.
@@ -146,6 +161,7 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
         {
             eventEntries = options.Resolver.GetFormatterWithVerify<EventEntryDto[]>()
                 .Deserialize(ref reader, options);
+            consumed = VersionSevenHeaderCount;
         }
 
         // Pre-v8 payloads end after EventEntries; the behavior section arrived with version 8.
@@ -154,6 +170,18 @@ internal sealed class GraphDtoFormatter : GraphEntityFormatter<GraphDto>
         {
             behaviors = options.Resolver.GetFormatterWithVerify<BehaviorDto[]>()
                 .Deserialize(ref reader, options);
+            consumed = VersionEightHeaderCount;
+        }
+
+        // Drain any trailing elements beyond the known shape so the reader always ends
+        // positioned after this array — a nested read that under-consumes desyncs every
+        // subsequent read of its parent. The version gate rejects newer payloads, so extras
+        // only come from crafted or corrupt input today (BlackboardSerializer's per-entry and
+        // header drains are the same defense); this is also the prerequisite for any future
+        // "minor additions without a version bump" policy.
+        for (int extra = consumed; extra < count; extra++)
+        {
+            reader.Skip();
         }
 
         reader.Depth--;

--- a/NxGraph.Serialization/GraphSerializer.cs
+++ b/NxGraph.Serialization/GraphSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using MessagePack;
@@ -145,6 +146,17 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                 $"GraphDto: JSON payload version {dto.Version} is newer than serializer version {SerializationVersion.Version}.");
         }
 
+        // A version-stripped payload must not pass as current: GraphDto.Version defaults to 0
+        // (not the current version) precisely so a JSON payload with no "version" property is
+        // detectable here. The writer always emits one — only malformed or hand-crafted
+        // payloads reach this throw.
+        if (dto.Version <= 0)
+        {
+            throw new InvalidOperationException(
+                "GraphDto: JSON payload carries no version (or a non-positive one); a graph payload " +
+                "must declare the serializer version it was written with.");
+        }
+
         return FromDto(dto);
     }
 
@@ -176,10 +188,6 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         {
             throw new InvalidOperationException(
                 $"Subgraph nesting exceeded MaxSubGraphDepth ({MaxSubGraphDepth}) while serializing.");
-        }
-        if (_codec is NullLogicCodec)
-        {
-            throw new InvalidOperationException("No ILogicCodec configured in GraphSerializer.");
         }
 
         int transitionCount = graph.TransitionCount;
@@ -386,13 +394,24 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                                 "reconstruction recipe; the serializer recurses into its SubGraphs itself.");
                         }
 
-                        List<GraphDto> childDtos = [];
+                        List<Graph> containerChildren = [];
                         foreach (Graph childGraph in container.SubGraphs)
                         {
-                            childDtos.Add(ToDto(childGraph, depth + 1));
+                            containerChildren.Add(childGraph);
                         }
 
-                        containers.Add(new ContainerDto(index, childDtos.ToArray()));
+                        // DEBUG-only contract check: SubGraphs must enumerate in a stable,
+                        // deterministic order (wire order is reconstruction identity for
+                        // containers). Release builds skip the second enumeration.
+                        AssertStableSubGraphOrder(container, containerChildren);
+
+                        GraphDto[] childDtos = new GraphDto[containerChildren.Count];
+                        for (int c = 0; c < childDtos.Length; c++)
+                        {
+                            childDtos[c] = ToDto(containerChildren[c], depth + 1);
+                        }
+
+                        containers.Add(new ContainerDto(index, childDtos));
                         nodes[index] = _containerCodec switch
                         {
                             IContainerCodec<string> t => new NodeTextDto(index, node.Id.Name,
@@ -494,7 +513,12 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
 
         return new GraphDto(nodes, transitions, subGraphs.ToArray(), graph.Id.Index, graph.Id.Name, retryPolicies,
             outcomeCodes, outcomeNames, composites.ToArray(), uids, forks.ToArray(), joins.ToArray(),
-            containers.ToArray(), eventEntries.ToArray(), behaviors.ToArray());
+            containers.ToArray(), eventEntries.ToArray(), behaviors.ToArray())
+        {
+            // The writer stamps the version explicitly: GraphDto.Version defaults to 0
+            // ("no version seen") so that version-stripped payloads are detectable on read.
+            Version = SerializationVersion.Version
+        };
     }
 
     /// <summary>
@@ -625,6 +649,17 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                 $"GraphDto: payload version {dto.Version} is newer than serializer version {SerializationVersion.Version}.");
         }
 
+        // The floor is gated per level too: a nested JSON graph with its "version" stripped
+        // deserializes as 0 (GraphDto's default) and must be rejected here, not read as if
+        // it were current. MessagePack payloads always carry a positional version, so only
+        // crafted ones can reach this with a non-positive value.
+        if (dto.Version <= 0)
+        {
+            throw new InvalidOperationException(
+                "GraphDto: payload carries no version (or a non-positive one); a graph payload " +
+                "must declare the serializer version it was written with.");
+        }
+
         int nodesLength = dto.Nodes.Length;
         if (nodesLength == 0) throw new InvalidOperationException("GraphDto must contain at least one node.");
 
@@ -634,10 +669,14 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
         // Owner indices of subgraph payloads, resolved up front: a node is only treated as a
         // nested-machine marker when a SubGraphDto actually claims it. This kills the in-band
         // collision where a codec legitimately emits the marker string for ordinary logic.
+        // Duplicate claims throw like every sibling section — the old silent HashSet dedup
+        // let the second payload overwrite the first in the rebuild pass.
         HashSet<int>? subGraphOwners = null;
         foreach (SubGraphDto subDto in dto.SubGraphs)
         {
-            (subGraphOwners ??= []).Add(subDto.OwnerIndex);
+            if (!(subGraphOwners ??= []).Add(subDto.OwnerIndex))
+                throw new InvalidOperationException(
+                    $"Subgraph DTO owner index {subDto.OwnerIndex} is duplicated in the payload.");
         }
 
         // Same claim-first defense for the v4 composite section: composite markers are only
@@ -729,6 +768,14 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
             if (slotFilled[nodeDto.Index])
                 throw new InvalidOperationException(
                     $"Node DTO index {nodeDto.Index} is duplicated in the payload.");
+            // Canonical order: logic is installed at nodes[nodeDto.Index], but the rebuild
+            // passes below re-read node names positionally (dto.Nodes[ownerIndex]) — requiring
+            // Nodes[i].Index == i makes those positional lookups sound. The shipped writer
+            // always emits canonical order; only hand-edited or crafted payloads differ.
+            if (nodeDto.Index != index)
+                throw new InvalidOperationException(
+                    $"Node DTO at position {index} declares index {nodeDto.Index}; node entries must appear " +
+                    "in canonical order (Nodes[i].Index == i).");
 
             switch (nodeDto)
             {
@@ -884,7 +931,12 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
                     $"Subgraph DTO owner index {subDto.OwnerIndex} does not reference a state-machine marker node.");
 
             Graph childGraph = FromDto(subDto.Graph, depth + 1);
-            ownerToSubGraph[subDto.OwnerIndex] = childGraph;
+            // Defense in depth: the claims pass above already rejects duplicate owners, so an
+            // overwrite here is unreachable — but the old indexer-assign silently dropped the
+            // first child, and this loop must never regress to that.
+            if (!ownerToSubGraph.TryAdd(subDto.OwnerIndex, childGraph))
+                throw new InvalidOperationException(
+                    $"Subgraph DTO owner index {subDto.OwnerIndex} is duplicated in the payload.");
         }
 
         for (int i = 0; i < nodesLength; i++)
@@ -1303,9 +1355,46 @@ public sealed class GraphSerializer : IGraphJsonSerializer, IGraphBinarySerializ
     /// In-memory placeholder for container-claimed nodes between the node loop and the
     /// container rebuild pass (children rebuild first). Purely internal — unlike the
     /// composite markers it never rides the wire, because container claims are markerless.
+    /// Index -15 is the next free slot after <see cref="NodeId.AsyncBehaviorStateMarker"/>
+    /// (-14): NodeId equality is index-only, so the sentinel space must stay collision-free
+    /// even though this placeholder is only ever compared by reference.
     /// </summary>
     private static readonly LogicNode ContainerPlaceholderMarker =
-        new(new NodeId(-12, "ContainerPlaceholder"), new EmptyAsyncLogic());
+        new(new NodeId(-15, "ContainerPlaceholder"), new EmptyAsyncLogic());
+
+    /// <summary>
+    /// DEBUG-only check of the container ordering contract: <see cref="ISubGraphProvider.SubGraphs"/>
+    /// must yield an identical sequence on every enumeration — wire order is reconstruction
+    /// identity ("SubGraphs enumeration order = wire order = Deserialize children order"), and a
+    /// container backed by an unordered collection corrupts its rebuilt children silently.
+    /// Release builds compile the call out; the contract itself is documented on
+    /// <see cref="ISubGraphProvider"/> and <c>IContainerCodec&lt;TWire&gt;</c>.
+    /// </summary>
+    [Conditional("DEBUG")]
+    private static void AssertStableSubGraphOrder(ISubGraphProvider container, List<Graph> firstPass)
+    {
+        int position = 0;
+        foreach (Graph childGraph in container.SubGraphs)
+        {
+            if (position >= firstPass.Count || !ReferenceEquals(firstPass[position], childGraph))
+            {
+                throw new InvalidOperationException(
+                    $"Container '{container.GetType().Name}' yielded a different SubGraphs sequence on a " +
+                    "second enumeration. SubGraphs must enumerate in a stable, deterministic order — the " +
+                    "serializer's wire order and the agent/blackboard walks depend on it.");
+            }
+
+            position++;
+        }
+
+        if (position != firstPass.Count)
+        {
+            throw new InvalidOperationException(
+                $"Container '{container.GetType().Name}' yielded a different SubGraphs count on a second " +
+                "enumeration. SubGraphs must enumerate in a stable, deterministic order — the serializer's " +
+                "wire order and the agent/blackboard walks depend on it.");
+        }
+    }
 
     /// <summary>
     /// Maps a payload selector key back to the registered delegate. The registry restores

--- a/NxGraph.Serialization/NullLogicCodec.cs
+++ b/NxGraph.Serialization/NullLogicCodec.cs
@@ -1,7 +1,0 @@
-﻿using NxGraph.Serialization.Abstraction;
-
-namespace NxGraph.Serialization;
-
-internal sealed class NullLogicCodec : ILogicCodec
-{
-}

--- a/NxGraph/Graphs/ISubGraphProvider.cs
+++ b/NxGraph/Graphs/ISubGraphProvider.cs
@@ -11,6 +11,15 @@ public interface ISubGraphProvider
     /// <summary>
     /// The directly-embedded child graphs (one level deep — nested providers inside a
     /// child graph are discovered recursively by the caller).
+    /// <para>
+    /// Hard requirement: enumeration must be <b>stable and deterministic</b> — every
+    /// enumeration yields the same graphs in the same order. Order is identity for this
+    /// walk's consumers: the graph serializer writes children to the wire in enumeration
+    /// order and hands them back to the container codec in that order on read, and the
+    /// agent/blackboard stamping walks visit in it. Backing this property with an unordered
+    /// collection corrupts serialized reconstruction silently (the serializer verifies the
+    /// contract in DEBUG builds with a second enumeration).
+    /// </para>
     /// </summary>
     IEnumerable<Graph> SubGraphs { get; }
 }


### PR DESCRIPTION
## What this does

Read-side and policy hardening for `NxGraph.Serialization` — no wire-shape change, `SerializationVersion` stays 9 (now pinned by an explicit tripwire test).

- Duplicate `SubGraphDto` owner indexes now throw like every sibling section (claims pass plus a defense-in-depth `TryAdd` in the rebuild loop) instead of silently dropping the first child.
- `Skip` mismatch policy no longer zeroes a board when nothing applies: a restore that stages zero entries — mismatched header, every entry skipped, or an entry-less payload — leaves the target untouched. The rule is uniform ("Skip never resets a board without restoring at least one value"), documented on the policy enum, and `Strict` is unchanged.
- Version-stripped payloads are rejected everywhere: `GraphDto.Version` defaults to 0, the writer stamps the version explicitly, and both the JSON top level and every nesting level (plus the MessagePack formatter's positional switch) reject non-positive versions with a targeted error.
- The MessagePack `GraphDtoFormatter` drains unknown trailing array elements (consumed-count accounting per version block), so a crafted header count can no longer desync the reader mid-payload.
- Container ordering is now a documented hard contract on `ISubGraphProvider`/`IContainerCodec` (stable, deterministic enumeration — wire order is reconstruction identity), verified by a DEBUG-only double-enumeration check that compiles out of Release.
- Batch of small fixes: canonical node order validated on read (`Nodes[i].Index == i`, making positional lookups sound), the container placeholder sentinel moved to its own reserved index (-15), the `HeaderMatches` null-name wildcard documented as intended, the dead never-constructed `NullLogicCodec` deleted (its guard was unreachable since the instance-serializer refactor), and the three identical "Failed to parse Blackboard JSON." errors split into condition-specific messages.

## Verification

203/203 serialization + 637/637 core tests green in Release at the branch tip; the DEBUG-only ordering check has its own Debug-config test. Every new guard was verified to fail against the pre-fix code. Public API baseline untouched; round-trip fixtures confirm the wire shape is unchanged.

## Merge notes

Independent of the other open hardening PRs (validated combined locally). The build/test hardening PR should land last.
