### PR TITLE
Make validation self-sufficient, fix Mermaid director escaping, and document API contracts

### DIFF
--- a/NxGraph.Tests/AsyncRelayStateLifecycleTests.cs
+++ b/NxGraph.Tests/AsyncRelayStateLifecycleTests.cs
@@ -60,6 +60,52 @@ public class AsyncRelayStateLifecycleTests
     }
 
     [Test]
+    public async Task on_enter_returning_a_completed_result_short_circuits_run_and_exit()
+    {
+        // Pins the documented enter-gating contract (current behavior, not a fix): a relay
+        // onEnter must return InProgress for the body to run — a completed result becomes
+        // the node's result and both run and onExit are skipped.
+        bool ran = false, exited = false;
+        AsyncStateMachine fsm = GraphBuilder
+            .StartWithAsync(new AsyncRelayState(
+                run: _ => { ran = true; return ResultHelpers.Success; },
+                onEnter: _ => new ValueTask<Result>(Result.Success),
+                onExit: _ => { exited = true; return default; }))
+            .ToAsyncStateMachine();
+
+        Result result = await fsm.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success), "The enter hook's result is the node's result.");
+            Assert.That(ran, Is.False, "run is skipped when onEnter returns a completed result.");
+            Assert.That(exited, Is.False, "onExit is skipped when onEnter short-circuits.");
+        });
+    }
+
+    [Test]
+    public async Task typed_relay_on_enter_returning_a_completed_result_short_circuits_run_and_exit()
+    {
+        bool ran = false, exited = false;
+        AsyncStateMachine<object> fsm = GraphBuilder
+            .StartWithAsync(new AsyncRelayState<object>(
+                run: (_, _) => { ran = true; return ResultHelpers.Success; },
+                onEnter: (_, _) => new ValueTask<Result>(Result.Success),
+                onExit: (_, _) => { exited = true; return default; }))
+            .ToAsyncStateMachine<object>()
+            .WithAgent(new object());
+
+        Result result = await fsm.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(ran, Is.False, "run is skipped when onEnter returns a completed result.");
+            Assert.That(exited, Is.False, "onExit is skipped when onEnter short-circuits.");
+        });
+    }
+
+    [Test]
     public void relay_state_on_exit_should_run_even_on_exception()
     {
         bool exited = false;

--- a/NxGraph.Tests/Blackboards/BlackboardTests.cs
+++ b/NxGraph.Tests/Blackboards/BlackboardTests.cs
@@ -150,6 +150,37 @@ public class BlackboardTests
     }
 
     [Test]
+    public void reference_type_defaults_are_shared_instances_across_boards()
+    {
+        // Pins the documented (and deliberate) shallow-copy contract on Register<T>: the
+        // schema's default template copies references, not objects, so a mutable
+        // reference-type default is one shared instance across every board and every
+        // ResetToDefaults(). Reference-type defaults should be immutable or null;
+        // per-board mutable state belongs in a value written at run time.
+        BlackboardSchema schema = new("shared-defaults");
+        BlackboardKey<List<int>> list = schema.Register("list", new List<int>());
+
+        Blackboard first = new(schema);
+        Blackboard second = new(schema);
+
+        first.Get(list).Add(42);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(second.Get(list), Is.EqualTo(new[] { 42 }),
+                "Both boards see the same default instance.");
+            Assert.That(first.Get(list), Is.SameAs(second.Get(list)),
+                "The default is one shared object, not a per-board copy.");
+        });
+
+        first.Set(list, [7]);
+        first.ResetToDefaults();
+
+        Assert.That(first.Get(list), Is.SameAs(second.Get(list)),
+            "ResetToDefaults restores the shared instance — mutations made through it persist.");
+    }
+
+    [Test]
     public void descriptors_box_read_write_and_reset()
     {
         BlackboardSchema schema = new();

--- a/NxGraph.Tests/GraphValidatorTests.cs
+++ b/NxGraph.Tests/GraphValidatorTests.cs
@@ -124,8 +124,10 @@ public class GraphValidatorTests
     }
 
     [Test]
-    public void MissingAllNodes_ShouldEmitInfo_AndStillValidateReachablePart()
+    public void MissingAllNodes_IsCompleteByDefault_AndEmitsNoSkipInfo()
     {
+        // The validator derives the node set from the graph itself when AllNodes is absent,
+        // so the old "Skipped unreachable/duplicate-name checks" Info no longer exists.
         Graph graph = BuildSimpleGraph(out _);
         GraphValidationResult res = graph.Validate();
 
@@ -134,10 +136,73 @@ public class GraphValidatorTests
             Assert.That(
                 res.Diagnostics.Any(d =>
                     d.Severity == Severity.Info && d.Message.Contains("Skipped unreachable/duplicate-name checks",
-                        StringComparison.OrdinalIgnoreCase)), Is.True,
-                "Expected an info diagnostic when AllNodes is not provided.");
+                        StringComparison.OrdinalIgnoreCase)), Is.False,
+                "The skip Info must not appear — the default path derives AllNodes from the graph.");
 
             Assert.That(res.HasErrors, Is.False, "Lack of AllNodes should not produce validation errors.");
+        });
+    }
+
+    [Test]
+    public void Validate_WithoutOptions_ReportsUnreachableNodes_AndDuplicateNames()
+    {
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success), isStart: true);
+        NodeId reached = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success));
+        NodeId unreachable = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success));
+        builder.SetName(reached, "A");
+        builder.SetName(unreachable, "A"); // duplicate name on the unreachable node
+        builder.AddTransition(start, reached);
+
+        Graph graph = builder.Build(throwOnError: false);
+
+        GraphValidationResult res = graph.Validate(); // no options at all
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                res.Diagnostics.Any(d =>
+                    d.Severity == Severity.Warning && d.Node.Index == unreachable.Index &&
+                    d.Message.Contains("unreachable", StringComparison.OrdinalIgnoreCase)), Is.True,
+                "Standalone Validate() must flag the unreachable node.");
+            Assert.That(
+                res.Diagnostics.Count(d =>
+                    d.Severity == Severity.Warning &&
+                    d.Message.Contains("Duplicate node name 'A'", StringComparison.Ordinal)), Is.EqualTo(2),
+                "Standalone Validate() must flag both holders of the duplicate name.");
+        });
+    }
+
+    [Test]
+    public void SuppliedAllNodes_OverridesTheDerivedSet()
+    {
+        // Back-compat contract: an explicitly supplied AllNodes list is honored verbatim —
+        // here it contains an id the graph does not know, which must surface as unreachable.
+        Graph graph = BuildSimpleGraph(out GraphBuilder builder);
+        List<NodeId> supplied = [..builder.GetAllNodeIds()!, new NodeId(99, "Phantom")];
+
+        GraphValidationResult res = graph.Validate(new GraphValidationOptions { AllNodes = supplied });
+
+        Assert.That(
+            res.Diagnostics.Any(d =>
+                d.Severity == Severity.Warning && d.Node.Index == 99 &&
+                d.Message.Contains("unreachable", StringComparison.OrdinalIgnoreCase)), Is.True,
+            "A supplied AllNodes list must be used instead of the graph-derived set.");
+    }
+
+    [Test]
+    public void GetAllNodeIds_SingleNodeGraph_ReturnsStart()
+    {
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(new AsyncRelayState(_ => ResultHelpers.Success), isStart: true);
+
+        IReadOnlyList<NodeId>? ids = builder.GetAllNodeIds();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ids, Is.Not.Null, "A builder holding only the start node must not return null.");
+            Assert.That(ids, Has.Count.EqualTo(1));
+            Assert.That(ids![0].Index, Is.EqualTo(start.Index));
         });
     }
 

--- a/NxGraph.Tests/MermaidGraphExporterTests.cs
+++ b/NxGraph.Tests/MermaidGraphExporterTests.cs
@@ -1,5 +1,6 @@
 using NxGraph.Authoring;
 using NxGraph.Diagnostics.Export;
+using NxGraph.Fsm;
 using NxGraph.Graphs;
 
 namespace NxGraph.Tests;
@@ -148,6 +149,32 @@ public class MermaidGraphExporterTests
         string mmd = exporter.Export(graph, opts);
 
         Assert.That(mmd, Does.Contain("%% NxGraph → Mermaid export: Enemy AI FSM"));
+    }
+
+    [Test]
+    public void director_name_with_quotes_is_escaped_exactly_once()
+    {
+        // Regression: BuildNodeLabel escapes the label, and the director-rhombus branch used
+        // to escape it a second time — names containing '"' or '\' rendered mangled
+        // (\\\" instead of \") on If/Switch nodes only.
+        GraphBuilder builder = new();
+        NodeId start = builder.AddNode(new RelayState(() => Result.Success), isStart: true);
+        NodeId thenBranch = builder.AddNode(new RelayState(() => Result.Success)); // n1
+        NodeId elseBranch = builder.AddNode(new RelayState(() => Result.Success)); // n2
+        NodeId choice = builder.AddNode(new ChoiceState(() => true, thenBranch, elseBranch)); // n3
+        builder.SetName(choice, "say \"hi\"");
+        builder.AddTransition(start, choice);
+        Graph graph = builder.Build(throwOnError: false);
+
+        string mmd = new MermaidGraphExporter().Export(graph);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mmd, Does.Contain("n3{\"say \\\"hi\\\" [3]\"}"),
+                "The director label must carry each quote escaped exactly once.");
+            Assert.That(mmd, Does.Not.Contain(@"\\"),
+                "No double backslashes — the name has none, so any pair proves double-escaping.");
+        });
     }
 
     [Test]

--- a/NxGraph/Authoring/GraphBuilder.Validations.cs
+++ b/NxGraph/Authoring/GraphBuilder.Validations.cs
@@ -23,9 +23,10 @@ public partial class GraphBuilder
     {
         Graph graph = InternalBuild();
 
+        // The validator derives the full node set from the built graph itself, so no
+        // AllNodes list is passed — unreachable/duplicate-name checks run regardless.
         GraphValidationOptions options = new()
         {
-            AllNodes = GetAllNodeIds(),
             WarnOnSelfLoop = true,
             StrictNoTerminalPath = false
         };

--- a/NxGraph/Authoring/GraphBuilder.cs
+++ b/NxGraph/Authoring/GraphBuilder.cs
@@ -601,14 +601,19 @@ public sealed partial class GraphBuilder
         return new StateToken(id, this);
     }
 
+    /// <summary>
+    /// Returns every node id known to the builder — the start node plus all added nodes —
+    /// with display names applied. A single-node graph returns its one-element list;
+    /// <c>null</c> only when no start node has been added yet.
+    /// </summary>
     public IReadOnlyList<NodeId>? GetAllNodeIds()
     {
-        if (_nodes.Count == 0 || _startNode == null)
+        if (_startNode == null)
         {
             return null;
         }
 
-        List<NodeId> ids = new(_nodes.Keys.Count) { ApplyName(_startNode.Id) };
+        List<NodeId> ids = new(_nodes.Count + 1) { ApplyName(_startNode.Id) };
         foreach (NodeId id in _nodes.Keys)
         {
             ids.Add(ApplyName(id));

--- a/NxGraph/Blackboards/BlackboardSchema.cs
+++ b/NxGraph/Blackboards/BlackboardSchema.cs
@@ -48,10 +48,26 @@ public sealed class BlackboardSchema
     /// <summary>All registered slots in registration order (index == ordinal).</summary>
     public IReadOnlyList<BlackboardKeyDescriptor> Keys => _descriptors;
 
-    /// <summary>Registers a slot whose default value is <c>default(T)</c>.</summary>
+    /// <summary>
+    /// Registers a slot whose default value is <c>default(T)</c> — for reference types that is
+    /// <see langword="null"/>, which is also the safe default for mutable types (see the
+    /// shared-instance warning on <see cref="Register{T}(string, T)"/>).
+    /// </summary>
     public BlackboardKey<T> Register<T>(string name) => Register<T>(name, default!);
 
-    /// <summary>Registers a slot with an explicit default value. Names must be unique per schema.</summary>
+    /// <summary>
+    /// Registers a slot with an explicit default value. Names must be unique per schema.
+    /// <para>
+    /// <b>Reference-type defaults are shared instances.</b> The schema's default template is
+    /// shallow-copied into every <see cref="Blackboard"/> created from it and on every
+    /// <see cref="Blackboard.ResetToDefaults"/> — copying the <i>reference</i>, not the object.
+    /// <c>Register("list", new List&lt;int&gt;())</c> therefore shares one mutable list across
+    /// all boards from this schema, and mutating it through any board (or after a reset) is
+    /// visible everywhere. Use immutable objects or <see langword="null"/> as reference-type
+    /// defaults; per-board mutable state belongs in the slot value written at run time
+    /// (<c>board.Set(key, new List&lt;int&gt;())</c>).
+    /// </para>
+    /// </summary>
     public BlackboardKey<T> Register<T>(string name, T defaultValue)
     {
         Guard.NotNull(name, nameof(name));

--- a/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
+++ b/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
@@ -73,7 +73,9 @@ public sealed class MermaidGraphExporter : IGraphExporter
                 if (ln.AsyncLogic is IDirector || ln.Logic is IDirector
                     || ln.AsyncLogic is IAsyncDirector || ln.Logic is IAsyncDirector)
                 {
-                    label = $"{{\"{EscapeLabel(label)}\"}}";
+                    // BuildNodeLabel already escaped the label — escaping again here mangled
+                    // quotes/backslashes in director names (rendered \\\" instead of \").
+                    label = $"{{\"{label}\"}}";
                     sb.Append("  ").Append(nodeId).Append(label).AppendLine();
                     continue;
                 }

--- a/NxGraph/Diagnostics/Validations/GraphValidationOptions.cs
+++ b/NxGraph/Diagnostics/Validations/GraphValidationOptions.cs
@@ -5,7 +5,10 @@ namespace NxGraph.Diagnostics.Validations;
 public sealed class GraphValidationOptions(IReadOnlyList<NodeId>? allNodes = null)
 {
     /// <summary>
-    /// Optional: supply the full set of nodes known to the graph (e.g., from GraphBuilder) to enable unreachable/duplicate-name checks.
+    /// Optional override for the node set used by the unreachable/duplicate-name checks.
+    /// When absent (the default), the validator derives the full set from the graph itself,
+    /// so a standalone <c>Validate()</c> is complete. Supply a list only to validate against
+    /// a different set — e.g. a pre-build ID list from <c>GraphBuilder.GetAllNodeIds()</c>.
     /// </summary>
     public IReadOnlyList<NodeId>? AllNodes { get; set; } = allNodes;
 

--- a/NxGraph/Diagnostics/Validations/GraphValidator.cs
+++ b/NxGraph/Diagnostics/Validations/GraphValidator.cs
@@ -9,7 +9,11 @@ namespace NxGraph.Diagnostics.Validations;
 public static class GraphValidator
 {
     /// <summary>
-    /// Validate a graph: reachability (if AllNodes provided), broken transitions, self-loops, and terminal-path existence.
+    /// Validate a graph: reachability, broken transitions, self-loops, terminal-path existence,
+    /// unreachable nodes, and duplicate names. The node set for the unreachable/duplicate-name
+    /// checks is derived from the graph itself; supply
+    /// <see cref="GraphValidationOptions.AllNodes"/> only to validate against a different list
+    /// (e.g. a pre-build ID list from <c>GraphBuilder.GetAllNodeIds()</c>).
     /// Runs in O(N) over reachable nodes and does not allocate on the steady-state hot path.
     /// </summary>
     public static GraphValidationResult Validate(this Graph graph, GraphValidationOptions? options = null)
@@ -221,49 +225,66 @@ public static class GraphValidator
         // 4e) Event-entry lints (spec 013) — always on, mirroring the fork/join presence Info.
         ValidateEventEntries(graph, result);
 
-        // 5) If AllNodes are supplied, check for unreachable nodes and duplicate names
-        if (options.AllNodes is { Count: > 0 } all)
+        // 5) Unreachable-node and duplicate-name checks. A supplied AllNodes wins (back-compat
+        // for pre-build ID lists); otherwise the set is derived from the graph itself — a built
+        // Graph holds every node with its display name applied at Build(), so standalone
+        // Validate() is complete by default.
+        IReadOnlyList<NodeId> all = options.AllNodes is { Count: > 0 } supplied
+            ? supplied
+            : CollectAllNodeIds(graph);
+
+        // Unreachable detection
+        foreach (NodeId node in all)
         {
-            // Unreachable detection
-            foreach (NodeId node in all)
-            {
-                if (!visited.Contains(node.Index))
-                    result.Add(Severity.Warning, "Node is unreachable from Start.", node);
-            }
-
-            // Duplicate names (case-sensitive by default)
-            Dictionary<string, List<NodeId>> byName = new();
-            foreach (NodeId node in all)
-            {
-                string name = node.Name;
-                if (string.IsNullOrEmpty(name)) continue;
-                if (!byName.TryGetValue(name, out List<NodeId>? list))
-                    byName[name] = list = new List<NodeId>(2);
-                list.Add(node);
-            }
-
-            foreach (KeyValuePair<string, List<NodeId>> kvp in byName)
-            {
-                if (kvp.Value.Count <= 1)
-                {
-                    continue;
-                }
-
-                foreach (NodeId dup in kvp.Value)
-                    result.Add(Severity.Warning, $"Duplicate node name '{kvp.Key}'.", dup);
-            }
+            if (!visited.Contains(node.Index))
+                result.Add(Severity.Warning, "Node is unreachable from Start.", node);
         }
-        else
+
+        // Duplicate names (case-sensitive by default)
+        Dictionary<string, List<NodeId>> byName = new();
+        foreach (NodeId node in all)
         {
-            // Cannot check unreachable/duplicates without AllNodes
-            result.Add(Severity.Info, "Skipped unreachable/duplicate-name checks (AllNodes not provided).",
-                NodeId.Default);
+            string name = node.Name;
+            if (string.IsNullOrEmpty(name)) continue;
+            if (!byName.TryGetValue(name, out List<NodeId>? list))
+                byName[name] = list = new List<NodeId>(2);
+            list.Add(node);
+        }
+
+        foreach (KeyValuePair<string, List<NodeId>> kvp in byName)
+        {
+            if (kvp.Value.Count <= 1)
+            {
+                continue;
+            }
+
+            foreach (NodeId dup in kvp.Value)
+                result.Add(Severity.Warning, $"Duplicate node name '{kvp.Key}'.", dup);
         }
 
         // 6) Blackboard schema declarations: lint-only — binding stays permissive at runtime.
         ValidateBlackboardDeclarations(graph, result);
 
         return result;
+    }
+
+    /// <summary>
+    /// Derives the full node-id list from the graph's dense node array (names were applied at
+    /// <c>Build()</c>). Null slots are skipped defensively — hand-constructed graphs can carry
+    /// holes the builder never produces.
+    /// </summary>
+    private static IReadOnlyList<NodeId> CollectAllNodeIds(Graph graph)
+    {
+        List<NodeId> ids = new(graph.NodeCount);
+        for (int i = 0; i < graph.NodeCount; i++)
+        {
+            if (graph.TryGetNodeByIndex(i, out INode? node) && node is not null)
+            {
+                ids.Add(node.Id);
+            }
+        }
+
+        return ids;
     }
 
     private static void ValidateUids(Graph graph, GraphValidationResult result)

--- a/NxGraph/Diagnostics/Validations/GraphValidator.cs
+++ b/NxGraph/Diagnostics/Validations/GraphValidator.cs
@@ -1,4 +1,4 @@
-﻿using NxGraph.Blackboards;
+using NxGraph.Blackboards;
 using NxGraph.Compatibility;
 using NxGraph.Fsm;
 using NxGraph.Fsm.Async;
@@ -273,7 +273,7 @@ public static class GraphValidator
     /// <c>Build()</c>). Null slots are skipped defensively — hand-constructed graphs can carry
     /// holes the builder never produces.
     /// </summary>
-    private static IReadOnlyList<NodeId> CollectAllNodeIds(Graph graph)
+    private static List<NodeId> CollectAllNodeIds(Graph graph)
     {
         List<NodeId> ids = new(graph.NodeCount);
         for (int i = 0; i < graph.NodeCount; i++)

--- a/NxGraph/Fsm/Async/AsyncRelayState.cs
+++ b/NxGraph/Fsm/Async/AsyncRelayState.cs
@@ -7,6 +7,16 @@ namespace NxGraph.Fsm.Async;
 /// The blackboard-context overload receives the machine-bound routed context (see
 /// <see cref="BlackboardContext"/>) instead of relying on closure capture, so one graph
 /// template can serve N machines with distinct boards.
+/// <para>
+/// <b>Enter-hook contract:</b> an <c>onEnter</c> delegate must return
+/// <see cref="Result.InProgress"/> for execution to proceed to <c>run</c>. Returning a
+/// completed result (<see cref="Result.Success"/> or <see cref="Result.Failure"/>)
+/// short-circuits the node: <c>run</c> and <c>onExit</c> are skipped and the returned
+/// result becomes the node's result. This enables enter-gating (skip or fail the node from
+/// its enter hook), but means <c>onEnter: ct =&gt; new(Result.Success)</c> silently disables
+/// the node body. The sync <see cref="RelayState"/> hooks are <see cref="Action"/>-typed and
+/// cannot short-circuit.
+/// </para>
 /// </summary>
 public sealed class AsyncRelayState : AsyncState
 {
@@ -19,8 +29,14 @@ public sealed class AsyncRelayState : AsyncState
     private readonly Func<BlackboardContext, CancellationToken, ValueTask<Result>>? _bbOnExit;
 
     /// <param name="run">The function to run when the state is executed. It should return a <see cref="Result"/>.</param>
-    /// <param name="onEnter">Optional function to run when the state is entered. It can be used for initialization or setup.</param>
-    /// <param name="onExit">Optional function to run when the state is exited. It can be used for cleanup or finalization.</param>
+    /// <param name="onEnter">
+    /// Optional function to run when the state is entered. It can be used for initialization or
+    /// setup. <b>Must return <see cref="Result.InProgress"/> for <paramref name="run"/> to
+    /// execute</b> — a completed result (<see cref="Result.Success"/>/<see cref="Result.Failure"/>)
+    /// short-circuits the node: <paramref name="run"/> and <paramref name="onExit"/> are skipped
+    /// and that result is reported as the node's result.
+    /// </param>
+    /// <param name="onExit">Optional function to run when the state is exited. It can be used for cleanup or finalization. Not invoked when <paramref name="onEnter"/> short-circuits.</param>
     public AsyncRelayState(
         Func<CancellationToken, ValueTask<Result>> run,
         Func<CancellationToken, ValueTask<Result>>? onEnter = null,
@@ -32,8 +48,13 @@ public sealed class AsyncRelayState : AsyncState
     }
 
     /// <param name="run">The function to run when the state is executed, receiving the routed blackboard context.</param>
-    /// <param name="onEnter">Optional enter hook receiving the routed blackboard context.</param>
-    /// <param name="onExit">Optional exit hook receiving the routed blackboard context.</param>
+    /// <param name="onEnter">
+    /// Optional enter hook receiving the routed blackboard context. <b>Must return
+    /// <see cref="Result.InProgress"/> for <paramref name="run"/> to execute</b> — a completed
+    /// result short-circuits the node: <paramref name="run"/> and <paramref name="onExit"/> are
+    /// skipped and that result is reported as the node's result.
+    /// </param>
+    /// <param name="onExit">Optional exit hook receiving the routed blackboard context. Not invoked when <paramref name="onEnter"/> short-circuits.</param>
     public AsyncRelayState(
         Func<BlackboardContext, CancellationToken, ValueTask<Result>> run,
         Func<BlackboardContext, CancellationToken, ValueTask<Result>>? onEnter = null,
@@ -46,6 +67,10 @@ public sealed class AsyncRelayState : AsyncState
 
     protected override ValueTask<Result> OnEnterAsync(CancellationToken ct)
     {
+        // Deliberately no DEBUG-only "onEnter returned a completed result" diagnostic here:
+        // enter-gating (skipping or failing the node from its enter hook) is a legitimate,
+        // documented pattern — see the class docs — so a warning would false-positive on
+        // intentional graphs. The contract is pinned by AsyncRelayStateLifecycleTests.
         return _bbRun is not null
             ? _bbOnEnter?.Invoke(Bb, ct) ?? ResultHelpers.InProgress
             : _onEnter?.Invoke(ct) ?? ResultHelpers.InProgress;
@@ -68,6 +93,13 @@ public sealed class AsyncRelayState : AsyncState
 /// RelayState is a state that can be used to encapsulate a function that returns a Result.
 /// The combined overload hands the delegate both the stamped agent and the routed
 /// blackboard context.
+/// <para>
+/// <b>Enter-hook contract:</b> an <c>onEnter</c> delegate must return
+/// <see cref="Result.InProgress"/> for execution to proceed to <c>run</c>. Returning a
+/// completed result (<see cref="Result.Success"/> or <see cref="Result.Failure"/>)
+/// short-circuits the node: <c>run</c> and <c>onExit</c> are skipped and the returned
+/// result becomes the node's result. See <see cref="AsyncRelayState"/>.
+/// </para>
 /// </summary>
 /// <typeparam name="TAgent">The type of the agent that this state operates on.</typeparam>
 public sealed class AsyncRelayState<TAgent> : AsyncState<TAgent>
@@ -81,8 +113,14 @@ public sealed class AsyncRelayState<TAgent> : AsyncState<TAgent>
     private readonly Func<TAgent, BlackboardContext, CancellationToken, ValueTask<Result>>? _bbOnExit;
 
     /// <param name="run">The function to run when the state is executed. It should return a <see cref="Result"/>.</param>
-    /// <param name="onEnter">Optional function to run when the state is entered. It can be used for initialization or setup.</param>
-    /// <param name="onExit">Optional function to run when the state is exited. It can be used for cleanup or finalization.</param>
+    /// <param name="onEnter">
+    /// Optional function to run when the state is entered. It can be used for initialization or
+    /// setup. <b>Must return <see cref="Result.InProgress"/> for <paramref name="run"/> to
+    /// execute</b> — a completed result (<see cref="Result.Success"/>/<see cref="Result.Failure"/>)
+    /// short-circuits the node: <paramref name="run"/> and <paramref name="onExit"/> are skipped
+    /// and that result is reported as the node's result.
+    /// </param>
+    /// <param name="onExit">Optional function to run when the state is exited. It can be used for cleanup or finalization. Not invoked when <paramref name="onEnter"/> short-circuits.</param>
     public AsyncRelayState(
         Func<TAgent, CancellationToken, ValueTask<Result>> run,
         Func<TAgent, CancellationToken, ValueTask<Result>>? onEnter = null,
@@ -94,8 +132,13 @@ public sealed class AsyncRelayState<TAgent> : AsyncState<TAgent>
     }
 
     /// <param name="run">The function to run when the state is executed, receiving the agent and the routed blackboard context.</param>
-    /// <param name="onEnter">Optional enter hook receiving the agent and the routed blackboard context.</param>
-    /// <param name="onExit">Optional exit hook receiving the agent and the routed blackboard context.</param>
+    /// <param name="onEnter">
+    /// Optional enter hook receiving the agent and the routed blackboard context. <b>Must return
+    /// <see cref="Result.InProgress"/> for <paramref name="run"/> to execute</b> — a completed
+    /// result short-circuits the node: <paramref name="run"/> and <paramref name="onExit"/> are
+    /// skipped and that result is reported as the node's result.
+    /// </param>
+    /// <param name="onExit">Optional exit hook receiving the agent and the routed blackboard context. Not invoked when <paramref name="onEnter"/> short-circuits.</param>
     public AsyncRelayState(
         Func<TAgent, BlackboardContext, CancellationToken, ValueTask<Result>> run,
         Func<TAgent, BlackboardContext, CancellationToken, ValueTask<Result>>? onEnter = null,

--- a/NxGraph/Fsm/Async/AsyncState.cs
+++ b/NxGraph/Fsm/Async/AsyncState.cs
@@ -20,6 +20,12 @@ public abstract class AsyncState : IAsyncLogic, ILogReporter, IBlackboardSettabl
 
     /// <summary>
     /// Executes the state asynchronously, entering and exiting the state as needed.
+    /// <para>
+    /// Lifecycle contract: when <see cref="OnEnterAsync"/> returns a completed result
+    /// (<see cref="Result.Success"/> or <see cref="Result.Failure"/>), that result is returned
+    /// immediately — <see cref="OnRunAsync"/> and <see cref="OnExitAsync"/> are skipped
+    /// (enter-gating). Only <see cref="Result.InProgress"/> proceeds to the run/exit pair.
+    /// </para>
     /// </summary>
     /// <param name="ct">The cancellation token to observe while executing the state.</param>
     /// <returns>A <see cref="ValueTask{Result}"/> representing the<see cref="Result"/> of the state execution.</returns>
@@ -48,6 +54,12 @@ public abstract class AsyncState : IAsyncLogic, ILogReporter, IBlackboardSettabl
         }
     }
 
+    /// <summary>
+    /// Enter hook. Return <see cref="Result.InProgress"/> (the default) to proceed to
+    /// <see cref="OnRunAsync"/>; a completed result short-circuits the state — it is
+    /// reported as the state's result and <see cref="OnRunAsync"/>/<see cref="OnExitAsync"/>
+    /// do not run.
+    /// </summary>
     protected virtual ValueTask<Result> OnEnterAsync(CancellationToken ct)
     {
         return ResultHelpers.InProgress;

--- a/NxGraph/Fsm/Async/AsyncTimeoutState.cs
+++ b/NxGraph/Fsm/Async/AsyncTimeoutState.cs
@@ -9,6 +9,14 @@ namespace NxGraph.Fsm.Async;
 /// returns <see cref="Result.Failure"/> or throws <see cref="TimeoutException"/>,
 /// depending on <see cref="TimeoutBehavior"/>.
 /// </summary>
+/// <remarks>
+/// Pooling characteristic: timeout executions rent their <see cref="CancellationTokenSource"/>
+/// from one process-wide pool shared by all <see cref="AsyncTimeoutState"/> instances. The
+/// pool grows to the peak number of <i>concurrent</i> timeout executions the process has seen
+/// and never shrinks — deliberate: steady-state runs allocate no CTSes, and a CTS is small, so
+/// a burst leaves behind at most burst-width retained instances rather than churn. Processes
+/// with rare, very wide bursts pay that retained memory for the process lifetime.
+/// </remarks>
 public class AsyncTimeoutState : IAsyncLogic
 {
     private readonly IAsyncLogic _inner;
@@ -88,6 +96,12 @@ public class AsyncTimeoutState : IAsyncLogic
     }
 
 
+    /// <summary>
+    /// Process-wide CTS pool. Unbounded by design: it holds at most peak-concurrency
+    /// instances (each Return matches a Rent), and bounding it would add counter traffic to
+    /// every rent/return to trim what is already a small, self-limiting footprint. See the
+    /// class-level remarks.
+    /// </summary>
     private static class CtsPool
     {
         private static readonly ConcurrentBag<CancellationTokenSource> Bag = [];

--- a/NxGraph/Fsm/RelayState.cs
+++ b/NxGraph/Fsm/RelayState.cs
@@ -9,6 +9,14 @@ namespace NxGraph.Fsm;
 /// The blackboard-context overload receives the machine-bound routed context (see
 /// <see cref="BlackboardContext"/>) instead of relying on closure capture, so one graph
 /// template can serve N machines with distinct boards.
+/// <para>
+/// Unlike the async relay, the <c>onEnter</c>/<c>onExit</c> hooks here are
+/// <see cref="Action"/>-typed and cannot short-circuit: <see cref="State.Execute"/> always
+/// proceeds from <c>OnEnter</c> to <c>OnRun</c> (the sync <c>OnEnter</c> is <c>void</c>),
+/// so <c>run</c> executes on every visit. The async relay's enter-gating contract
+/// (<c>onEnter</c> returning a completed result skips <c>run</c>/<c>onExit</c>) has no sync
+/// equivalent — sync enter-gating belongs in <c>run</c> itself.
+/// </para>
 /// </summary>
 public sealed class RelayState : State
 {
@@ -70,6 +78,10 @@ public sealed class RelayState : State
 /// <summary>
 /// Synchronous counterpart of <see cref="AsyncRelayState{TAgent}"/>. The combined overload
 /// hands the delegate both the stamped agent and the routed blackboard context.
+/// <para>
+/// The <c>onEnter</c>/<c>onExit</c> hooks are <see cref="Action{TAgent}"/>-typed and cannot
+/// short-circuit — <c>run</c> executes on every visit (see <see cref="RelayState"/>).
+/// </para>
 /// </summary>
 /// <typeparam name="TAgent">The type of agent available during execution.</typeparam>
 public sealed class RelayState<TAgent> : State<TAgent>

--- a/NxGraph/Graphs/LogicNode.cs
+++ b/NxGraph/Graphs/LogicNode.cs
@@ -37,12 +37,19 @@ public class LogicNode : INode
     /// Optional action invoked by the run loops when the machine enters this node —
     /// once per visit, before the node's first execution (retries do not re-fire it).
     /// Cached at build time; a null check plus a cached-delegate invoke costs nothing.
+    /// <para>
+    /// Exception: on token-runtime join nodes, Enter fires per token <i>arrival</i> (parked
+    /// arrivals included) while Exit fires only on the arrival that fires the join — see
+    /// <c>NxGraph.Tokens.JoinState</c> for the pairing rules.
+    /// </para>
     /// </summary>
     public Action? EnterAction { get; }
 
     /// <summary>
     /// Optional action invoked by the run loops when the machine leaves this node —
-    /// once per visit, after its final execution, regardless of outcome.
+    /// once per visit, after its final execution, regardless of outcome. On token-runtime
+    /// join nodes it fires once per join firing, so it does not pair 1:1 with
+    /// <see cref="EnterAction"/> there (see <c>NxGraph.Tokens.JoinState</c>).
     /// </summary>
     public Action? ExitAction { get; }
 

--- a/NxGraph/Graphs/NodeId.cs
+++ b/NxGraph/Graphs/NodeId.cs
@@ -56,6 +56,14 @@ public struct NodeId(int index) : IEquatable<NodeId>
     /// <summary>
     /// Represents the default NodeId with an index of -1 and a name of "Default".
     /// </summary>
+    /// <remarks>
+    /// Negative indexes form a reserved sentinel space: -1 is this terminal/none sentinel, and
+    /// -2 and below are serialization wire markers (the <c>*Marker</c> statics below, mirrored
+    /// on <see cref="LogicNode"/>) that name composite/structural node kinds on the payload.
+    /// They are never valid graph node indexes and no run loop routes to them. New markers are
+    /// reserved in the serialization layer (see the payload-version notes in
+    /// <c>NxGraph.Serialization</c>): each takes the next unused negative index.
+    /// </remarks>
     public static NodeId Default => new(-1) { Name = "Default" };
     public static NodeId StateMachineMarker => new(-2) { Name = "StateMachine" };
     public static NodeId SyncStateMachineMarker => new(-3) { Name = "SyncStateMachine" };
@@ -72,7 +80,11 @@ public struct NodeId(int index) : IEquatable<NodeId>
     public static NodeId AsyncBehaviorStateMarker => new(-14) { Name = "AsyncBehaviorState" };
 
     /// <summary>
-    /// Represents the start NodeId with an index of 0 and a name of "Start".
+    /// Represents the start NodeId with an index of 0 and an <b>empty</b> name
+    /// (<see cref="ToString"/> prints <c>(0)</c>). Display names are presentation data
+    /// assigned at authoring time (<c>SetName</c>, applied at <c>Build()</c>) — the start
+    /// node has no implicit "Start" name, so name-based lookups (<c>Goto</c>) and
+    /// duplicate-name lints never match it unless a name was explicitly set.
     /// </summary>
     public static NodeId Start => new(0);
 

--- a/NxGraph/Tokens/JoinState.cs
+++ b/NxGraph/Tokens/JoinState.cs
@@ -14,6 +14,14 @@ namespace NxGraph.Tokens;
 /// is authored by routing several chains to the <i>same</i> <see cref="JoinState"/> instance
 /// (<c>.To(join)</c> dedupes by reference into one node).
 /// </para>
+/// <para>
+/// <b>Enter/exit hook pairing:</b> on a join, the node's <c>EnterAction</c> (DSL
+/// <c>.OnEnter</c>) fires on <b>every</b> token arrival — parked arrivals included — while
+/// <c>ExitAction</c> (<c>.OnExit</c>) fires only once per firing, on the arrival that
+/// satisfies the policy. With <c>JoinPolicy.All(n)</c> a firing therefore sees n enter
+/// invocations and one exit; enter/exit counts pair up only for
+/// <see cref="JoinPolicy.Any"/>. Both token machines behave identically.
+/// </para>
 /// </summary>
 public sealed class JoinState : ILogic, IAsyncLogic
 {


### PR DESCRIPTION
## What this does

- **Validation is complete by default.** `graph.Validate()` now derives the node set from the graph itself, so the unreachable-node and duplicate-name checks run without options; a supplied `GraphValidationOptions.AllNodes` still wins (pinned by test) and is re-documented as an override for pre-build ID lists. `Build()` stops passing the list, so every DSL build exercises the default path, and the "skipped checks" Info is gone. `GraphBuilder.GetAllNodeIds()` now returns the one-element list for a single-node graph instead of null.
- **Mermaid director labels are no longer double-escaped** — names containing quotes or backslashes rendered mangled on If/Switch rhombus nodes only; regression test included.
- **The relay enter-hook short-circuit is documented and pinned.** `AsyncRelayState`'s `onEnter` returning a completed `Success` skips run and exit hooks by design; that contract is now stated loudly on all four async relay ctors and on `AsyncState` itself, pinned by tests, and the sync relays are recorded as structurally immune (`Action`-typed hooks cannot short-circuit). No runtime behavior change; a DEBUG diagnostic was considered and declined since enter-gating is a legitimate documented pattern.
- **Contract documentation batch:** blackboard schema reference-type defaults are shared instances (warning on both `Register` overloads plus a pinning test), `NodeId.Start` doc corrected (empty name), token-join enter/exit pairing semantics documented on `JoinState` with softened `LogicNode` wording, the negative-index sentinel space explained on `NodeId`, and `AsyncTimeoutState`'s CTS pool documented as grow-to-peak/never-shrinks (bounded pool declined as not trivially clean).

## Verification

644 + 193 tests green in Release; public API baseline unchanged (behavior changes live behind existing signatures). The two Debug-config test failures visible on this machine reproduce identically at the merge base and are pre-existing (DEBUG-only `Build()` throw on deliberately-invalid crafted graphs) — flagged for a future fix, untouched here.

## Merge notes

Independent of the other open hardening PRs (validated combined locally). The build/test hardening PR should land last.
