### PR TITLE
Test-suite and delivery hardening: strict traces, netstandard2.1 API baseline, analyzers as errors

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+#
+# Third-party and first-party actions are pinned to commit SHAs (tag in the trailing
+# comment) so a moved tag cannot silently change what runs.
 
 name: Build
 
@@ -15,15 +18,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: 8.0.x
     - name: Build & Test
       run: dotnet run --project NxGraph.Build -- ci
     - name: Upload coverage report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: coverage-report
-        path: '**/TestResults/*'
+        # coverlet.msbuild (the single coverage driver) writes lcov coverage.info next to
+        # each test csproj; the old '**/TestResults/*' pattern captured the removed VSTest
+        # collector's output and would now upload nothing.
+        path: '**/coverage.info'

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: "Which package(s) to publish: all | serialization | serialization-abstraction"
+        description: "Which package(s) to publish: all | nxgraph | serialization | serialization-abstraction"
         required: true
         default: all
       version:
@@ -33,11 +33,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      # Actions are pinned to commit SHAs (tag in the trailing comment) so a moved tag
+      # cannot silently change what runs.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: 8.0.x
           cache: true
@@ -66,7 +68,10 @@ jobs:
           NUGET_SOURCE: https://api.nuget.org/v3/index.json
           ARTIFACTS_DIR: artifacts
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-          REPO_BRANCH: ${{ github.ref_name }}
+          # On tag pushes ref_name is the tag, not a branch — stamping it into SourceLink's
+          # RepositoryBranch would embed a tag name. Empty means the property is omitted
+          # (BuildHelpers.PackArgs skips blank values); the commit below still pins sources.
+          REPO_BRANCH: ${{ github.ref_type == 'branch' && github.ref_name || '' }}
           REPO_COMMIT: ${{ github.sha }}
         run: dotnet run --project NxGraph.Build -- publish
 
@@ -92,7 +97,7 @@ jobs:
             unzip -l "$f" | grep -E '\.pdb$' || true
           done
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: nuget-packages

--- a/.github/workflows/upm-build.yml
+++ b/.github/workflows/upm-build.yml
@@ -18,10 +18,12 @@ jobs:
         mode: [ source, binary ]
 
     steps:
-      - uses: actions/checkout@v4
+      # Actions are pinned to commit SHAs (tag in the trailing comment) so a moved tag
+      # cannot silently change what runs.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: 8.0.x
 
@@ -29,7 +31,7 @@ jobs:
         run: dotnet run --project NxGraph.Build -- stage-${{ matrix.mode }}
 
       - name: Upload staged UPM package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: upm-${{ matrix.mode }}
           path: upm/com.enzx.nxgraph/

--- a/.github/workflows/upm-release.yml
+++ b/.github/workflows/upm-release.yml
@@ -35,12 +35,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      # Actions are pinned to commit SHAs (tag in the trailing comment) so a moved tag
+      # cannot silently change what runs — this job holds `contents: write`.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: 8.0.x
 
@@ -109,7 +111,7 @@ jobs:
           echo "Pushed UPM package v${VER} to 'upm' branch."
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}
           name: "UPM v${{ steps.meta.outputs.version }}"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,14 @@
 <!-- Repo-wide build defaults. Every project in the solution (tests, examples, benchmarks,
      and the NxGraph.Build tool via its own Directory.Build.props import chain) inherits
      these. Per-project files keep only what genuinely differs: TargetFramework(s), package
-     Title/Description/Tags/readme, and IsPackable/IsTestProject flags. -->
+     Title/Description/Tags/readme, and IsPackable/IsTestProject flags.
+
+     TFM decision (recorded): TargetFrameworks stay per-project. The core library
+     multi-targets net8.0 + netstandard2.1 because the Unity (UPM) package stages the
+     netstandard2.1 build of NxGraph.dll; the serialization packages stay net8.0-only —
+     no netstandard2.1 consumer story exists for them (the UPM package ships only the
+     core), so widening them would cost polyfills for nothing. Revisit only if a
+     netstandard consumer of the serialization surface appears. -->
 <Project>
 
     <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,44 @@
+<!-- Repo-wide build defaults. Every project in the solution (tests, examples, benchmarks,
+     and the NxGraph.Build tool via its own Directory.Build.props import chain) inherits
+     these. Per-project files keep only what genuinely differs: TargetFramework(s), package
+     Title/Description/Tags/readme, and IsPackable/IsTestProject flags. -->
+<Project>
+
+    <PropertyGroup>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <!-- Code analysis: .NET analyzers at the recommended severity profile, and every
+             warning (compiler + analyzer) is an error so the build can never go soft again.
+             Suppressions must be targeted NoWarn entries with a justifying comment. -->
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest-recommended</AnalysisLevel>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <!-- Shared NuGet package metadata. Only the packable projects (NxGraph,
+         NxGraph.Serialization, NxGraph.Serialization.Abstraction) pack, but these values are
+         harmless on IsPackable=false projects and centralizing them prevents drift. -->
+    <PropertyGroup>
+        <Authors>Moe Iraji</Authors>
+        <PackageProjectUrl>https://github.com/Enzx/NxGraph</PackageProjectUrl>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/Enzx/NxGraph</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
+
+    <!-- Determinism + SourceLink, gated on a CI environment variable (GitHub Actions sets
+         both CI and GITHUB_ACTIONS to 'true'). Local incremental builds keep local paths for
+         debuggability; any CI build (not just `pack` via NxGraph.Build) is deterministic
+         with repository metadata embedded. NxGraph.Build's PackArgs still passes these
+         explicitly so local pack/publish runs produce release-grade packages too. -->
+    <PropertyGroup Condition="'$(CI)' == 'true' or '$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+        <Deterministic>true</Deterministic>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <DebugType>portable</DebugType>
+    </PropertyGroup>
+
+</Project>

--- a/NxFSM.Examples/NxFSM.Examples.csproj
+++ b/NxFSM.Examples/NxFSM.Examples.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
+    <!-- Common properties (LangVersion/Nullable/analyzers) come from the repo-root
+         Directory.Build.props. -->
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NxGraph.Benchmarks/FeatureBenchmarks.cs
+++ b/NxGraph.Benchmarks/FeatureBenchmarks.cs
@@ -1,0 +1,290 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+using NxGraph.Tokens;
+
+namespace NxGraph.Benchmarks;
+
+/// <summary>
+/// Benchmarks for the headline features that shipped after the original suite: parallel
+/// composites (static and dynamic selection), scoped blackboards (typed keys vs the
+/// documented <c>Dictionary&lt;string, object&gt;</c> anti-pattern), the token runtime's
+/// diamond (fork → join), step I/O port relays, durable suspend + resume, and Switch
+/// dispatch. No Stateless comparison rows — these have no counterpart there.
+/// </summary>
+[MemoryDiagnoser]
+[HideColumns("Job", "Median", "StdDev", "StdErr", "Error", "RatioSD")]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+[CsvExporter]
+public class FeatureBenchmarks
+{
+    private const int BlackboardOpsPerRun = 10;
+
+    private static readonly BlackboardSchema BoardSchema = new("bench", BlackboardScope.Graph);
+    private static readonly BlackboardKey<int> CounterKey = BoardSchema.Register("counter", 0);
+    private static readonly BlackboardKey<int> PortKey = BoardSchema.Register("port", 0);
+
+    // ReSharper disable NullableWarningSuppressionIsUsed
+    private AsyncStateMachine _parallelAsync = null!;
+    private StateMachine _parallelSync = null!;
+    private AsyncStateMachine _dynamicParallelAsync = null!;
+    private StateMachine _dynamicParallelSync = null!;
+    private StateMachine _blackboardTyped = null!;
+    private StateMachine _blackboardDictionary = null!;
+    private Dictionary<string, object> _dictionaryBoard = null!;
+    private AsyncTokenMachine _tokenDiamondAsync = null!;
+    private TokenMachine _tokenDiamondSync = null!;
+    private AsyncStateMachine _portRelayAsync = null!;
+    private StateMachine _portRelaySync = null!;
+    private AsyncStateMachine _suspendResumeAsync = null!;
+    private StateMachine _suspendResumeSync = null!;
+    private AsyncStateMachine _switchAsync = null!;
+    private StateMachine _switchSync = null!;
+    // ReSharper restore NullableWarningSuppressionIsUsed
+
+    private static Graph AsyncRegion()
+    {
+        return GraphBuilder
+            .StartWithAsync(static _ => ResultHelpers.Success)
+            .ToAsync(static _ => ResultHelpers.Success)
+            .Build();
+    }
+
+    private static Graph SyncRegion()
+    {
+        return GraphBuilder
+            .StartWith(static () => Result.Success)
+            .To(static () => Result.Success)
+            .Build();
+    }
+
+    private static Result Run(StateMachine sm)
+    {
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = sm.Execute();
+        }
+
+        return result;
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // ── Parallel composite: 2 regions × 2 nodes, cooperative rounds to the join ──
+        _parallelAsync = GraphBuilder.Start()
+            .Parallel(AsyncRegion(), AsyncRegion())
+            .ToAsyncStateMachine();
+
+        _parallelSync = GraphBuilder.Start()
+            .Parallel(ParallelStepMode.RunToJoin, SyncRegion(), SyncRegion())
+            .ToStateMachine();
+
+        // ── Dynamic parallel: selector picks 1 of 2 regions once at entry ──
+        _dynamicParallelAsync = GraphBuilder.Start()
+            .Parallel(static _ => RegionMask.Bit(0), AsyncRegion(), AsyncRegion())
+            .ToAsyncStateMachine();
+
+        _dynamicParallelSync = GraphBuilder.Start()
+            .Parallel(ParallelStepMode.RunToJoin, static _ => RegionMask.Bit(0), SyncRegion(), SyncRegion())
+            .ToStateMachine();
+
+        // ── Blackboard access: typed scoped key vs Dictionary<string, object> ──
+        _blackboardTyped = GraphBuilder.Start()
+            .WithSchema(BoardSchema)
+            .To(static bb =>
+            {
+                for (int i = 0; i < BlackboardOpsPerRun; i++)
+                {
+                    int value = bb.Get(CounterKey);
+                    bb.Set(CounterKey, value + 1);
+                }
+
+                return Result.Success;
+            })
+            .ToStateMachine()
+            .WithBlackboard(new Blackboard(BoardSchema));
+
+        Dictionary<string, object> dictionary = new() { ["counter"] = 0 };
+        _dictionaryBoard = dictionary;
+        _blackboardDictionary = GraphBuilder
+            .StartWith(() =>
+            {
+                for (int i = 0; i < BlackboardOpsPerRun; i++)
+                {
+                    int value = (int)dictionary["counter"];
+                    dictionary["counter"] = value + 1; // boxes on every write
+                }
+
+                return Result.Success;
+            })
+            .ToStateMachine();
+
+        // ── Token runtime: diamond fork(a, b) → join(All 2) → finish ──
+        _tokenDiamondAsync = BuildAsyncDiamond().ToAsyncTokenMachine();
+        _tokenDiamondSync = BuildSyncDiamond().ToTokenMachine();
+        _tokenDiamondSync.SetStepMode(ParallelStepMode.RunToJoin);
+
+        // ── Step I/O ports: producer writes the port, consumer reads it ──
+        _portRelayAsync = GraphBuilder.Start()
+            .WithSchema(BoardSchema)
+            .ToAsync(PortKey, static (_, _) => new ValueTask<int>(42))
+            .ToAsync(PortKey, static (value, _, _) =>
+                value == 42 ? ResultHelpers.Success : ResultHelpers.Failure)
+            .ToAsyncStateMachine()
+            .WithBlackboard(new Blackboard(BoardSchema));
+
+        _portRelaySync = GraphBuilder.Start()
+            .WithSchema(BoardSchema)
+            .To(PortKey, static _ => 42)
+            .To(PortKey, static (value, _) => value == 42 ? Result.Success : Result.Failure)
+            .ToStateMachine()
+            .WithBlackboard(new Blackboard(BoardSchema));
+
+        // ── Suspend + resume round-trip on a 4-node chain, paused after the first step ──
+        _suspendResumeAsync = GraphBuilder
+            .StartWithAsync(static _ => ResultHelpers.Success)
+            .ToAsync(static _ => ResultHelpers.Success)
+            .ToAsync(static _ => ResultHelpers.Success)
+            .ToAsync(static _ => ResultHelpers.Success)
+            .ToAsyncStateMachine();
+
+        _suspendResumeSync = GraphBuilder
+            .StartWith(static () => Result.Success)
+            .To(static () => Result.Success)
+            .To(static () => Result.Success)
+            .To(static () => Result.Success)
+            .ToStateMachine();
+
+        // ── Switch dispatch: 3 cases + default, selector picks the middle case ──
+        _switchAsync = GraphBuilder
+            .StartWithAsync(static _ => ResultHelpers.Success)
+            .SwitchAsync(static () => new ValueTask<int>(2))
+            .CaseAsync(1, static _ => ResultHelpers.Success)
+            .CaseAsync(2, static _ => ResultHelpers.Success)
+            .CaseAsync(3, static _ => ResultHelpers.Success)
+            .DefaultAsync(static _ => ResultHelpers.Failure)
+            .End()
+            .ToAsyncStateMachine();
+
+        _switchSync = GraphBuilder
+            .StartWith(static () => Result.Success)
+            .Switch(static () => 2)
+            .Case(1, static () => Result.Success)
+            .Case(2, static () => Result.Success)
+            .Case(3, static () => Result.Success)
+            .Default(static () => Result.Failure)
+            .End()
+            .ToStateMachine();
+    }
+
+    private static Graph BuildAsyncDiamond()
+    {
+        JoinState join = new(JoinPolicy.All(2));
+        return GraphBuilder
+            .StartWithAsync(static _ => ResultHelpers.Success)
+            .ForkTo(
+                b => b.ToAsync(static _ => ResultHelpers.Success).To(join)
+                    .ToAsync(static _ => ResultHelpers.Success),
+                b => b.ToAsync(static _ => ResultHelpers.Success).To(join))
+            .Build();
+    }
+
+    private static Graph BuildSyncDiamond()
+    {
+        JoinState join = new(JoinPolicy.All(2));
+        return GraphBuilder
+            .StartWith(static () => Result.Success)
+            .ForkTo(
+                b => b.To(static () => Result.Success).To(join)
+                    .To(static () => Result.Success),
+                b => b.To(static () => Result.Success).To(join))
+            .Build();
+    }
+
+    // ---- Benchmarks ----
+
+    [BenchmarkCategory("ParallelComposite")]
+    [Benchmark(Description = "Async parallel composite, 2 regions x 2 nodes")]
+    public ValueTask<Result> ParallelAsync() => _parallelAsync.ExecuteAsync();
+
+    [BenchmarkCategory("ParallelComposite")]
+    [Benchmark(Description = "Sync parallel composite (RunToJoin), 2 regions x 2 nodes")]
+    public Result ParallelSync() => Run(_parallelSync);
+
+    [BenchmarkCategory("DynamicParallel")]
+    [Benchmark(Description = "Async dynamic parallel, selector picks 1 of 2 regions")]
+    public ValueTask<Result> DynamicParallelAsync() => _dynamicParallelAsync.ExecuteAsync();
+
+    [BenchmarkCategory("DynamicParallel")]
+    [Benchmark(Description = "Sync dynamic parallel (RunToJoin), selector picks 1 of 2 regions")]
+    public Result DynamicParallelSync() => Run(_dynamicParallelSync);
+
+    [BenchmarkCategory("BlackboardAccess")]
+    [Benchmark(Baseline = true, Description = "Typed BlackboardKey<int> Get+Set x10 in one node")]
+    public Result BlackboardTypedKey() => Run(_blackboardTyped);
+
+    [BenchmarkCategory("BlackboardAccess")]
+    [Benchmark(Description = "Dictionary<string, object> get+set x10 in one node (boxing anti-pattern)")]
+    public Result BlackboardDictionary() => Run(_blackboardDictionary);
+
+    [BenchmarkCategory("TokenDiamond")]
+    [Benchmark(Description = "Async token diamond: fork(2) -> join(All 2) -> finish")]
+    public ValueTask<Result> TokenDiamondAsync() => _tokenDiamondAsync.ExecuteAsync();
+
+    [BenchmarkCategory("TokenDiamond")]
+    [Benchmark(Description = "Sync token diamond (RunToJoin): fork(2) -> join(All 2) -> finish")]
+    public Result TokenDiamondSync() => _tokenDiamondSync.Execute();
+
+    [BenchmarkCategory("PortRelay")]
+    [Benchmark(Description = "Async port relay hop: producer -> consumer via Graph-scoped key")]
+    public ValueTask<Result> PortRelayAsync() => _portRelayAsync.ExecuteAsync();
+
+    [BenchmarkCategory("PortRelay")]
+    [Benchmark(Description = "Sync port relay hop: producer -> consumer via Graph-scoped key")]
+    public Result PortRelaySync() => Run(_portRelaySync);
+
+    [BenchmarkCategory("SuspendResume")]
+    [Benchmark(Description = "Async suspend+resume round-trip mid-run (4-node chain)")]
+    public async ValueTask<Result> SuspendResumeAsync()
+    {
+        Result result = await _suspendResumeAsync.StepAsync();
+        StateMachineSnapshot snapshot = _suspendResumeAsync.Suspend();
+        _suspendResumeAsync.Resume(snapshot);
+        while (result == Result.InProgress)
+        {
+            result = await _suspendResumeAsync.StepAsync();
+        }
+
+        return result;
+    }
+
+    [BenchmarkCategory("SuspendResume")]
+    [Benchmark(Description = "Sync suspend+resume round-trip mid-run (4-node chain)")]
+    public Result SuspendResumeSync()
+    {
+        Result result = _suspendResumeSync.Execute();
+        StateMachineSnapshot snapshot = _suspendResumeSync.Suspend();
+        _suspendResumeSync.Resume(snapshot);
+        while (result == Result.InProgress)
+        {
+            result = _suspendResumeSync.Execute();
+        }
+
+        return result;
+    }
+
+    [BenchmarkCategory("SwitchDispatch")]
+    [Benchmark(Description = "Async Switch dispatch: 3 cases + default")]
+    public ValueTask<Result> SwitchDispatchAsync() => _switchAsync.ExecuteAsync();
+
+    [BenchmarkCategory("SwitchDispatch")]
+    [Benchmark(Description = "Sync Switch dispatch: 3 cases + default")]
+    public Result SwitchDispatchSync() => Run(_switchSync);
+}

--- a/NxGraph.Benchmarks/NxGraph.Benchmarks.csproj
+++ b/NxGraph.Benchmarks/NxGraph.Benchmarks.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <!-- Common properties (LangVersion/Nullable/analyzers) come from the repo-root
+         Directory.Build.props. -->
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.13.12"/>

--- a/NxGraph.Benchmarks/StatelessBenchmarks.cs
+++ b/NxGraph.Benchmarks/StatelessBenchmarks.cs
@@ -1,13 +1,21 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using Stateless;
 
 namespace NxGraph.Benchmarks;
 
+/// <summary>
+/// Comparison baselines against the Stateless library, harness-matched to the NxGraph
+/// suites: no <c>[IterationSetup]</c> (BenchmarkDotNet documents it as ruining ns-scale
+/// precision, and the NxGraph classes measure setup-free thanks to
+/// <c>RestartPolicy.Auto</c> re-execution), so each benchmark resets its state variable
+/// inside the measured body — the same place NxGraph pays its per-run reset.
+/// </summary>
 [MemoryDiagnoser]
 [HideColumns("Job", "Median", "StdDev", "StdErr", "Error", "RatioSD")]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
 [CategoriesColumn]
+[CsvExporter]
 public class StatelessBenchmarks
 {
     private const int TriggerNext = 1;
@@ -56,13 +64,18 @@ public class StatelessBenchmarks
                 .Permit(TriggerNext, i + 1);
         }
 
+        // Timeout analog matched to NxGraph's AsyncTimeoutState: arm a cancellation timer
+        // for the deadline, run the (immediately completing) work under its token, and
+        // reclaim the timer when the work finishes. The previous version scheduled a real
+        // uncancelled Task.Delay(1000) per invocation — an orphaned live timer NxGraph
+        // never pays, which made the comparison row measure a different operation.
         _timeoutWrapper = new StateMachine<int, int>(() => _stateTimeoutWrapper, s => _stateTimeoutWrapper = s);
         _timeoutWrapper.Configure(0)
             .OnEntryAsync(async _ =>
             {
-                Task work = Task.CompletedTask;
-                Task timeout = Task.Delay(1000); // 1 second timeout
-                await Task.WhenAny(work, timeout); // work completes first; just measuring wrapper cost
+                using CancellationTokenSource cts = new();
+                cts.CancelAfter(TimeSpan.FromSeconds(1));
+                await WorkUnderToken(cts.Token); // completes immediately; timer reclaimed by Dispose
             })
             .Permit(TriggerNext, 1);
 
@@ -75,40 +88,10 @@ public class StatelessBenchmarks
         }
     }
 
-    [IterationSetup(Target = nameof(SingleTransition))]
-    public void ResetSingle()
+    private static Task WorkUnderToken(CancellationToken ct)
     {
-        _stateSingle = 0;
-    }
-
-    [IterationSetup(Target = nameof(Chain10))]
-    public void Reset10()
-    {
-        _stateChain10 = 0;
-    }
-
-    [IterationSetup(Target = nameof(Chain50))]
-    public void Reset50()
-    {
-        _stateChain50 = 0;
-    }
-
-    [IterationSetup(Target = nameof(Chain10_WithObserver))]
-    public void ResetObserver()
-    {
-        _stateWithObserver = 0;
-    }
-
-    [IterationSetup(Target = nameof(WithTimeoutWrapper))]
-    public void ResetTimeout()
-    {
-        _stateTimeoutWrapper = 0;
-    }
-
-    [IterationSetup(Target = nameof(DirectorLinear10))]
-    public void ResetDirector()
-    {
-        _stateDirector = 0;
+        ct.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
     }
 
     // ---- Benchmarks ----
@@ -117,6 +100,7 @@ public class StatelessBenchmarks
     [Benchmark(Baseline = true, Description = "Single transition 0 -> 1 (async)")]
     public async Task<int> SingleTransition()
     {
+        _stateSingle = 0;
         await _single.FireAsync(TriggerNext);
         return _stateSingle;
     }
@@ -125,6 +109,7 @@ public class StatelessBenchmarks
     [Benchmark(Description = "Chain of 10 transitions (async)")]
     public async Task<int> Chain10()
     {
+        _stateChain10 = 0;
         for (int i = 0; i < 10; i++)
         {
             await _chain10.FireAsync(TriggerNext);
@@ -137,6 +122,7 @@ public class StatelessBenchmarks
     [Benchmark(Description = "Chain of 50 transitions (async)")]
     public async Task<int> Chain50()
     {
+        _stateChain50 = 0;
         for (int i = 0; i < 50; i++)
         {
             await _chain50.FireAsync(TriggerNext);
@@ -147,8 +133,9 @@ public class StatelessBenchmarks
 
     [BenchmarkCategory("WithObserver")]
     [Benchmark(Description = "Chain10 + async no-op OnEntry (observer-like)")]
-    public async Task<int> Chain10_WithObserver()
+    public async Task<int> Chain10WithObserver()
     {
+        _stateWithObserver = 0;
         for (int i = 0; i < 10; i++)
         {
             await _withObserver.FireAsync(TriggerNext);
@@ -161,6 +148,7 @@ public class StatelessBenchmarks
     [Benchmark(Description = "Timeout-style wrapper around immediate success (async)")]
     public async Task<int> WithTimeoutWrapper()
     {
+        _stateTimeoutWrapper = 0;
         await _timeoutWrapper.FireAsync(TriggerNext);
         return _stateTimeoutWrapper;
     }
@@ -169,6 +157,7 @@ public class StatelessBenchmarks
     [Benchmark(Description = "Director-driven 10-step flow (async-fired)")]
     public async Task<int> DirectorLinear10()
     {
+        _stateDirector = 0;
         //emulate a director sequencing nodes
         for (int i = 0; i < 10; i++)
         {

--- a/NxGraph.Benchmarks/SyncFsmBenchmarks.cs
+++ b/NxGraph.Benchmarks/SyncFsmBenchmarks.cs
@@ -18,6 +18,8 @@ public class SyncFsmBenchmarks
     private StateMachine _chain10 = null!;
     private StateMachine _chain50 = null!;
     private StateMachine _withObserver = null!;
+    private StateMachine _withTimeoutWrapper = null!;
+    private StateMachine _directorLinear10 = null!;
     // ReSharper restore NullableWarningSuppressionIsUsed
 
     private sealed class SyncNoopObserver : IStateMachineObserver { }
@@ -42,6 +44,21 @@ public class SyncFsmBenchmarks
         _withObserver = GraphBuilder
             .StartWith(() => Result.Success)
             .ToStateMachine(new SyncNoopObserver());
+
+        // Sync twin of the async suite's timeout wrapper: TimeoutState checks the deadline
+        // between ticks (no CTS), so this measures the timestamp bookkeeping around an
+        // immediately succeeding node.
+        _withTimeoutWrapper = GraphBuilder
+            .Start()
+            .ToWithTimeout(1.Seconds(), () => Result.Success, TimeoutBehavior.Fail)
+            .ToStateMachine();
+
+        // Sync twin of the async suite's director-driven flow (same shape, same steady-state
+        // behavior: the director's counter is instance state and does not reset between runs).
+        StateToken builder = GraphBuilder.StartWith(() => Result.Success);
+        for (int i = 0; i < 9; i++)
+            builder = builder.To(() => Result.Success);
+        _directorLinear10 = builder.To(new SyncLinearDirector(10)).ToStateMachine();
     }
 
     private static Result Run(StateMachine sm)
@@ -67,4 +84,28 @@ public class SyncFsmBenchmarks
     [BenchmarkCategory("WithObserver")]
     [Benchmark(Description = "Sync single node + SyncNoopObserver")]
     public Result WithObserver() => Run(_withObserver);
+
+    [BenchmarkCategory("WithTimeoutWrapper")]
+    [Benchmark(Description = "Sync timeout wrapper around immediate success")]
+    public Result WithTimeoutWrapper() => Run(_withTimeoutWrapper);
+
+    [BenchmarkCategory("DirectorLinear10")]
+    [Benchmark(Description = "Sync director-driven 10-step flow")]
+    public Result DirectorLinear10() => Run(_directorLinear10);
+}
+
+file sealed class SyncLinearDirector(int max) : State, IDirector
+{
+    private int _counter;
+
+    public NodeId SelectNext()
+    {
+        _counter++;
+        return _counter >= max ? NodeId.Default : new NodeId();
+    }
+
+    protected override Result OnRun()
+    {
+        return Result.Success;
+    }
 }

--- a/NxGraph.Build/BuildHelpers.cs
+++ b/NxGraph.Build/BuildHelpers.cs
@@ -242,13 +242,13 @@ public static partial class BuildHelpers
             {
                 (target, version) = refName switch
                 {
-                    _ when refName.StartsWith("serialization-abstraction/v") =>
+                    _ when refName.StartsWith("serialization-abstraction/v", StringComparison.Ordinal) =>
                         ("serialization-abstraction", refName["serialization-abstraction/v".Length..]),
-                    _ when refName.StartsWith("serialization/v") =>
+                    _ when refName.StartsWith("serialization/v", StringComparison.Ordinal) =>
                         ("serialization", refName["serialization/v".Length..]),
-                    _ when refName.StartsWith("nxgraph/v") =>
+                    _ when refName.StartsWith("nxgraph/v", StringComparison.Ordinal) =>
                         ("nxgraph", refName["nxgraph/v".Length..]),
-                    _ when refName.StartsWith("v") =>
+                    _ when refName.StartsWith('v') =>
                         ("all", refName[1..]),
                     _ => throw new InvalidOperationException($"Unsupported tag format '{refName}'.")
                 };
@@ -274,7 +274,7 @@ public static partial class BuildHelpers
             var refType = OptionalEnv("GITHUB_REF_TYPE");
             var refName = OptionalEnv("GITHUB_REF_NAME");
 
-            if (refType == "tag" && refName is not null && refName.StartsWith("upm/v"))
+            if (refType == "tag" && refName is not null && refName.StartsWith("upm/v", StringComparison.Ordinal))
                 version = refName["upm/v".Length..];
         }
 

--- a/NxGraph.Build/Directory.Build.props
+++ b/NxGraph.Build/Directory.Build.props
@@ -1,10 +1,14 @@
-﻿<!-- Imported before Microsoft.Common.props — safe to set intermediate/output paths here.
+<!-- Imported before Microsoft.Common.props — safe to set intermediate/output paths here.
      This isolates build-tool output to .tools/ at the repository root so NxGraph.Build.exe,
-     Bullseye.dll, SimpleExec.dll, etc. never appear alongside the real project artifacts. -->
+     Bullseye.dll, SimpleExec.dll, etc. never appear alongside the real project artifacts.
+
+     MSBuild stops at the nearest Directory.Build.props, so the repo-root defaults
+     (analyzers, TreatWarningsAsErrors, metadata) are imported explicitly here — the root
+     file sets no output paths, so the .tools/ isolation below is unaffected. -->
 <Project>
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
     <PropertyGroup>
         <BaseOutputPath>$(MSBuildThisFileDirectory)..\.tools\bin\</BaseOutputPath>
         <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\.tools\obj\</BaseIntermediateOutputPath>
     </PropertyGroup>
 </Project>
-

--- a/NxGraph.Build/NxGraph.Build.csproj
+++ b/NxGraph.Build/NxGraph.Build.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
+    <!-- Common properties (LangVersion/Nullable/analyzers) come from the repo-root
+         Directory.Build.props, imported via this project's own Directory.Build.props
+         (which also isolates output to .tools/). -->
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -15,4 +15,3 @@
     </ItemGroup>
 
 </Project>
-

--- a/NxGraph.Build/Program.cs
+++ b/NxGraph.Build/Program.cs
@@ -6,6 +6,11 @@ namespace NxGraph.Build;
 
 public static class Program
 {
+    // Resolved once in Main and reused by every RunDotNet invocation — DotNetLocator.Locate
+    // probes the filesystem/registry, which is wasteful per call and could even pick a
+    // different SDK mid-run if the environment changes.
+    private static DotNetLocator.Result? _dotnet;
+
     private static readonly string[] DirectoriesToCopy =
     [
         Path.Combine("Authoring"),
@@ -36,6 +41,7 @@ public static class Program
         var repoRoot = FindRepoRoot();
 
         var dotnet = DotNetLocator.Locate(preferMajor: 8);
+        _dotnet = dotnet;
 
         // Preflight: print which dotnet is being used and basic SDK info.
         // This helps diagnose Windows-specific failures where a process fails to start
@@ -96,10 +102,15 @@ public static class Program
             // Line-coverage floor per instrumented module (each test project scopes its own
             // Include filter in its csproj). Raise this as new features land with tests;
             // never lower it without a recorded decision.
+            //
+            // Coverage runs on the coverlet.msbuild driver alone (/p:CollectCoverage +
+            // /p:Threshold is the gate; lcov coverage.info is the report). The VSTest
+            // collector (--collect:"XPlat Code Coverage") was removed deliberately: running
+            // both drivers at once is unsupported by coverlet and obscured which one gated.
+            // See NxGraph.Build/README.md § Coverage.
             var threshold = OptionalEnv("COVERAGE_THRESHOLD") ?? "70";
             await RunDotNet(repoRoot,
                 $"test --no-build --configuration {config} --verbosity normal " +
-                $"--collect:\"XPlat Code Coverage\" " +
                 $"/p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:Threshold={threshold} " +
                 $"/p:ThresholdType=line /p:ThresholdStat=minimum");
         });
@@ -157,18 +168,25 @@ public static class Program
             if (nupkgs.Length == 0)
                 throw new InvalidOperationException($"No .nupkg files found in {artifactsDir}");
 
+            // The API key must ride the command line: `dotnet nuget push` reads it from no
+            // environment variable, and a NuGet.Config `apikeys` entry would persist the
+            // secret to disk — worse. So the push invocations run with echo suppressed and a
+            // redacted command line is printed instead; GitHub CI additionally masks the
+            // secret, but local `publish` runs used to print it in cleartext.
+            string PushArgs(string pattern, string key) =>
+                $"nuget push \"{Path.Combine(artifactsDir, pattern)}\" " +
+                $"--api-key \"{key}\" --source \"{source}\" --skip-duplicate";
+
             Console.WriteLine("\n→ Pushing .nupkg...");
-            await RunDotNet(repoRoot,
-                $"nuget push \"{Path.Combine(artifactsDir, "*.nupkg")}\" " +
-                $"--api-key \"{apiKey}\" --source \"{source}\" --skip-duplicate");
+            await RunDotNet(repoRoot, PushArgs("*.nupkg", apiKey),
+                redactedArgs: PushArgs("*.nupkg", "***"));
 
             var snupkgs = Directory.GetFiles(artifactsDir, "*.snupkg");
             if (snupkgs.Length > 0)
             {
                 Console.WriteLine("\n→ Pushing .snupkg...");
-                await RunDotNet(repoRoot,
-                    $"nuget push \"{Path.Combine(artifactsDir, "*.snupkg")}\" " +
-                    $"--api-key \"{apiKey}\" --source \"{source}\" --skip-duplicate");
+                await RunDotNet(repoRoot, PushArgs("*.snupkg", apiKey),
+                    redactedArgs: PushArgs("*.snupkg", "***"));
             }
         });
 
@@ -205,12 +223,24 @@ public static class Program
         await RunTargetsAndExitAsync(args);
     }
 
-    private static async Task RunDotNet(string workingDirectory, string args)
+    /// <param name="workingDirectory">Directory to run in.</param>
+    /// <param name="args">The real argument string handed to dotnet.</param>
+    /// <param name="redactedArgs">When set, <paramref name="args"/> contains a secret: echo is
+    /// suppressed and this redacted rendering is printed (and used in failure messages)
+    /// instead, so the secret never reaches the console or an exception text.</param>
+    private static async Task RunDotNet(string workingDirectory, string args, string? redactedArgs = null)
     {
+        var printableArgs = redactedArgs ?? args;
         try
         {
-            var dotnet = DotNetLocator.Locate(preferMajor: 8);
-            await RunAsync(dotnet.ExecutablePath, args, workingDirectory: workingDirectory);
+            var dotnet = _dotnet ??= DotNetLocator.Locate(preferMajor: 8);
+            if (redactedArgs is not null)
+            {
+                Console.WriteLine($"{dotnet.ExecutablePath} {redactedArgs}");
+            }
+
+            await RunAsync(dotnet.ExecutablePath, args, workingDirectory: workingDirectory,
+                noEcho: redactedArgs is not null);
         }
         catch (SimpleExec.ExitCodeException e)
         {
@@ -218,9 +248,9 @@ public static class Program
             // unusual negative exit codes. Provide actionable hints.
             var dotnetPath = SafeResolveExecutablePath("dotnet");
             throw new InvalidOperationException(
-                $"dotnet {args} failed with exit code {e.ExitCode}. " +
+                $"dotnet {printableArgs} failed with exit code {e.ExitCode}. " +
                 $"WorkingDirectory='{workingDirectory}'. dotnet='{dotnetPath ?? "<not found>"}'. " +
-                "Try running the same command manually with higher verbosity: 'dotnet " + args + " -v diag'. " +
+                "Try running the same command manually with higher verbosity: 'dotnet " + printableArgs + " -v diag'. " +
                 "On Windows, negative exit codes often indicate the process failed to start (broken install/PATH) or was terminated by policy (AV/AppLocker).",
                 e);
         }

--- a/NxGraph.Build/README.md
+++ b/NxGraph.Build/README.md
@@ -24,13 +24,14 @@ Bullseye supports passing **multiple targets** in a single invocation. Shared de
 
 | Target | Depends on | Description |
 |---|---|---|
+| `info` | — | Diagnostic preflight: print repo root, resolved `dotnet` (and why), candidates, `dotnet --info` |
 | `clean` | — | Remove all staged UPM files (source & binary) |
 | `restore` | — | `dotnet restore` the solution |
 | `build` | `restore` | `dotnet build` the solution |
-| `test` | `build` | `dotnet test` with code-coverage collection |
+| `test` | `build` | `dotnet test` with code coverage + threshold gate (see [Coverage](#coverage)) |
 | **`ci`** | `test` | **Full CI pipeline** (restore → build → test) |
 | `pack` | `build` | Pack one or more NuGet packages |
-| `push` | `pack` | Push `.nupkg` + `.snupkg` to nuget.org |
+| `push` | `pack` | Push `.nupkg` + `.snupkg` to nuget.org (API key never echoed — see below) |
 | **`publish`** | `ci`, `push` | **Full release pipeline** (ci + pack + push) |
 | `stage-source` | — | Copy NxGraph source files into the UPM package |
 | `stage-binary` | — | Build NxGraph DLL and copy into the UPM package |
@@ -61,6 +62,32 @@ dotnet run --project NxGraph.Build -- ci
 
 This runs **restore → build → test** with code-coverage. Equivalent to what the
 `dotnet.yml` workflow does on every push/PR.
+
+## Coverage
+
+The `test` target runs coverage on **one** driver: **coverlet.msbuild**
+(`/p:CollectCoverage=true /p:Threshold=<n> /p:ThresholdType=line /p:ThresholdStat=minimum`,
+with `/p:CoverletOutputFormat=lcov` writing `coverage.info` next to each test csproj).
+Each test project scopes its instrumentation via an `<Include>` property in its csproj,
+and the threshold applies **per instrumented module**.
+
+Historically the invocation also passed the VSTest collector
+(`--collect:"XPlat Code Coverage"`, package `coverlet.collector`) at the same time.
+Running both drivers at once is unsupported by coverlet and obscured which one enforced
+the gate (the two packages had even drifted to different majors). The collector package
+and flag were removed; the msbuild driver is the gate, and a deliberately impossible
+`COVERAGE_THRESHOLD=99` run was used to verify the gate actually fails red.
+
+The gate is enforced in `ci` via `COVERAGE_THRESHOLD` (default 70). Raise it as coverage
+grows; never lower it without a recorded decision.
+
+### Push secret handling
+
+`push` hands the NuGet API key to `dotnet nuget push --api-key` with SimpleExec echo
+suppressed, printing a redacted command line (`--api-key "***"`) instead — the key never
+reaches the console or an exception message. The command-line route is deliberate:
+`dotnet nuget push` reads the key from no environment variable, and a `NuGet.Config`
+`apikeys` entry would persist the secret to disk.
 
 ### Build & test with a custom coverage threshold
 
@@ -127,6 +154,12 @@ VERSION=1.0.0 dotnet run --project NxGraph.Build -- ci stage-binary upm-patch-ve
 Bullseye runs all four targets (and their transitive dependencies) in a single process.
 This is what the `upm-release.yml` workflow runs — the remaining git-push and GitHub Release
 steps stay in YAML because they need authenticated git operations.
+
+**UPM release checklist:** the committed `upm/com.enzx.nxgraph/package.json` carries the
+**last released** version by policy (CI's `upm-patch-version` stamps the same value at
+release time). When cutting a UPM release, bump the manifest `version`, the CHANGELOG top
+entry, and the package README's install pin to the new version in the release-prep commit —
+three artifacts, one version.
 
 ### Clean staged UPM files
 

--- a/NxGraph.Serialization.Abstraction/BehaviorFieldWriter.cs
+++ b/NxGraph.Serialization.Abstraction/BehaviorFieldWriter.cs
@@ -79,10 +79,7 @@ public sealed class BehaviorFieldWriter
     /// </summary>
     public void WriteBehaviors(string name, IReadOnlyList<object> entries)
     {
-        if (entries is null)
-        {
-            throw new ArgumentNullException(nameof(entries));
-        }
+        ArgumentNullException.ThrowIfNull(entries);
 
         if (_entryCodec is null)
         {

--- a/NxGraph.Serialization.Abstraction/NxGraph.Serialization.Abstraction.csproj
+++ b/NxGraph.Serialization.Abstraction/NxGraph.Serialization.Abstraction.csproj
@@ -1,19 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <!-- Common properties (LangVersion/Nullable/analyzers/package metadata) come from the
+         repo-root Directory.Build.props. -->
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <!-- CS1591: XML docs are required only where they add value; missing-doc coverage is
+             tracked editorially, not as a build gate.
+             CA1720: BehaviorFieldKind members (String/Int32/Int64/Single/Double) and the
+             Integer/integer value slot deliberately carry type names — the field model's kinds
+             ARE the primitive types (spec 014 wire contract); renaming would break the wire
+             and the API baseline to dodge a naming lint. -->
+        <NoWarn>$(NoWarn);CS1591;CA1720</NoWarn>
         <Title>NxGraph.Serialization.Abstraction</Title>
-        <Authors>Moe Iraji</Authors>
         <Description>Serializer and codec abstractions for NxGraph — reference this package to implement custom graph serializers or node-logic codecs without depending on a concrete format.</Description>
-        <PackageProjectUrl>https://github.com/Enzx/NxGraph</PackageProjectUrl>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/Enzx/NxGraph</RepositoryUrl>
         <PackageTags>statemachine fsm serialization abstractions</PackageTags>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>Docs/readme.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/NxGraph.Serialization.Tests/BehaviorSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/BehaviorSerializationTests.cs
@@ -22,7 +22,7 @@ public class BehaviorSerializationTests
 {
     public sealed class Hero
     {
-        public readonly List<string> Visits = [];
+        public List<string> Visits { get; } = [];
     }
 
     private sealed class GreetHero : IBehavior<Hero>, IAsyncBehavior<Hero>, ISerializableBehavior

--- a/NxGraph.Serialization.Tests/DummyLogicBinaryCodec.cs
+++ b/NxGraph.Serialization.Tests/DummyLogicBinaryCodec.cs
@@ -12,9 +12,9 @@ public class DummyLogicBinaryCodec : ILogicBinaryCodec
                ?? throw new InvalidOperationException("Failed to deserialize DummyState from bytes.");
     }
 
-    public ReadOnlyMemory<byte> Serialize(IAsyncLogic data)
+    public ReadOnlyMemory<byte> Serialize(IAsyncLogic asyncLogic)
     {
-        string json = System.Text.Json.JsonSerializer.Serialize((DummyState)data);
+        string json = System.Text.Json.JsonSerializer.Serialize((DummyState)asyncLogic);
         return Encoding.UTF8.GetBytes(json);
     }
 }

--- a/NxGraph.Serialization.Tests/DummyLogicTextCodec.cs
+++ b/NxGraph.Serialization.Tests/DummyLogicTextCodec.cs
@@ -8,6 +8,6 @@ public class DummyLogicTextCodec : ILogicTextCodec
         => System.Text.Json.JsonSerializer.Deserialize<DummyState>(s)
            ?? throw new InvalidOperationException("Failed to deserialize DummyState from text.");
 
-    public string Serialize(IAsyncLogic data)
-        => System.Text.Json.JsonSerializer.Serialize((DummyState)data);
+    public string Serialize(IAsyncLogic asyncLogic)
+        => System.Text.Json.JsonSerializer.Serialize((DummyState)asyncLogic);
 }

--- a/NxGraph.Serialization.Tests/NxGraph.Serialization.Tests.csproj
+++ b/NxGraph.Serialization.Tests/NxGraph.Serialization.Tests.csproj
@@ -2,8 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
@@ -11,14 +9,22 @@
         <!-- Coverage instrumentation scope: serialization packages only; the core library
              is covered by NxGraph.Tests. -->
         <Include>[NxGraph.Serialization]*,[NxGraph.Serialization.Abstraction]*</Include>
+
+        <!-- Test-idiom analyzer exemptions (analyzers + TreatWarningsAsErrors stay on):
+             CA1707: underscore test names are this suite's naming convention.
+             CA1861: inline assertion arrays (Is.EqualTo(new[] { ... })) are the readable
+             test idiom; the repeated-call allocation concern does not apply to tests.
+             CA2201: fault-model tests deliberately throw ApplicationException as a
+             recognizable injected fault type. -->
+        <NoWarn>$(NoWarn);CA1707;CA1861;CA2201</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+        <!-- Coverage: coverlet.msbuild is the single coverage driver (the `/p:Threshold` gate
+             in NxGraph.Build's `test` target). The VSTest collector (coverlet.collector) was
+             removed deliberately — running both drivers at once is unsupported and hid which
+             one actually gated. See NxGraph.Build/README.md § Coverage. -->
+        <PackageReference Include="coverlet.msbuild" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/NxGraph.Serialization.Tests/NxGraph.Serialization.Tests.csproj
+++ b/NxGraph.Serialization.Tests/NxGraph.Serialization.Tests.csproj
@@ -23,10 +23,15 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="MessagePack" Version="3.1.7" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="NUnit" Version="3.14.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="3.9.0"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
+        <!-- Test framework versions aligned with NxGraph.Tests (NUnit 4 line) so hang-guard
+             attributes ([CancelAfter]) and assertion semantics are uniform across the suite. -->
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
+        <PackageReference Include="NUnit" Version="4.4.0"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/NxGraph.Serialization.Tests/RepeatSerializationTests.cs
+++ b/NxGraph.Serialization.Tests/RepeatSerializationTests.cs
@@ -23,7 +23,7 @@ public class RepeatSerializationTests
 {
     public sealed class Hero
     {
-        public readonly List<string> Visits = [];
+        public List<string> Visits { get; } = [];
     }
 
     private sealed class GreetHero : IBehavior<Hero>, IAsyncBehavior<Hero>, ISerializableBehavior

--- a/NxGraph.Serialization/BehaviorRegistry.cs
+++ b/NxGraph.Serialization/BehaviorRegistry.cs
@@ -64,7 +64,7 @@ public sealed class BehaviorRegistry : IBehaviorRegistry
         }
 
         if (behaviorTypeName.StartsWith(SetValuePrefix, StringComparison.Ordinal) &&
-            behaviorTypeName.EndsWith("]", StringComparison.Ordinal))
+            behaviorTypeName.EndsWith(']'))
         {
             behavior = ReadSetValue(behaviorTypeName, fields);
             return true;
@@ -85,14 +85,14 @@ public sealed class BehaviorRegistry : IBehaviorRegistry
         }
 
         if (behaviorTypeName.StartsWith(RepeatPrefix, StringComparison.Ordinal) &&
-            behaviorTypeName.EndsWith("]", StringComparison.Ordinal))
+            behaviorTypeName.EndsWith(']'))
         {
             behavior = ReadTypedRepeat(behaviorTypeName, RepeatPrefix, nameof(ReadRepeatGeneric), fields);
             return true;
         }
 
         if (behaviorTypeName.StartsWith(AsyncRepeatPrefix, StringComparison.Ordinal) &&
-            behaviorTypeName.EndsWith("]", StringComparison.Ordinal))
+            behaviorTypeName.EndsWith(']'))
         {
             behavior = ReadTypedRepeat(behaviorTypeName, AsyncRepeatPrefix, nameof(ReadAsyncRepeatGeneric), fields);
             return true;

--- a/NxGraph.Serialization/NxGraph.Serialization.csproj
+++ b/NxGraph.Serialization/NxGraph.Serialization.csproj
@@ -1,21 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <!-- Common properties (LangVersion/Nullable/analyzers/package metadata) come from the
+         repo-root Directory.Build.props. -->
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <!-- CS1591: XML docs are required only where they add value; missing-doc coverage is
+             tracked editorially, not as a build gate. -->
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <Title>NxGraph.Serialization</Title>
-        <Authors>Moe Iraji</Authors>
         <Description>JSON and MessagePack serialization for NxGraph: durable graph payloads, state-machine snapshots, and blackboard payloads with pluggable node-logic codecs.</Description>
-        <PackageProjectUrl>https://github.com/Enzx/NxGraph</PackageProjectUrl>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/Enzx/NxGraph</RepositoryUrl>
         <PackageTags>statemachine fsm serialization messagepack json durability</PackageTags>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>Docs/readme.md</PackageReadmeFile>
-
     </PropertyGroup>
 
     <ItemGroup>

--- a/NxGraph.Serialization/StableTypeResolver.cs
+++ b/NxGraph.Serialization/StableTypeResolver.cs
@@ -26,7 +26,7 @@ internal static class StableTypeResolver
             return null;
         }
 
-        if (!name.EndsWith("]", StringComparison.Ordinal))
+        if (!name.EndsWith(']'))
         {
             return ResolveSimple(name);
         }

--- a/NxGraph.Tests/AgentPropagationTests.cs
+++ b/NxGraph.Tests/AgentPropagationTests.cs
@@ -8,7 +8,7 @@ namespace NxGraph.Tests;
 [Category("agent_propagation")]
 public class AgentPropagationTests
 {
-    private class DummyAgent
+    private sealed class DummyAgent
     {
         public bool Visited;
     }

--- a/NxGraph.Tests/AllStateTests.cs
+++ b/NxGraph.Tests/AllStateTests.cs
@@ -47,13 +47,13 @@ public class AllStateTests
                 async (_, _) =>
                 {
                     first.SetResult();
-                    await second.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                    await second.Task.WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
                     return Result.Success;
                 },
                 async (_, _) =>
                 {
                     second.SetResult();
-                    await first.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                    await first.Task.WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
                     return Result.Success;
                 })
             .Build();
@@ -266,14 +266,14 @@ public class AllStateTests
                 async (bb, _) =>
                 {
                     leftStarted.SetResult();
-                    await rightStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                    await rightStarted.Task.WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
                     bb.Set(left, 21);
                     return Result.Success;
                 },
                 async (bb, _) =>
                 {
                     rightStarted.SetResult();
-                    await leftStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+                    await leftStarted.Task.WaitAsync(TimeSpan.FromSeconds(30), CancellationToken.None);
                     bb.Set(right, 42);
                     return Result.Success;
                 })

--- a/NxGraph.Tests/AllStateTests.cs
+++ b/NxGraph.Tests/AllStateTests.cs
@@ -35,7 +35,9 @@ public class AllStateTests
         // Each work signals its own start, then awaits the other's signal. The node completes
         // only if both works were started before either finished — i.e. under true overlap.
         // Sequential execution (await one work to completion before starting the next) would
-        // never finish; no timing assertions are involved.
+        // stall the handshake; no timing assertions are involved. The 30 s WaitAsync bound is
+        // the hang backstop: a concurrency regression turns into a bounded red test (the
+        // TimeoutException surfaces through the machine), never a hung suite.
         TaskCompletionSource first = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TaskCompletionSource second = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -45,13 +47,13 @@ public class AllStateTests
                 async (_, _) =>
                 {
                     first.SetResult();
-                    await second.Task;
+                    await second.Task.WaitAsync(TimeSpan.FromSeconds(30));
                     return Result.Success;
                 },
                 async (_, _) =>
                 {
                     second.SetResult();
-                    await first.Task;
+                    await first.Task.WaitAsync(TimeSpan.FromSeconds(30));
                     return Result.Success;
                 })
             .Build();
@@ -200,6 +202,10 @@ public class AllStateTests
         bool[] cancelled = new bool[2];
         CancellationTokenSource cts = new(10);
 
+        // The waits are bounded (30 s, not Timeout.Infinite) as the hang backstop: the works
+        // only ever see the token through the library's own plumbing, so no test-side guard
+        // can reach a hang if that plumbing regresses — with a bounded delay such a
+        // regression completes the works and turns the assertions red instead of hanging.
         Graph graph = GraphBuilder
             .Start()
             .ToAllAsync(
@@ -207,7 +213,7 @@ public class AllStateTests
                 {
                     try
                     {
-                        await Task.Delay(System.Threading.Timeout.Infinite, ct);
+                        await Task.Delay(TimeSpan.FromSeconds(30), ct);
                     }
                     catch (OperationCanceledException)
                     {
@@ -221,7 +227,7 @@ public class AllStateTests
                 {
                     try
                     {
-                        await Task.Delay(System.Threading.Timeout.Infinite, ct);
+                        await Task.Delay(TimeSpan.FromSeconds(30), ct);
                     }
                     catch (OperationCanceledException)
                     {
@@ -250,6 +256,7 @@ public class AllStateTests
 
         // The handshake forces both works to be mid-flight while writing, so the writes
         // genuinely overlap — distinct keys mean distinct slots, which is the contract.
+        // The 30 s WaitAsync bound is the hang backstop (see the overlap test above).
         TaskCompletionSource leftStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         TaskCompletionSource rightStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -259,14 +266,14 @@ public class AllStateTests
                 async (bb, _) =>
                 {
                     leftStarted.SetResult();
-                    await rightStarted.Task;
+                    await rightStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
                     bb.Set(left, 21);
                     return Result.Success;
                 },
                 async (bb, _) =>
                 {
                     rightStarted.SetResult();
-                    await leftStarted.Task;
+                    await leftStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
                     bb.Set(right, 42);
                     return Result.Success;
                 })

--- a/NxGraph.Tests/AllocationGateTests.cs
+++ b/NxGraph.Tests/AllocationGateTests.cs
@@ -14,13 +14,24 @@ namespace NxGraph.Tests;
 /// Measurements use <see cref="GC.GetAllocatedBytesForCurrentThread"/>; all node logic
 /// completes synchronously, so awaits never leave the measuring thread. The gate only
 /// holds for Release builds (Debug async methods heap-allocate their state machines),
-/// so the fixture self-ignores in Debug.
+/// so the fixture self-ignores in Debug. That means the 0 B guarantee rides entirely on
+/// the CI Release leg: NxGraph.Build's <c>ci</c> target defaults CONFIGURATION=Release,
+/// so the gate does run in CI today — keep that true if the CI configuration ever changes.
+/// </para>
+/// <para>
+/// JIT behavior is pinned for this test project (<c>TieredCompilation=false</c> and
+/// <c>TieredPgo=false</c> in NxGraph.Tests.csproj), so every method compiles straight to
+/// its final optimized form and no background re-tier / OSR transition can land inside a
+/// measurement window. Pinning was chosen over raising the warmup count because tier-up
+/// completes asynchronously — no fixed warmup count can guarantee it has finished on a
+/// loaded runner, which is exactly the nondeterminism this gate must not have.
 /// </para>
 /// </summary>
 [TestFixture]
 [NonParallelizable]
 public class AllocationGateTests
 {
+    private const int WarmupRuns = 50;
     private const int Iterations = 200;
 
     private sealed class NoopAsyncObserver : IAsyncStateMachineObserver
@@ -41,40 +52,53 @@ public class AllocationGateTests
 #endif
     }
 
-    private static async Task AssertZeroAllocAsync(AsyncStateMachine machine)
+    // All cases funnel through the two delegate cores below so the warmup/iterate/measure
+    // protocol exists exactly once; per-shape entry points only adapt the run action.
+
+    private static Task AssertZeroAllocAsync(AsyncStateMachine machine)
     {
-        for (int i = 0; i < 50; i++)
+        return AssertZeroAllocAsync(async () => { await machine.ExecuteAsync(); }, "Async hot path");
+    }
+
+    private static async Task AssertZeroAllocAsync(Func<ValueTask> runOnce, string label)
+    {
+        for (int i = 0; i < WarmupRuns; i++)
         {
-            await machine.ExecuteAsync();
+            await runOnce();
         }
 
         long before = GC.GetAllocatedBytesForCurrentThread();
         for (int i = 0; i < Iterations; i++)
         {
-            await machine.ExecuteAsync();
+            await runOnce();
         }
 
         long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
         Assert.That(allocated, Is.Zero,
-            $"Async hot path allocated {allocated} B over {Iterations} runs.");
+            $"{label} allocated {allocated} B over {Iterations} runs.");
     }
 
     private static void AssertZeroAlloc(StateMachine machine)
     {
-        for (int i = 0; i < 50; i++)
+        AssertZeroAlloc(() => RunToCompletion(machine), "Sync hot path");
+    }
+
+    private static void AssertZeroAlloc(Action runOnce, string label)
+    {
+        for (int i = 0; i < WarmupRuns; i++)
         {
-            RunToCompletion(machine);
+            runOnce();
         }
 
         long before = GC.GetAllocatedBytesForCurrentThread();
         for (int i = 0; i < Iterations; i++)
         {
-            RunToCompletion(machine);
+            runOnce();
         }
 
         long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
         Assert.That(allocated, Is.Zero,
-            $"Sync hot path allocated {allocated} B over {Iterations} runs.");
+            $"{label} allocated {allocated} B over {Iterations} runs.");
     }
 
     private static void RunToCompletion(StateMachine machine)
@@ -125,21 +149,7 @@ public class AllocationGateTests
             .Goto("Top")
             .Build();
 
-        AsyncStateMachine machine = graph.ToAsyncStateMachine();
-
-        for (int i = 0; i < 50; i++)
-        {
-            await machine.ExecuteAsync();
-        }
-
-        long before = GC.GetAllocatedBytesForCurrentThread();
-        for (int i = 0; i < Iterations; i++)
-        {
-            await machine.ExecuteAsync();
-        }
-
-        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        Assert.That(allocated, Is.Zero, $"Goto loop allocated {allocated} B over {Iterations} runs.");
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine());
     }
 
     [Test]
@@ -192,23 +202,12 @@ public class AllocationGateTests
     {
         AsyncStateMachine machine = AsyncChain(10).ToAsyncStateMachine();
 
-        for (int i = 0; i < 50; i++)
+        await AssertZeroAllocAsync(async () =>
         {
-            while ((await machine.StepAsync()) == Result.InProgress)
+            while (await machine.StepAsync() == Result.InProgress)
             {
             }
-        }
-
-        long before = GC.GetAllocatedBytesForCurrentThread();
-        for (int i = 0; i < Iterations; i++)
-        {
-            while ((await machine.StepAsync()) == Result.InProgress)
-            {
-            }
-        }
-
-        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        Assert.That(allocated, Is.Zero, $"Stepped execution allocated {allocated} B over {Iterations} runs.");
+        }, "Stepped execution");
     }
 
     [Test]
@@ -533,6 +532,68 @@ public class AllocationGateTests
             .WithBlackboard(local));
     }
 
+    // ── Directors: Switch dispatch and non-blackboard Choice ────────────
+
+    [Test]
+    public async Task async_switch_dispatch_is_allocation_free()
+    {
+        int lap = 0;
+        Graph graph = GraphBuilder
+            .Start()
+            .Switch(() => ++lap % 3) // rotate: case 1, case 2, default
+            .CaseAsync(1, _ => ResultHelpers.Success)
+            .CaseAsync(2, _ => ResultHelpers.Success)
+            .DefaultAsync(_ => ResultHelpers.Success)
+            .End()
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine());
+    }
+
+    [Test]
+    public void sync_switch_dispatch_is_allocation_free()
+    {
+        int lap = 0;
+        Graph graph = GraphBuilder
+            .Start()
+            .Switch(() => ++lap % 3) // rotate: case 1, case 2, default
+            .Case(1, () => Result.Success)
+            .Case(2, () => Result.Success)
+            .Default(() => Result.Success)
+            .End()
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine());
+    }
+
+    [Test]
+    public async Task async_choice_without_blackboard_is_allocation_free()
+    {
+        bool flag = false;
+        Graph graph = GraphBuilder
+            .Start()
+            .If(() => flag = !flag) // exercise both branches over the run set
+            .ThenAsync(_ => ResultHelpers.Success)
+            .ElseAsync(_ => ResultHelpers.Success)
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine());
+    }
+
+    [Test]
+    public void sync_choice_without_blackboard_is_allocation_free()
+    {
+        bool flag = false;
+        Graph graph = GraphBuilder
+            .Start()
+            .If(() => flag = !flag) // exercise both branches over the run set
+            .Then(() => Result.Success)
+            .Else(() => Result.Success)
+            .Build();
+
+        AssertZeroAlloc(graph.ToStateMachine());
+    }
+
     // ── Blackboards: Node scope (per-transition reset included) ─────────
 
     private static Graph NodeScopeChain(bool sync)
@@ -690,6 +751,19 @@ public class AllocationGateTests
     }
 
     [Test]
+    public async Task async_to_with_timeout_happy_path_is_allocation_free()
+    {
+        // Inner completes before the deadline; the wrapper's pooled CTS (rent → CancelAfter →
+        // TryReset → return) must keep the happy path at 0 B steady-state.
+        Graph graph = GraphBuilder
+            .Start()
+            .ToWithTimeoutAsync(TimeSpan.FromSeconds(5), _ => ResultHelpers.Success)
+            .Build();
+
+        await AssertZeroAllocAsync(graph.ToAsyncStateMachine());
+    }
+
+    [Test]
     public void sync_to_all_join_is_allocation_free()
     {
         // The async AsyncAllState allocates per execution by design (task materialization
@@ -761,20 +835,9 @@ public class AllocationGateTests
         (Graph graph, Blackboard board, BlackboardKey<GatePing> _) = EventGraph(sync: false);
         AsyncStateMachine machine = graph.ToAsyncStateMachine().WithBlackboard(board);
 
-        for (int i = 0; i < 50; i++)
-        {
-            await machine.ExecuteAsync(new GatePing(i));
-        }
-
-        long before = GC.GetAllocatedBytesForCurrentThread();
-        for (int i = 0; i < Iterations; i++)
-        {
-            await machine.ExecuteAsync(new GatePing(i));
-        }
-
-        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        Assert.That(allocated, Is.Zero,
-            $"Typed event raise allocated {allocated} B over {Iterations} runs.");
+        int payload = 0;
+        await AssertZeroAllocAsync(async () => { await machine.ExecuteAsync(new GatePing(payload++)); },
+            "Typed event raise");
     }
 
     [Test]
@@ -783,20 +846,9 @@ public class AllocationGateTests
         (Graph graph, Blackboard board, BlackboardKey<GatePing> _) = EventGraph(sync: true);
         StateMachine machine = graph.ToStateMachine().WithBlackboard(board);
 
-        for (int i = 0; i < 50; i++)
-        {
-            RaiseToCompletion(machine, new GatePing(i));
-        }
-
-        long before = GC.GetAllocatedBytesForCurrentThread();
-        for (int i = 0; i < Iterations; i++)
-        {
-            RaiseToCompletion(machine, new GatePing(i));
-        }
-
-        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        Assert.That(allocated, Is.Zero,
-            $"Sync typed event raise allocated {allocated} B over {Iterations} runs.");
+        int payload = 0;
+        AssertZeroAlloc(() => RaiseToCompletion(machine, new GatePing(payload++)),
+            "Sync typed event raise");
     }
 
     private static void RaiseToCompletion<TEvent>(StateMachine machine, TEvent evt)
@@ -813,38 +865,12 @@ public class AllocationGateTests
     private static void AssertZeroAllocTokens(NxGraph.Tokens.TokenMachine machine)
     {
         machine.SetStepMode(ParallelStepMode.RunToJoin);
-        for (int i = 0; i < 50; i++)
-        {
-            machine.Execute();
-        }
-
-        long before = GC.GetAllocatedBytesForCurrentThread();
-        for (int i = 0; i < Iterations; i++)
-        {
-            machine.Execute();
-        }
-
-        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        Assert.That(allocated, Is.Zero,
-            $"Sync token hot path allocated {allocated} B over {Iterations} runs.");
+        AssertZeroAlloc(() => machine.Execute(), "Sync token hot path");
     }
 
-    private static async Task AssertZeroAllocTokensAsync(NxGraph.Tokens.AsyncTokenMachine machine)
+    private static Task AssertZeroAllocTokensAsync(NxGraph.Tokens.AsyncTokenMachine machine)
     {
-        for (int i = 0; i < 50; i++)
-        {
-            await machine.ExecuteAsync();
-        }
-
-        long before = GC.GetAllocatedBytesForCurrentThread();
-        for (int i = 0; i < Iterations; i++)
-        {
-            await machine.ExecuteAsync();
-        }
-
-        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        Assert.That(allocated, Is.Zero,
-            $"Async token hot path allocated {allocated} B over {Iterations} runs.");
+        return AssertZeroAllocAsync(async () => { await machine.ExecuteAsync(); }, "Async token hot path");
     }
 
     /// <summary>load → fork(a, b) → join(All 2) → finish, sync logic throughout.</summary>
@@ -873,41 +899,76 @@ public class AllocationGateTests
     [Test]
     public void sync_token_any_merge_is_allocation_free()
     {
+        AssertZeroAllocTokens(TokenAnyMerge().ToTokenMachine());
+    }
+
+    [Test]
+    public async Task async_token_any_merge_is_allocation_free()
+    {
+        await AssertZeroAllocTokensAsync(TokenAnyMerge().ToAsyncTokenMachine());
+    }
+
+    /// <summary>load → fork(a, b) → merge(Any) with a shared tail, sync logic throughout.</summary>
+    private static Graph TokenAnyMerge()
+    {
         NxGraph.Tokens.JoinState merge = new(NxGraph.Tokens.JoinPolicy.Any);
-        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+        return GraphBuilder.StartWith(() => Result.Success)
             .ForkTo(
                 b => b.To(() => Result.Success).To(merge).To(() => Result.Success),
                 b => b.To(() => Result.Success).To(merge))
             .Build();
-
-        AssertZeroAllocTokens(graph.ToTokenMachine());
     }
 
     [Test]
     public void sync_token_retry_without_backoff_is_allocation_free()
     {
         int calls = 0;
+        AssertZeroAllocTokens(TokenRetryDiamond(() => ++calls % 2 == 0).ToTokenMachine());
+    }
+
+    [Test]
+    public async Task async_token_retry_without_backoff_is_allocation_free()
+    {
+        // No backoff on purpose: a zero backoff never reaches Task.Delay, so the async
+        // per-token retry loop must stay 0 B like the sync one.
+        int calls = 0;
+        await AssertZeroAllocTokensAsync(TokenRetryDiamond(() => ++calls % 2 == 0).ToAsyncTokenMachine());
+    }
+
+    /// <summary>Fork with one flaky branch retried in place (no backoff) joining an All(2).</summary>
+    private static Graph TokenRetryDiamond(Func<bool> succeeds)
+    {
         NxGraph.Tokens.JoinState join = new(NxGraph.Tokens.JoinPolicy.All(2));
-        Graph graph = GraphBuilder.StartWith(() => Result.Success)
+        return GraphBuilder.StartWith(() => Result.Success)
             .ForkTo(
-                b => b.To(() => ++calls % 2 == 0 ? Result.Success : Result.Failure)
+                b => b.To(() => succeeds() ? Result.Success : Result.Failure)
                     .Retry(2)
                     .To(join),
                 b => b.To(() => Result.Success).To(join))
             .Build();
-
-        AssertZeroAllocTokens(graph.ToTokenMachine());
     }
 
     [Test]
     public void sync_token_node_scope_scratch_is_allocation_free()
+    {
+        AssertZeroAllocTokens(TokenNodeScopeScratch().ToTokenMachine());
+    }
+
+    [Test]
+    public async Task async_token_node_scope_scratch_is_allocation_free()
+    {
+        await AssertZeroAllocTokensAsync(TokenNodeScopeScratch().ToAsyncTokenMachine());
+    }
+
+    /// <summary>Fork whose branches write per-token Node-scoped scratch before an All(2) join.</summary>
+    private static Graph TokenNodeScopeScratch()
     {
         BlackboardSchema nodeSchema = new("token-scratch", BlackboardScope.Node);
         BlackboardKey<int> counter = nodeSchema.Register("counter", 0);
 
         NxGraph.Tokens.JoinState join = new(NxGraph.Tokens.JoinPolicy.All(2));
         StateToken start = GraphBuilder.StartWith(() => Result.Success);
-        Graph graph = start.ForkTo(
+        return start.ForkTo(
                 b => b.To(bb =>
                 {
                     bb.Set(counter, bb.Get(counter) + 1);
@@ -919,14 +980,18 @@ public class AllocationGateTests
                     return Result.Success;
                 }).To(join))
             .Builder.WithSchema(nodeSchema).Build();
-
-        AssertZeroAllocTokens(graph.ToTokenMachine());
     }
 
     [Test]
     public async Task async_token_with_observer_is_allocation_free()
     {
         await AssertZeroAllocTokensAsync(TokenDiamond().ToAsyncTokenMachine(new NoopAsyncTokenObserver()));
+    }
+
+    [Test]
+    public void sync_token_with_observer_is_allocation_free()
+    {
+        AssertZeroAllocTokens(TokenDiamond().ToTokenMachine(new NoopSyncTokenObserver()));
     }
 
     // ── Behaviors: sequence run loop + binding resolution (spec 014) ────
@@ -1008,6 +1073,8 @@ public class AllocationGateTests
 
         AssertZeroAlloc(graph.ToStateMachine().WithBlackboard(board));
     }
+
+    private sealed class NoopSyncTokenObserver : NxGraph.Tokens.ITokenMachineObserver;
 
     private sealed class NoopAsyncTokenObserver : NxGraph.Tokens.IAsyncTokenMachineObserver
     {

--- a/NxGraph.Tests/ChoiceStateTests.cs
+++ b/NxGraph.Tests/ChoiceStateTests.cs
@@ -9,8 +9,8 @@ namespace NxGraph.Tests;
 public class ChoiceStateTests
 {
     [Test]
-    [Timeout(5000)]
-    public async Task choice_state_should_follow_true_branch()
+    [CancelAfter(10_000)]
+    public async Task choice_state_should_follow_true_branch(CancellationToken ct)
     {
         const bool flag = true;
 
@@ -20,7 +20,7 @@ public class ChoiceStateTests
             .ElseAsync(_ => ResultHelpers.Failure)
             .ToAsyncStateMachine();
 
-        Result result = await fsm.ExecuteAsync();
+        Result result = await fsm.ExecuteAsync(ct);
         Assert.That(result, Is.EqualTo(Result.Success));
     }
 
@@ -41,7 +41,6 @@ public class ChoiceStateTests
     }
 
     [Test]
-    [Timeout(5000)]
     public void start_if_graph_is_executable_by_the_sync_runtime()
     {
         // Regression: Start().If(predicate) used to wrap the sync predicate in an

--- a/NxGraph.Tests/HierarchicalFsmsTests.cs
+++ b/NxGraph.Tests/HierarchicalFsmsTests.cs
@@ -11,46 +11,69 @@ namespace NxGraph.Tests;
 [TestFixture(Category = "NxFSM")]
 public class HierarchicalFsmTests
 {
-    private class HierarchicalDummyState(string? data = null) : IAsyncLogic
+    private class HierarchicalDummyState : IAsyncLogic
     {
-        public string Data { get; init; } = data ?? string.Empty;
+        public HierarchicalDummyState()
+        {
+        }
 
+        public HierarchicalDummyState(string data, List<string> log)
+        {
+            Data = data;
+            _log = log;
+        }
+
+        public string Data { get; init; } = string.Empty;
+
+        // Instance state threaded in by the test, never serialized (private field): the
+        // suite must stay free of shared mutable statics so no fixture blocks a future
+        // parallel run. The serialization round-trip re-attaches it via the codec.
+        private List<string>? _log;
+
+        internal void AttachLog(List<string> log) => _log = log;
 
         public ValueTask<Result> ExecuteAsync(CancellationToken ct = default)
         {
-            ExecutionLog.Add(Data);
+            _log?.Add(Data);
             return ResultHelpers.Success;
         }
     }
 
-    private class DummyLogicTextCodec : ILogicCodec<string>
+    private class DummyLogicTextCodec(List<string> log) : ILogicCodec<string>
     {
         public string Serialize(IAsyncLogic asyncLogic) =>
             JsonSerializer.Serialize((HierarchicalDummyState)asyncLogic);
 
-        public IAsyncLogic Deserialize(string data) =>
-            JsonSerializer.Deserialize<HierarchicalDummyState>(data)
-            ?? new HierarchicalDummyState();
+        public IAsyncLogic Deserialize(string data)
+        {
+            HierarchicalDummyState state = JsonSerializer.Deserialize<HierarchicalDummyState>(data)
+                                           ?? new HierarchicalDummyState();
+            state.AttachLog(log);
+            return state;
+        }
     }
 
-    private static readonly List<string> ExecutionLog = [];
+    // Note: the suite runs sequentially by standing decision (no [assembly: Parallelizable]);
+    // see the note in NxGraph.Tests.csproj. Fixture instance state like this list still must
+    // not be static, so a single fixture can never re-couple otherwise independent tests.
+    private readonly List<string> _executionLog = [];
     private static readonly List<string> ExpectedLog = ["parent start", "child start", "child end", "parent end"];
 
     [SetUp]
-    public void SetUp() => ExecutionLog.Clear();
+    public void SetUp() => _executionLog.Clear();
 
 
     [Test]
     public async Task Executes_HierarchicalFsm_InExpected_Order()
     {
         Graph childGraph = GraphBuilder
-            .StartWithAsync(new HierarchicalDummyState("child start"))
-            .ToAsync(new HierarchicalDummyState("child end")).Build();
+            .StartWithAsync(new HierarchicalDummyState("child start", _executionLog))
+            .ToAsync(new HierarchicalDummyState("child end", _executionLog)).Build();
         AsyncStateMachine childFsm = childGraph.ToAsyncStateMachine();
         Graph parentGraph = GraphBuilder
-            .StartWithAsync(new HierarchicalDummyState("parent start"))
+            .StartWithAsync(new HierarchicalDummyState("parent start", _executionLog))
             .ToAsync(childFsm)
-            .ToAsync(new HierarchicalDummyState("parent end"))
+            .ToAsync(new HierarchicalDummyState("parent end", _executionLog))
             .Build();
         AsyncStateMachine parentFsm = parentGraph.ToAsyncStateMachine();
         await parentFsm.ExecuteAsync();
@@ -67,7 +90,8 @@ public class HierarchicalFsmTests
             Assert.That(((HierarchicalDummyState)childGraph.StartNode.AsyncLogic).Data, Is.EqualTo("child start"));
             Assert.That(((HierarchicalDummyState)childGraph.GetNodeByIndex(1).AsyncLogic).Data,
                 Is.EqualTo("child end"));
-            Assert.That(ExecutionLog, Is.EquivalentTo(ExpectedLog));
+            // Sequence-equal on purpose: this test's whole point is the execution order.
+            Assert.That(_executionLog, Is.EqualTo(ExpectedLog));
         }
     }
 
@@ -138,17 +162,17 @@ public class HierarchicalFsmTests
     public async Task Serializes_And_Deserializes_HierarchicalFsm_Correctly()
     {
         Graph childGraph = GraphBuilder
-            .StartWithAsync(new HierarchicalDummyState("child start"))
-            .ToAsync(new HierarchicalDummyState("child end")).Build();
+            .StartWithAsync(new HierarchicalDummyState("child start", _executionLog))
+            .ToAsync(new HierarchicalDummyState("child end", _executionLog)).Build();
         AsyncStateMachine childFsm = childGraph.ToAsyncStateMachine();
         Graph parentGraph = GraphBuilder
-            .StartWithAsync(new HierarchicalDummyState("parent start"))
+            .StartWithAsync(new HierarchicalDummyState("parent start", _executionLog))
             .ToAsync(childFsm)
-            .ToAsync(new HierarchicalDummyState("parent end"))
+            .ToAsync(new HierarchicalDummyState("parent end", _executionLog))
             .Build();
         AsyncStateMachine parentFsm = parentGraph.ToAsyncStateMachine();
         await parentFsm.ExecuteAsync();
-        GraphSerializer serializer = new(new DummyLogicTextCodec());
+        GraphSerializer serializer = new(new DummyLogicTextCodec(_executionLog));
         await using MemoryStream stream = new();
         await serializer.ToJsonAsync(parentGraph, stream);
         string json = System.Text.Encoding.UTF8.GetString(stream.ToArray());
@@ -157,8 +181,9 @@ public class HierarchicalFsmTests
         Graph roundTripped = await serializer.FromJsonAsync(stream);
         AsyncStateMachine roundTrippedFsm = roundTripped.ToAsyncStateMachine();
 
-        ExecutionLog.Clear();
+        _executionLog.Clear();
         await roundTrippedFsm.ExecuteAsync();
-        Assert.That(ExecutionLog, Is.EquivalentTo(ExpectedLog));
+        // Sequence-equal on purpose: the round-tripped graph must preserve execution order.
+        Assert.That(_executionLog, Is.EqualTo(ExpectedLog));
     }
 }

--- a/NxGraph.Tests/HierarchicalFsmsTests.cs
+++ b/NxGraph.Tests/HierarchicalFsmsTests.cs
@@ -11,7 +11,7 @@ namespace NxGraph.Tests;
 [TestFixture(Category = "NxFSM")]
 public class HierarchicalFsmTests
 {
-    private class HierarchicalDummyState : IAsyncLogic
+    private sealed class HierarchicalDummyState : IAsyncLogic
     {
         public HierarchicalDummyState()
         {
@@ -39,7 +39,7 @@ public class HierarchicalFsmTests
         }
     }
 
-    private class DummyLogicTextCodec(List<string> log) : ILogicCodec<string>
+    private sealed class DummyLogicTextCodec(List<string> log) : ILogicCodec<string>
     {
         public string Serialize(IAsyncLogic asyncLogic) =>
             JsonSerializer.Serialize((HierarchicalDummyState)asyncLogic);

--- a/NxGraph.Tests/NxGraph.Tests.csproj
+++ b/NxGraph.Tests/NxGraph.Tests.csproj
@@ -8,8 +8,6 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
@@ -23,14 +21,29 @@
              measurement window. See the fixture header for the full rationale. -->
         <TieredCompilation>false</TieredCompilation>
         <TieredPgo>false</TieredPgo>
+
+        <!-- This assembly never ships, so source-path determinism buys nothing here — and it
+             would break the public-API baseline tests, which locate their approved.txt files
+             (and the netstandard2.1 build output) via [CallerFilePath]. Under the repo-root
+             props' CI gate, ContinuousIntegrationBuild=true would otherwise map those paths
+             to /_/... . Shipped assemblies keep full determinism. -->
+        <DeterministicSourcePaths>false</DeterministicSourcePaths>
+
+        <!-- Test-idiom analyzer exemptions (analyzers + TreatWarningsAsErrors stay on):
+             CA1707: underscore test names are this suite's naming convention.
+             CA1861: inline assertion arrays (Is.EqualTo(new[] { ... })) are the readable
+             test idiom; the repeated-call allocation concern does not apply to tests.
+             CA2201: fault-model tests deliberately throw ApplicationException as a
+             recognizable injected fault type. -->
+        <NoWarn>$(NoWarn);CA1707;CA1861;CA2201</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+        <!-- Coverage: coverlet.msbuild is the single coverage driver (the `/p:Threshold` gate
+             in NxGraph.Build's `test` target). The VSTest collector (coverlet.collector) was
+             removed deliberately — running both drivers at once is unsupported and hid which
+             one actually gated. See NxGraph.Build/README.md § Coverage. -->
+        <PackageReference Include="coverlet.msbuild" Version="8.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/NxGraph.Tests/NxGraph.Tests.csproj
+++ b/NxGraph.Tests/NxGraph.Tests.csproj
@@ -1,5 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <!-- Standing decision: this suite runs sequentially — no [assembly: Parallelizable].
+         Real-time tests (waits, timeouts, retry backoff) and fixtures exercising shared
+         graphs/machines get noisier and flakier under intra-assembly parallelism; revisit
+         only once every fixture is proven isolation-safe. Fixture state still must not be
+         static (see HierarchicalFsmTests), so that day stays reachable. -->
+
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -11,6 +17,12 @@
         <!-- Coverage instrumentation scope: this project is the behavior spec for the core
              library only; serialization assemblies are covered by NxGraph.Serialization.Tests. -->
         <Include>[NxGraph]*</Include>
+
+        <!-- Allocation-gate determinism (AllocationGateTests): compile straight to final
+             optimized code so no background re-tier / OSR transition can allocate inside a
+             measurement window. See the fixture header for the full rationale. -->
+        <TieredCompilation>false</TieredCompilation>
+        <TieredPgo>false</TieredPgo>
     </PropertyGroup>
 
     <ItemGroup>
@@ -31,6 +43,19 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+        <!-- netstandard2.1 public-API baseline (PublicApiSurfaceTests): MetadataLoadContext
+             walks the netstandard2.1 build of NxGraph against the reference facades of the
+             NETStandard.Library.Ref targeting pack (compile assets excluded — the pack is
+             only a source of facade dlls, located via the assembly metadata below). -->
+        <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.1" />
+        <PackageReference Include="NETStandard.Library.Ref" Version="2.1.0" GeneratePathProperty="true" ExcludeAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+            <_Parameter1>NxGraph.Tests.NetStandardRefDir</_Parameter1>
+            <_Parameter2>$(PkgNETStandard_Library_Ref)\ref\netstandard2.1</_Parameter2>
+        </AssemblyAttribute>
     </ItemGroup>
 
     <ItemGroup>

--- a/NxGraph.Tests/PropertyTests.cs
+++ b/NxGraph.Tests/PropertyTests.cs
@@ -120,7 +120,7 @@ public class PropertyTests
     }
 }
 
-internal class DummyState(string? data = null) : IAsyncLogic
+internal sealed class DummyState(string? data = null) : IAsyncLogic
 {
     public string Data { get; init; } = data ?? string.Empty;
    
@@ -131,7 +131,7 @@ internal class DummyState(string? data = null) : IAsyncLogic
     }
 }
 
-internal class DummyLogicTextCodec : ILogicCodec<string>
+internal sealed class DummyLogicTextCodec : ILogicCodec<string>
 {
 
     public string Serialize(IAsyncLogic asyncLogic) =>

--- a/NxGraph.Tests/PublicApi/NxGraph.netstandard2.1.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.netstandard2.1.approved.txt
@@ -1,0 +1,1157 @@
+static class NxGraph.Authoring.Dsl
+  method NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey] CaseAsync[TKey](NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey], TKey, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey] Case[TKey](NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey], TKey, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey] DefaultAsync[TKey](NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey], System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey] Default[TKey](NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey], System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey] SwitchAsync[TKey](NxGraph.Authoring.StateToken, System.Func`1[System.Threading.Tasks.ValueTask`1[TKey]])
+  method NxGraph.Authoring.Dsl+BranchBuilder SetName(NxGraph.Authoring.Dsl+BranchBuilder, System.String)
+  method NxGraph.Authoring.Dsl+BranchBuilder Then(NxGraph.Authoring.Dsl+IfBuilder, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.Dsl+BranchBuilder Then(NxGraph.Authoring.Dsl+IfBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.Dsl+BranchBuilder ThenAsync(NxGraph.Authoring.Dsl+IfBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+BranchBuilder ThenAsync(NxGraph.Authoring.Dsl+IfBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+BranchBuilder To(NxGraph.Authoring.Dsl+BranchBuilder, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.Dsl+BranchBuilder To(NxGraph.Authoring.Dsl+BranchBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToAll(NxGraph.Authoring.Dsl+BranchBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result][])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToAllAsync(NxGraph.Authoring.Dsl+BranchBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]][])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToAsync(NxGraph.Authoring.Dsl+BranchBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToAsync(NxGraph.Authoring.Dsl+BranchBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToAsync[TIn,TOut](NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToAsync[TIn](NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToAsync[TOut](NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToBehaviors(NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToBehaviorsAsync(NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToBehaviorsAsync[TAgent](NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.Dsl+BranchBuilder ToBehaviors[TAgent](NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.Dsl+BranchBuilder To[TIn,TOut](NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.Dsl+BranchBuilder To[TIn](NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.Dsl+BranchBuilder To[TOut](NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.Dsl+BranchBuilder WithSchema(NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Blackboards.BlackboardSchema)
+  method NxGraph.Authoring.Dsl+BranchEnd Else(NxGraph.Authoring.Dsl+BranchBuilder, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.Dsl+BranchEnd Else(NxGraph.Authoring.Dsl+BranchBuilder, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.Dsl+BranchEnd ElseAsync(NxGraph.Authoring.Dsl+BranchBuilder, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+BranchEnd ElseAsync(NxGraph.Authoring.Dsl+BranchBuilder, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+BranchEnd SetName(NxGraph.Authoring.Dsl+BranchEnd, System.String)
+  method NxGraph.Authoring.Dsl+BranchEnd WithSchema(NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Blackboards.BlackboardSchema)
+  method NxGraph.Authoring.Dsl+IfBuilder If(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Boolean])
+  method NxGraph.Authoring.Dsl+IfBuilder If(NxGraph.Authoring.StateToken, System.Func`1[System.Boolean])
+  method NxGraph.Authoring.Dsl+IfBuilder If(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Boolean])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] CaseAsync[TKey](NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey], TKey, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] CaseAsync[TKey](NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey], TKey, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] Case[TKey](NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey], TKey, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] Case[TKey](NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey], TKey, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] DefaultAsync[TKey](NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey], System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] DefaultAsync[TKey](NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] Default[TKey](NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey], System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] Default[TKey](NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey], System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] Switch[TKey](NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,TKey])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] Switch[TKey](NxGraph.Authoring.StateToken, System.Func`1[TKey])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] Switch[TKey](NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,TKey])
+  method NxGraph.Authoring.StartToken WithSchema(NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardSchema)
+  method NxGraph.Authoring.StateToken OnError(NxGraph.Authoring.StateToken, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken OnErrorAsync(NxGraph.Authoring.StateToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, NxGraph.Fsm.ParallelStepMode, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, NxGraph.Fsm.ParallelStepMode, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken Parallel(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
+  method NxGraph.Authoring.StateToken SetName(NxGraph.Authoring.StateToken, System.String)
+  method NxGraph.Authoring.StateToken StartWithTimeoutAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken StartWithTimeoutAsync(System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StartToken, NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph, System.Boolean)
+  method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StartToken, NxGraph.Graphs.Graph, System.Boolean)
+  method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StateToken, NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph, System.Boolean)
+  method NxGraph.Authoring.StateToken SubGraph(NxGraph.Authoring.StateToken, NxGraph.Graphs.Graph, System.Boolean)
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.Dsl+BranchEnd, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.Dsl+BranchEnd, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StartToken, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken, System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken ToAll(NxGraph.Authoring.Dsl+BranchEnd, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result][])
+  method NxGraph.Authoring.StateToken ToAll(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result][])
+  method NxGraph.Authoring.StateToken ToAll(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result][])
+  method NxGraph.Authoring.StateToken ToAllAsync(NxGraph.Authoring.Dsl+BranchEnd, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]][])
+  method NxGraph.Authoring.StateToken ToAllAsync(NxGraph.Authoring.StartToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]][])
+  method NxGraph.Authoring.StateToken ToAllAsync(NxGraph.Authoring.StateToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]][])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.Dsl+BranchEnd, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.Dsl+BranchEnd, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StartToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StateToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Authoring.StateToken, System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TAgent](NxGraph.Authoring.StateToken, System.Func`4[TAgent,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn,TOut](NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn,TOut](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn,TOut](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn](NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TOut](NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToAsync[TOut](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToAsync[TOut](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method NxGraph.Authoring.StateToken ToBehaviors(NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviors(NxGraph.Authoring.StartToken, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviors(NxGraph.Authoring.StateToken, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync(NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync(NxGraph.Authoring.StartToken, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync(NxGraph.Authoring.StateToken, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync[TAgent](NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync[TAgent](NxGraph.Authoring.StartToken, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviorsAsync[TAgent](NxGraph.Authoring.StateToken, NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviors[TAgent](NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviors[TAgent](NxGraph.Authoring.StartToken, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToBehaviors[TAgent](NxGraph.Authoring.StateToken, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StartToken, System.TimeSpan, NxGraph.Graphs.ILogic, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StartToken, System.TimeSpan, System.Func`1[NxGraph.Result], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StateToken, System.TimeSpan, NxGraph.Graphs.ILogic, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeout(NxGraph.Authoring.StateToken, System.TimeSpan, System.Func`1[NxGraph.Result], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, System.TimeSpan, NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StartToken, System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, System.TimeSpan, NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken ToWithTimeoutAsync(NxGraph.Authoring.StateToken, System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Authoring.StateToken To[TAgent](NxGraph.Authoring.StateToken, System.Func`3[TAgent,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken To[TIn,TOut](NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken To[TIn,TOut](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken To[TIn,TOut](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken To[TIn](NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken To[TIn](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken To[TIn](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken To[TOut](NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken To[TOut](NxGraph.Authoring.StartToken, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken To[TOut](NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Authoring.StateToken WaitFor(NxGraph.Authoring.StartToken, System.TimeSpan)
+  method NxGraph.Authoring.StateToken WaitFor(NxGraph.Authoring.StateToken, System.TimeSpan)
+  method NxGraph.Authoring.StateToken WaitForAsync(NxGraph.Authoring.StartToken, System.TimeSpan)
+  method NxGraph.Authoring.StateToken WaitForAsync(NxGraph.Authoring.StateToken, System.TimeSpan)
+  method NxGraph.Authoring.StateToken WithSchema(NxGraph.Authoring.StateToken, NxGraph.Blackboards.BlackboardSchema)
+  method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Authoring.StartToken, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Authoring.StateToken, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] ToAsyncStateMachine[TAgent](NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] ToAsyncStateMachine[TAgent](NxGraph.Authoring.StartToken, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] ToAsyncStateMachine[TAgent](NxGraph.Authoring.StateToken, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] WithAgent[TAgent](NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent], TAgent)
+  method NxGraph.Fsm.StateMachine ToStateMachine(NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine ToStateMachine(NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine ToStateMachine(NxGraph.Authoring.StartToken, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine ToStateMachine(NxGraph.Authoring.StateToken, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] ToStateMachine[TAgent](NxGraph.Authoring.Dsl+BranchBuilder, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] ToStateMachine[TAgent](NxGraph.Authoring.Dsl+BranchEnd, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] ToStateMachine[TAgent](NxGraph.Authoring.StartToken, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] ToStateMachine[TAgent](NxGraph.Authoring.StateToken, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] WithAgent[TAgent](NxGraph.Fsm.StateMachine`1[TAgent], TAgent)
+  method NxGraph.Graphs.Graph Build(NxGraph.Authoring.Dsl+BranchBuilder)
+  method NxGraph.Graphs.Graph SetName(NxGraph.Graphs.Graph, System.String)
+  method System.TimeSpan Days(System.Double)
+  method System.TimeSpan Days(System.Int32)
+  method System.TimeSpan Hours(System.Double)
+  method System.TimeSpan Hours(System.Int32)
+  method System.TimeSpan Milliseconds(System.Double)
+  method System.TimeSpan Milliseconds(System.Int32)
+  method System.TimeSpan Minutes(System.Double)
+  method System.TimeSpan Minutes(System.Int32)
+  method System.TimeSpan Seconds(System.Double)
+  method System.TimeSpan Seconds(System.Int32)
+  method T WithBlackboard[T](T, NxGraph.Blackboards.Blackboard)
+struct NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1
+  method NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey] Case(TKey, NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey] CaseAsync(TKey, NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey] Default(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey] DefaultAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken End()
+struct NxGraph.Authoring.Dsl+BranchBuilder
+  method NxGraph.Authoring.Dsl+BranchBuilder To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.Dsl+BranchBuilder ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.Dsl+BranchBuilder WaitFor(System.TimeSpan)
+  method NxGraph.Authoring.Dsl+BranchBuilder WaitForAsync(System.TimeSpan)
+  method NxGraph.Authoring.Dsl+BranchEnd Else(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.Dsl+BranchEnd ElseAsync(NxGraph.Graphs.IAsyncLogic)
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+  property NxGraph.Graphs.NodeId Tip { get; }
+struct NxGraph.Authoring.Dsl+BranchEnd
+  method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken WaitFor(System.TimeSpan)
+  method NxGraph.Authoring.StateToken WaitForAsync(System.TimeSpan)
+  method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[T] ToAsyncStateMachine[T](NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Graphs.Graph Build(System.Boolean)
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+  property NxGraph.Graphs.NodeId Tip { get; }
+struct NxGraph.Authoring.Dsl+IfBuilder
+  method NxGraph.Authoring.Dsl+BranchBuilder Then(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.Dsl+BranchBuilder ThenAsync(NxGraph.Graphs.IAsyncLogic)
+struct NxGraph.Authoring.Dsl+SwitchBuilder`1
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] Case(TKey, NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] CaseAsync(TKey, NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] Default(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] DefaultAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken End()
+sealed class NxGraph.Authoring.EventBranch
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken)
+  method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken To(System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken ToAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync[TIn](NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken To[TIn](NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+struct NxGraph.Authoring.EventsToken
+  method NxGraph.Authoring.EventsToken On[TEvent](NxGraph.Blackboards.BlackboardKey`1[TEvent], System.Func`2[NxGraph.Authoring.EventBranch,NxGraph.Authoring.StateToken])
+  method NxGraph.Authoring.EventsToken Otherwise(System.Func`2[NxGraph.Authoring.EventBranch,NxGraph.Authoring.StateToken])
+  method NxGraph.Authoring.EventsToken WithSchema(NxGraph.Blackboards.BlackboardSchema)
+  method NxGraph.Graphs.Graph Build(System.Boolean)
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+sealed class NxGraph.Authoring.ForkBranch
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken)
+  method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken To(System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken To(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken ToAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken ToAsync(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+struct NxGraph.Authoring.ForkToken
+  method NxGraph.Authoring.ForkToken SetName(System.String)
+  method NxGraph.Graphs.Graph Build()
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+struct NxGraph.Authoring.GotoToken
+  method NxGraph.Graphs.Graph Build()
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+sealed class NxGraph.Authoring.GraphBuilder
+  ctor System.Void .ctor()
+  method NxGraph.Authoring.EventsToken StartWithEvents()
+  method NxGraph.Authoring.GraphBuilder AddFailureTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method NxGraph.Authoring.GraphBuilder AddGoto(NxGraph.Graphs.NodeId, System.String)
+  method NxGraph.Authoring.GraphBuilder AddTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method NxGraph.Authoring.GraphBuilder SetEnterAction(NxGraph.Graphs.NodeId, System.Action)
+  method NxGraph.Authoring.GraphBuilder SetExitAction(NxGraph.Graphs.NodeId, System.Action)
+  method NxGraph.Authoring.GraphBuilder SetOutcome(NxGraph.Graphs.NodeId, System.Int32, System.String)
+  method NxGraph.Authoring.GraphBuilder SetRetryPolicy(NxGraph.Graphs.NodeId, NxGraph.Fsm.RetryPolicy)
+  method NxGraph.Authoring.GraphBuilder SetUid(NxGraph.Graphs.NodeId, System.Guid)
+  method NxGraph.Authoring.GraphBuilder WithSchema(NxGraph.Blackboards.BlackboardSchema)
+  method NxGraph.Authoring.StartToken Start()
+  method NxGraph.Authoring.StateToken StartWith(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken StartWith(System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken StartWith(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Authoring.StateToken StartWithAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken StartWithAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken StartWithAsync(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Authoring.StateToken TokenFor(NxGraph.Graphs.NodeId)
+  method NxGraph.Diagnostics.Validations.GraphValidationResult Validate(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Validations.GraphValidationOptions)
+  method NxGraph.Graphs.Graph Build(System.Boolean)
+  method NxGraph.Graphs.NodeId AddNode(NxGraph.Graphs.IAsyncLogic, System.Boolean)
+  method NxGraph.Graphs.NodeId AddNode(NxGraph.Graphs.ILogic, System.Boolean)
+  method System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId] GetAllNodeIds()
+  method System.Void SetName(NxGraph.Graphs.Graph, System.String)
+  method System.Void SetName(NxGraph.Graphs.NodeId, System.String)
+static class NxGraph.Authoring.GraphBuilderExtensions
+  method NxGraph.Fsm.Async.AsyncStateMachine ToAsyncStateMachine(NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] Add[TAgent](NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent], TAgent)
+  method NxGraph.Fsm.Async.AsyncStateMachine`1[TAgent] ToAsyncStateMachine[TAgent](NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method NxGraph.Fsm.StateMachine ToStateMachine(NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
+  method NxGraph.Fsm.StateMachine`1[TAgent] Add[TAgent](NxGraph.Fsm.StateMachine`1[TAgent], TAgent)
+  method NxGraph.Fsm.StateMachine`1[TAgent] ToStateMachine[TAgent](NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
+sealed class NxGraph.Authoring.GraphValidationException : System.Exception, System.Runtime.Serialization.ISerializable
+  ctor System.Void .ctor(NxGraph.Diagnostics.Validations.GraphValidationResult)
+  property NxGraph.Diagnostics.Validations.GraphValidationResult Result { get; }
+struct NxGraph.Authoring.StartToken
+  method NxGraph.Authoring.Dsl+AsyncSwitchBuilder`1[TKey] SwitchAsync[TKey](System.Func`1[System.Threading.Tasks.ValueTask`1[TKey]])
+  method NxGraph.Authoring.Dsl+IfBuilder If(System.Func`1[System.Boolean])
+  method NxGraph.Authoring.Dsl+SwitchBuilder`1[TKey] Switch[TKey](System.Func`1[TKey])
+  method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken To(System.Func`1[NxGraph.Result])
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken ToAsync(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method NxGraph.Graphs.Graph Build()
+struct NxGraph.Authoring.StateToken
+  method NxGraph.Authoring.GotoToken Goto(System.String)
+  method NxGraph.Authoring.StateToken OnEnter(System.Action)
+  method NxGraph.Authoring.StateToken OnError(NxGraph.Authoring.StateToken)
+  method NxGraph.Authoring.StateToken OnError(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken OnErrorAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken OnExit(System.Action)
+  method NxGraph.Authoring.StateToken Retry(System.Byte, System.TimeSpan, NxGraph.Fsm.BackoffKind)
+  method NxGraph.Authoring.StateToken To(NxGraph.Authoring.StateToken)
+  method NxGraph.Authoring.StateToken To(NxGraph.Graphs.ILogic)
+  method NxGraph.Authoring.StateToken ToAsync(NxGraph.Graphs.IAsyncLogic)
+  method NxGraph.Authoring.StateToken WithOutcome(System.Int32, System.String)
+  method NxGraph.Authoring.StateToken WithUid(System.Guid)
+  method NxGraph.Graphs.Graph Build()
+  property NxGraph.Authoring.GraphBuilder Builder { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+static class NxGraph.Authoring.TokenDsl
+  method NxGraph.Authoring.ForkToken ForkTo(NxGraph.Authoring.StartToken, System.Func`2[NxGraph.Authoring.ForkBranch,NxGraph.Authoring.StateToken][])
+  method NxGraph.Authoring.ForkToken ForkTo(NxGraph.Authoring.StateToken, System.Func`2[NxGraph.Authoring.ForkBranch,NxGraph.Authoring.StateToken][])
+  method NxGraph.Tokens.AsyncTokenMachine ToAsyncTokenMachine(NxGraph.Graphs.Graph, NxGraph.Tokens.IAsyncTokenMachineObserver, System.Int32)
+  method NxGraph.Tokens.AsyncTokenMachine`1[TAgent] ToAsyncTokenMachine[TAgent](NxGraph.Graphs.Graph, NxGraph.Tokens.IAsyncTokenMachineObserver, System.Int32)
+  method NxGraph.Tokens.TokenMachine ToTokenMachine(NxGraph.Graphs.Graph, NxGraph.Tokens.ITokenMachineObserver, System.Int32)
+  method NxGraph.Tokens.TokenMachine`1[TAgent] ToTokenMachine[TAgent](NxGraph.Graphs.Graph, NxGraph.Tokens.ITokenMachineObserver, System.Int32)
+sealed class NxGraph.Behaviors.AsyncBehaviorState : NxGraph.Fsm.Async.AsyncState, NxGraph.Behaviors.IBehaviorComposite, NxGraph.Behaviors.IBehaviorReportSink, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(NxGraph.Behaviors.IAsyncBehavior[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IAsyncBehavior] Behaviors { get; }
+sealed class NxGraph.Behaviors.AsyncBehaviorState`1 : AsyncState`1, IAgentSettable`1, NxGraph.Behaviors.IBehaviorComposite, NxGraph.Behaviors.IBehaviorReportSink, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(NxGraph.Behaviors.IAsyncBehavior[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IAsyncBehavior] Behaviors { get; }
+sealed class NxGraph.Behaviors.AsyncRepeat : NxGraph.Behaviors.IAsyncBehavior
+  ctor System.Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Behaviors.IAsyncBehavior[])
+  ctor System.Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Blackboards.BlackboardKey`1[System.Int32], NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Behaviors.AsyncRepeat Unbound(NxGraph.Behaviors.BlackboardValue`1[System.Int32], System.String, NxGraph.Behaviors.IAsyncBehavior[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[System.Int32] Count { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IAsyncBehavior] Body { get; }
+  property System.String IndexKeyName { get; }
+sealed class NxGraph.Behaviors.AsyncRepeat`1 : IAsyncBehavior`1, NxGraph.Behaviors.IAsyncAgentBehavior, NxGraph.Behaviors.IAsyncBehavior
+  ctor System.Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Behaviors.IAsyncBehavior[])
+  ctor System.Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Blackboards.BlackboardKey`1[System.Int32], NxGraph.Behaviors.IAsyncBehavior[])
+  method NxGraph.Behaviors.AsyncRepeat`1[TAgent] Unbound(NxGraph.Behaviors.BlackboardValue`1[System.Int32], System.String, NxGraph.Behaviors.IAsyncBehavior[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(TAgent, NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[System.Int32] Count { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IAsyncBehavior] Body { get; }
+  property System.String IndexKeyName { get; }
+struct NxGraph.Behaviors.BehaviorContext
+  method System.Void Report(System.String)
+  method T Resolve[T](NxGraph.Behaviors.BlackboardValue`1[T]&)
+  property NxGraph.Blackboards.BlackboardContext Bb { get; }
+  property System.Boolean HasReporter { get; }
+sealed class NxGraph.Behaviors.BehaviorState : NxGraph.Fsm.State, NxGraph.Behaviors.IBehaviorComposite, NxGraph.Behaviors.IBehaviorReportSink, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Result OnRun()
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IBehavior] Behaviors { get; }
+sealed class NxGraph.Behaviors.BehaviorState`1 : State`1, IAgentSettable`1, NxGraph.Behaviors.IBehaviorComposite, NxGraph.Behaviors.IBehaviorReportSink, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Result OnRun()
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IBehavior] Behaviors { get; }
+struct NxGraph.Behaviors.BlackboardValue`1
+  method NxGraph.Behaviors.BlackboardValue`1[T] Bound(System.String)
+  method System.String ToString()
+  operator NxGraph.Behaviors.BlackboardValue`1[T] op_Implicit(NxGraph.Blackboards.BlackboardKey`1[T])
+  operator NxGraph.Behaviors.BlackboardValue`1[T] op_Implicit(T)
+  property System.Boolean IsBound { get; }
+  property System.String KeyName { get; }
+  property T Literal { get; }
+interface NxGraph.Behaviors.IAgentBehavior : NxGraph.Behaviors.IBehavior
+interface NxGraph.Behaviors.IAsyncAgentBehavior : NxGraph.Behaviors.IAsyncBehavior
+interface NxGraph.Behaviors.IAsyncBehavior
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+interface NxGraph.Behaviors.IAsyncBehavior`1 : NxGraph.Behaviors.IAsyncAgentBehavior, NxGraph.Behaviors.IAsyncBehavior
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(TAgent, NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+interface NxGraph.Behaviors.IBehavior
+  method NxGraph.Result Execute(NxGraph.Behaviors.BehaviorContext&)
+interface NxGraph.Behaviors.IBehaviorComposite
+  property System.Boolean IsSync { get; }
+  property System.Collections.Generic.IReadOnlyList`1[System.Object] Entries { get; }
+  property System.Type AgentType { get; }
+interface NxGraph.Behaviors.IBehavior`1 : NxGraph.Behaviors.IAgentBehavior, NxGraph.Behaviors.IBehavior
+  method NxGraph.Result Execute(TAgent, NxGraph.Behaviors.BehaviorContext&)
+sealed class NxGraph.Behaviors.Log : NxGraph.Behaviors.IAsyncBehavior, NxGraph.Behaviors.IBehavior
+  ctor System.Void .ctor(NxGraph.Behaviors.BlackboardValue`1[NxGraph.Behaviors.LogSeverity], NxGraph.Behaviors.BlackboardValue`1[System.String])
+  ctor System.Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.String])
+  method NxGraph.Result Execute(NxGraph.Behaviors.BehaviorContext&)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[NxGraph.Behaviors.LogSeverity] Severity { get; }
+  property NxGraph.Behaviors.BlackboardValue`1[System.String] Message { get; }
+enum NxGraph.Behaviors.LogSeverity : System.IComparable, System.IConvertible, System.IFormattable
+  Error = 3
+  Info = 1
+  Trace = 0
+  Warning = 2
+sealed class NxGraph.Behaviors.Repeat : NxGraph.Behaviors.IAsyncBehavior, NxGraph.Behaviors.IBehavior
+  ctor System.Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Behaviors.IBehavior[])
+  ctor System.Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Blackboards.BlackboardKey`1[System.Int32], NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Behaviors.Repeat Unbound(NxGraph.Behaviors.BlackboardValue`1[System.Int32], System.String, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Result Execute(NxGraph.Behaviors.BehaviorContext&)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[System.Int32] Count { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IBehavior] Body { get; }
+  property System.String IndexKeyName { get; }
+sealed class NxGraph.Behaviors.Repeat`1 : IAsyncBehavior`1, IBehavior`1, NxGraph.Behaviors.IAgentBehavior, NxGraph.Behaviors.IAsyncAgentBehavior, NxGraph.Behaviors.IAsyncBehavior, NxGraph.Behaviors.IBehavior
+  ctor System.Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Behaviors.IBehavior[])
+  ctor System.Void .ctor(NxGraph.Behaviors.BlackboardValue`1[System.Int32], NxGraph.Blackboards.BlackboardKey`1[System.Int32], NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Behaviors.Repeat`1[TAgent] Unbound(NxGraph.Behaviors.BlackboardValue`1[System.Int32], System.String, NxGraph.Behaviors.IBehavior[])
+  method NxGraph.Result Execute(TAgent, NxGraph.Behaviors.BehaviorContext&)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(TAgent, NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[System.Int32] Count { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Behaviors.IBehavior] Body { get; }
+  property System.String IndexKeyName { get; }
+sealed class NxGraph.Behaviors.SetValue`1 : NxGraph.Behaviors.IAsyncBehavior, NxGraph.Behaviors.IBehavior
+  ctor System.Void .ctor(NxGraph.Blackboards.BlackboardKey`1[T], NxGraph.Behaviors.BlackboardValue`1[T])
+  method NxGraph.Behaviors.SetValue`1[T] Unbound(System.String, NxGraph.Behaviors.BlackboardValue`1[T])
+  method NxGraph.Result Execute(NxGraph.Behaviors.BehaviorContext&)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(NxGraph.Behaviors.BehaviorContext, System.Threading.CancellationToken)
+  property NxGraph.Behaviors.BlackboardValue`1[T] Value { get; }
+  property NxGraph.Blackboards.BlackboardKey`1[T] Key { get; }
+  property System.String KeyName { get; }
+sealed class NxGraph.Blackboards.Blackboard
+  ctor System.Void .ctor(NxGraph.Blackboards.BlackboardSchema)
+  method System.Boolean TryGet[T](NxGraph.Blackboards.BlackboardKey`1[T], T&)
+  method System.Void ResetToDefaults()
+  method System.Void Set[T](NxGraph.Blackboards.BlackboardKey`1[T], T)
+  method T Get[T](NxGraph.Blackboards.BlackboardKey`1[T])
+  method T& GetRef[T](NxGraph.Blackboards.BlackboardKey`1[T])
+  property NxGraph.Blackboards.BlackboardSchema Schema { get; }
+struct NxGraph.Blackboards.BlackboardContext
+  ctor System.Void .ctor(NxGraph.Blackboards.Blackboard, NxGraph.Blackboards.Blackboard, NxGraph.Blackboards.Blackboard)
+  method NxGraph.Blackboards.Blackboard Board(NxGraph.Blackboards.BlackboardScope)
+  method NxGraph.Blackboards.BlackboardContext With(NxGraph.Blackboards.Blackboard)
+  method NxGraph.Blackboards.BlackboardContext WithoutNode()
+  method System.Boolean HasBoard(NxGraph.Blackboards.BlackboardScope)
+  method System.Boolean TryGet[T](NxGraph.Blackboards.BlackboardKey`1[T], T&)
+  method System.Void Set[T](NxGraph.Blackboards.BlackboardKey`1[T], T)
+  method T Get[T](NxGraph.Blackboards.BlackboardKey`1[T])
+  method T& GetRef[T](NxGraph.Blackboards.BlackboardKey`1[T])
+  property NxGraph.Blackboards.Blackboard Global { get; }
+  property NxGraph.Blackboards.Blackboard Graph { get; }
+  property NxGraph.Blackboards.Blackboard Node { get; }
+  property System.Boolean IsEmpty { get; }
+abstract class NxGraph.Blackboards.BlackboardKeyDescriptor
+  method System.Object GetValue(NxGraph.Blackboards.Blackboard)
+  method System.Void ResetValue(NxGraph.Blackboards.Blackboard)
+  method System.Void SetValue(NxGraph.Blackboards.Blackboard, System.Object)
+  property System.Int32 Ordinal { get; }
+  property System.String Name { get; }
+  property System.Type ValueType { get; }
+struct NxGraph.Blackboards.BlackboardKey`1 : IEquatable`1
+  method System.Boolean Equals(NxGraph.Blackboards.BlackboardKey`1[T])
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  operator System.Boolean op_Equality(NxGraph.Blackboards.BlackboardKey`1[T], NxGraph.Blackboards.BlackboardKey`1[T])
+  operator System.Boolean op_Inequality(NxGraph.Blackboards.BlackboardKey`1[T], NxGraph.Blackboards.BlackboardKey`1[T])
+  property System.Boolean IsValid { get; }
+  property System.String Name { get; }
+sealed class NxGraph.Blackboards.BlackboardSchema
+  ctor System.Void .ctor(System.String, NxGraph.Blackboards.BlackboardScope)
+  method NxGraph.Blackboards.BlackboardKey`1[T] Register[T](System.String)
+  method NxGraph.Blackboards.BlackboardKey`1[T] Register[T](System.String, T)
+  method System.Boolean TryGetKey(System.String, NxGraph.Blackboards.BlackboardKeyDescriptor&)
+  method System.Boolean TryResolve[T](System.String, NxGraph.Blackboards.BlackboardKey`1[T]&)
+  property NxGraph.Blackboards.BlackboardScope Scope { get; }
+  property System.Boolean IsFrozen { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Blackboards.BlackboardKeyDescriptor] Keys { get; }
+  property System.Int32 KeyCount { get; }
+  property System.String Name { get; }
+enum NxGraph.Blackboards.BlackboardScope : System.IComparable, System.IConvertible, System.IFormattable
+  Global = 0
+  Graph = 1
+  Node = 2
+interface NxGraph.Blackboards.IBlackboardBindable
+  method System.Void SetBlackboard(NxGraph.Blackboards.Blackboard)
+interface NxGraph.Blackboards.IBlackboardSettable
+  method System.Void SetBlackboards(NxGraph.Blackboards.BlackboardContext&)
+class NxGraph.Diagnostics.Export.ExportOptions
+  ctor System.Void .ctor()
+enum NxGraph.Diagnostics.Export.FlowDirection : System.IComparable, System.IConvertible, System.IFormattable
+  BottomToTop = 3
+  LeftToRight = 1
+  RightToLeft = 2
+  TopToBottom = 0
+static class NxGraph.Diagnostics.Export.GraphExportExtensions
+  method System.String ExportWith(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Export.IGraphExporter, NxGraph.Diagnostics.Export.ExportOptions)
+  method System.String ToMermaid(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Export.MermaidExportOptions)
+interface NxGraph.Diagnostics.Export.IGraphExporter
+  method System.String Export(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Export.ExportOptions)
+  property System.String ContentType { get; }
+  property System.String FileExtension { get; }
+  property System.String Format { get; }
+sealed class NxGraph.Diagnostics.Export.MermaidExportOptions : NxGraph.Diagnostics.Export.ExportOptions
+  ctor System.Void .ctor()
+  property NxGraph.Diagnostics.Export.FlowDirection Direction { get; set; }
+  property System.Boolean AddTerminalNode { get; set; }
+  property System.Boolean ShowNodeIndices { get; set; }
+  property System.Boolean UseNodeNames { get; set; }
+  property System.String TerminalLabel { get; set; }
+  property System.String Title { get; set; }
+sealed class NxGraph.Diagnostics.Export.MermaidGraphExporter : NxGraph.Diagnostics.Export.IGraphExporter
+  ctor System.Void .ctor()
+  method System.String Export(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Export.ExportOptions)
+  property System.String ContentType { get; }
+  property System.String FileExtension { get; }
+  property System.String Format { get; }
+enum NxGraph.Diagnostics.Replay.EventType : System.IComparable, System.IConvertible, System.IFormattable
+  Log = 9
+  StateEntered = 0
+  StateExited = 1
+  StateFailed = 3
+  StateMachineCancelled = 7
+  StateMachineCompleted = 6
+  StateMachineReset = 4
+  StateMachineStarted = 5
+  StatusChanged = 8
+  Transition = 2
+interface NxGraph.Diagnostics.Replay.ILogReporter
+  property System.Func`3[System.String,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask] LogReport { get; set; }
+struct NxGraph.Diagnostics.Replay.ReplayEvent
+  ctor System.Void .ctor(NxGraph.Diagnostics.Replay.EventType, NxGraph.Graphs.NodeId, System.Nullable`1[NxGraph.Graphs.NodeId], System.String, System.Int64)
+  property NxGraph.Diagnostics.Replay.EventType Type { get; }
+  property NxGraph.Graphs.NodeId SourceId { get; }
+  property System.Int64 Timestamp { get; }
+  property System.Nullable`1[NxGraph.Graphs.NodeId] TargetId { get; }
+  property System.String Message { get; }
+sealed class NxGraph.Diagnostics.Replay.ReplayRecorder : NxGraph.Fsm.IAsyncStateMachineObserver, NxGraph.Fsm.IStateMachineObserver
+  ctor System.Void .ctor(System.Int32)
+  method System.ReadOnlyMemory`1[NxGraph.Diagnostics.Replay.ReplayEvent] GetEvents()
+  method System.Threading.Tasks.ValueTask OnLogReport(NxGraph.Graphs.NodeId, System.String, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateEntered(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineCancelled(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineReset(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineStarted(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask StateMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus, System.Threading.CancellationToken)
+  method System.Void Clear()
+  property NxGraph.Diagnostics.Replay.ReplayEvent Item[System.Int32] { get; }
+  property System.Int32 Capacity { get; }
+  property System.Int32 Count { get; }
+  property System.Int64 DroppedCount { get; }
+class NxGraph.Diagnostics.Replay.StateMachineReplay
+  ctor System.Void .ctor(System.ReadOnlySpan`1[NxGraph.Diagnostics.Replay.ReplayEvent])
+  method NxGraph.Diagnostics.Replay.ReplayEvent[] Deserialize(System.Byte[])
+  method System.Byte[] Serialize()
+  method System.Void ReplayAll(System.Action`1[NxGraph.Diagnostics.Replay.ReplayEvent])
+  property System.Collections.Generic.IEnumerable`1[NxGraph.Diagnostics.Replay.ReplayEvent] Events { get; }
+sealed class NxGraph.Diagnostics.Validations.GraphDiagnostic
+  ctor System.Void .ctor(NxGraph.Diagnostics.Validations.Severity, System.String, NxGraph.Graphs.NodeId)
+  method System.String ToString()
+  property NxGraph.Diagnostics.Validations.Severity Severity { get; }
+  property NxGraph.Graphs.NodeId Node { get; }
+  property System.String Message { get; }
+static class NxGraph.Diagnostics.Validations.GraphValidationExtensions
+  method NxGraph.Diagnostics.Validations.GraphValidationResult ValidateAndThrowIfErrorsDebug(NxGraph.Graphs.Graph, System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId])
+sealed class NxGraph.Diagnostics.Validations.GraphValidationOptions
+  ctor System.Void .ctor(System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId])
+  property System.Boolean StrictAsyncCompatible { get; set; }
+  property System.Boolean StrictNoTerminalPath { get; set; }
+  property System.Boolean StrictSyncOnly { get; set; }
+  property System.Boolean WarnOnSelfLoop { get; set; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId] AllNodes { get; set; }
+sealed class NxGraph.Diagnostics.Validations.GraphValidationResult
+  ctor System.Void .ctor()
+  method System.String ToString()
+  property System.Boolean HasErrors { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Diagnostics.Validations.GraphDiagnostic] Diagnostics { get; }
+static class NxGraph.Diagnostics.Validations.GraphValidator
+  method NxGraph.Diagnostics.Validations.GraphValidationResult Validate(NxGraph.Graphs.Graph, NxGraph.Diagnostics.Validations.GraphValidationOptions)
+enum NxGraph.Diagnostics.Validations.Severity : System.IComparable, System.IConvertible, System.IFormattable
+  Error = 2
+  Info = 0
+  Warning = 1
+sealed class NxGraph.Fsm.AllState : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result][])
+  method NxGraph.Result OnRun()
+sealed class NxGraph.Fsm.Async.AsyncAllState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]][])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.Async.AsyncChoiceState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.IAsyncDirector, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(System.Func`1[System.Threading.Tasks.ValueTask`1[System.Boolean]], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  ctor System.Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Threading.Tasks.ValueTask`1[System.Boolean]], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+class NxGraph.Fsm.Async.AsyncCompositeState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.IAsyncLogic)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  property NxGraph.Graphs.IAsyncLogic Child { get; }
+sealed class NxGraph.Fsm.Async.AsyncDynamicParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.Async.AsyncStateMachine] Regions { get; }
+  property System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask] Selector { get; }
+sealed class NxGraph.Fsm.Async.AsyncHistoryState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  property NxGraph.Fsm.Async.AsyncStateMachine Child { get; }
+sealed class NxGraph.Fsm.Async.AsyncParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph[])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.Async.AsyncStateMachine] Regions { get; }
+sealed class NxGraph.Fsm.Async.AsyncPortConsumerRelayState`1 : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.Async.AsyncPortPipeRelayState`2 : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`4[TIn,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.Async.AsyncPortProducerRelayState`1 : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[TOut]])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.Async.AsyncRelayState : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  ctor System.Void .ctor(System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.Async.AsyncRelayState`1 : AsyncState`1, IAgentSettable`1, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(System.Func`3[TAgent,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[TAgent,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`3[TAgent,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  ctor System.Void .ctor(System.Func`4[TAgent,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`4[TAgent,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], System.Func`4[TAgent,NxGraph.Blackboards.BlackboardContext,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]])
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+abstract class NxGraph.Fsm.Async.AsyncState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor()
+  method System.Threading.Tasks.ValueTask LogAsync(System.String, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  property NxGraph.Blackboards.BlackboardContext Bb { get; }
+  property System.Func`3[System.String,System.Threading.CancellationToken,System.Threading.Tasks.ValueTask] LogReport { get; set; }
+class NxGraph.Fsm.Async.AsyncStateMachine : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
+  field readonly NxGraph.Graphs.Graph Graph
+  method NxGraph.Fsm.StateMachineDeepSnapshot SuspendDeep()
+  method NxGraph.Fsm.StateMachineSnapshot Suspend()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync[TEvent](TEvent, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] Reset(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] StepAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] StepAsync[TEvent](TEvent, System.Threading.CancellationToken)
+  method System.Void Resume(NxGraph.Fsm.StateMachineSnapshot)
+  method System.Void ResumeDeep(NxGraph.Fsm.StateMachineDeepSnapshot)
+  method System.Void SetAutoReset(System.Boolean)
+  method System.Void SetBlackboard(NxGraph.Blackboards.Blackboard)
+  method System.Void SetRestartPolicy(NxGraph.Fsm.RestartPolicy)
+  property NxGraph.Fsm.ExecutionStatus Status { get; }
+  property System.Int32 LastOutcome { get; }
+  property System.String LastOutcomeName { get; }
+class NxGraph.Fsm.Async.AsyncStateMachine`1 : NxGraph.Fsm.Async.AsyncStateMachine, IAgentSettable`1, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IAsyncStateMachineObserver)
+  method System.Void SetAgent(TAgent)
+abstract class NxGraph.Fsm.Async.AsyncState`1 : NxGraph.Fsm.Async.AsyncState, IAgentSettable`1, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor()
+  field TAgent Agent
+  method System.Void SetAgent(TAgent)
+sealed class NxGraph.Fsm.Async.AsyncSwitchState`1 : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.IAsyncDirector, NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(System.Func`1[System.Threading.Tasks.ValueTask`1[TKey]], System.Collections.Generic.IReadOnlyDictionary`2[TKey,NxGraph.Graphs.NodeId], NxGraph.Graphs.NodeId)
+  ctor System.Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Threading.Tasks.ValueTask`1[TKey]], System.Collections.Generic.IReadOnlyDictionary`2[TKey,NxGraph.Graphs.NodeId], NxGraph.Graphs.NodeId)
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+class NxGraph.Fsm.Async.AsyncTimeoutState : NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+static class NxGraph.Fsm.Async.AsyncWait
+  method NxGraph.Fsm.Async.AsyncState For(System.TimeSpan)
+static class NxGraph.Fsm.Async.Timeout
+  method NxGraph.Graphs.IAsyncLogic For(System.TimeSpan, System.Func`2[System.Threading.CancellationToken,System.Threading.Tasks.ValueTask`1[NxGraph.Result]], NxGraph.Fsm.TimeoutBehavior)
+  method NxGraph.Graphs.IAsyncLogic Wrap(NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+enum NxGraph.Fsm.BackoffKind : System.IComparable, System.IConvertible, System.IFormattable
+  Exponential = 2
+  Fixed = 0
+  Linear = 1
+sealed class NxGraph.Fsm.ChoiceState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.IDirector, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(System.Func`1[System.Boolean], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  ctor System.Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,System.Boolean], NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method NxGraph.Graphs.NodeId SelectNext()
+  method NxGraph.Result Execute()
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+sealed class NxGraph.Fsm.CompositeSnapshot : System.IEquatable`1[[NxGraph.Fsm.CompositeSnapshot]]
+  ctor System.Void .ctor(System.Int32, System.Boolean, System.Boolean[], NxGraph.Fsm.StateMachineDeepSnapshot[])
+  method NxGraph.Fsm.CompositeSnapshot <Clone>$()
+  method System.Boolean Equals(NxGraph.Fsm.CompositeSnapshot)
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  method System.Void Deconstruct(System.Int32&, System.Boolean&, System.Boolean[]&, NxGraph.Fsm.StateMachineDeepSnapshot[]&)
+  operator System.Boolean op_Equality(NxGraph.Fsm.CompositeSnapshot, NxGraph.Fsm.CompositeSnapshot)
+  operator System.Boolean op_Inequality(NxGraph.Fsm.CompositeSnapshot, NxGraph.Fsm.CompositeSnapshot)
+  property NxGraph.Fsm.StateMachineDeepSnapshot[] Children { get; set; }
+  property System.Boolean InFlight { get; set; }
+  property System.Boolean[] Done { get; set; }
+  property System.Int32 NodeIndex { get; set; }
+sealed class NxGraph.Fsm.DynamicParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Fsm.ParallelStepMode, System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask], NxGraph.Graphs.Graph[])
+  method NxGraph.Result Execute()
+  property NxGraph.Fsm.ParallelStepMode Mode { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.StateMachine] Regions { get; }
+  property System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Fsm.RegionMask] Selector { get; }
+sealed class NxGraph.Fsm.EventEntryState : NxGraph.Fsm.IAsyncDirector, NxGraph.Fsm.IDirector, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.EventRegistration])
+  ctor System.Void .ctor(System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.EventRegistration], NxGraph.Graphs.NodeId)
+  property NxGraph.Graphs.NodeId DefaultTarget { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.EventRegistration] Registrations { get; }
+abstract class NxGraph.Fsm.EventRegistration
+  method NxGraph.Fsm.EventRegistration Unbound(System.String, System.String, NxGraph.Graphs.NodeId)
+  property NxGraph.Graphs.NodeId Target { get; }
+  property System.String EventTypeName { get; }
+  property System.String KeyName { get; }
+sealed class NxGraph.Fsm.EventRegistration`1 : NxGraph.Fsm.EventRegistration
+  ctor System.Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TEvent], NxGraph.Graphs.NodeId)
+  property NxGraph.Blackboards.BlackboardKey`1[TEvent] Key { get; }
+enum NxGraph.Fsm.ExecutionStatus : System.IComparable, System.IConvertible, System.IFormattable
+  Cancelled = 6
+  Completed = 4
+  Created = 0
+  Failed = 5
+  Ready = 8
+  Resetting = 7
+  Running = 2
+  Starting = 1
+  Transitioning = 3
+sealed class NxGraph.Fsm.HistoryState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.ParallelStepMode)
+  method NxGraph.Result Execute()
+  property NxGraph.Fsm.ParallelStepMode Mode { get; }
+  property NxGraph.Fsm.StateMachine Child { get; }
+interface NxGraph.Fsm.IAgentSettable`1
+  method System.Void SetAgent(TAgent)
+interface NxGraph.Fsm.IAsyncDirector
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
+interface NxGraph.Fsm.IAsyncStateMachineObserver
+  method System.Threading.Tasks.ValueTask OnLogReport(NxGraph.Graphs.NodeId, System.String, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateEntered(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineCancelled(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineReset(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateMachineStarted(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask StateMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus, System.Threading.CancellationToken)
+interface NxGraph.Fsm.IDirector
+  method NxGraph.Graphs.NodeId SelectNext()
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+interface NxGraph.Fsm.IStateMachineObserver
+  method System.Void OnLogReport(NxGraph.Graphs.NodeId, System.String)
+  method System.Void OnStateEntered(NxGraph.Graphs.NodeId)
+  method System.Void OnStateExited(NxGraph.Graphs.NodeId)
+  method System.Void OnStateFailed(NxGraph.Graphs.NodeId, System.Exception)
+  method System.Void OnStateMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result)
+  method System.Void OnStateMachineReset(NxGraph.Graphs.NodeId)
+  method System.Void OnStateMachineStarted(NxGraph.Graphs.NodeId)
+  method System.Void OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method System.Void StateMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus)
+interface NxGraph.Fsm.ISuspendableComposite
+  method NxGraph.Fsm.CompositeSnapshot SuspendComposite(System.Int32)
+  method System.Void ResumeComposite(NxGraph.Fsm.CompositeSnapshot)
+sealed class NxGraph.Fsm.NodeStatusTracker
+  ctor System.Void .ctor()
+  method NxGraph.Fsm.ExecutionStatus Get(NxGraph.Graphs.NodeId)
+  method System.TimeSpan GetDuration(NxGraph.Graphs.NodeId)
+  method System.Void Initialize(NxGraph.Graphs.Graph)
+  method System.Void MarkCancelled(NxGraph.Graphs.NodeId)
+  method System.Void MarkEntered(NxGraph.Graphs.NodeId)
+  method System.Void MarkExited(NxGraph.Graphs.NodeId, System.Boolean)
+  method System.Void MarkTransitioned(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method System.Void Reset()
+  property System.Boolean IsInitialized { get; }
+  property System.Int32 Length { get; }
+sealed class NxGraph.Fsm.NodeStatusTrackingObserver : NxGraph.Fsm.IAsyncStateMachineObserver
+  ctor System.Void .ctor(NxGraph.Fsm.NodeStatusTracker)
+  method System.Threading.Tasks.ValueTask OnStateEntered(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateExited(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateFailed(NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+sealed class NxGraph.Fsm.ParallelState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Fsm.ParallelStepMode, NxGraph.Graphs.Graph[])
+  method NxGraph.Result Execute()
+  property NxGraph.Fsm.ParallelStepMode Mode { get; }
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Fsm.StateMachine] Regions { get; }
+enum NxGraph.Fsm.ParallelStepMode : System.IComparable, System.IConvertible, System.IFormattable
+  RoundPerTick = 1
+  RunToJoin = 0
+sealed class NxGraph.Fsm.PortConsumerRelayState`1 : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TIn], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,NxGraph.Result])
+  method NxGraph.Result OnRun()
+sealed class NxGraph.Fsm.PortPipeRelayState`2 : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TIn], NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`3[TIn,NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Result OnRun()
+sealed class NxGraph.Fsm.PortProducerRelayState`1 : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(NxGraph.Blackboards.BlackboardKey`1[TOut], System.Func`2[NxGraph.Blackboards.BlackboardContext,TOut])
+  method NxGraph.Result OnRun()
+struct NxGraph.Fsm.RegionMask : System.IEquatable`1[[NxGraph.Fsm.RegionMask]]
+  method NxGraph.Fsm.RegionMask All(System.Int32)
+  method NxGraph.Fsm.RegionMask Bit(System.Int32)
+  method NxGraph.Fsm.RegionMask Of(System.Int32[])
+  method System.Boolean Contains(System.Int32)
+  method System.Boolean Equals(NxGraph.Fsm.RegionMask)
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  operator NxGraph.Fsm.RegionMask op_BitwiseOr(NxGraph.Fsm.RegionMask, NxGraph.Fsm.RegionMask)
+  operator System.Boolean op_Equality(NxGraph.Fsm.RegionMask, NxGraph.Fsm.RegionMask)
+  operator System.Boolean op_Inequality(NxGraph.Fsm.RegionMask, NxGraph.Fsm.RegionMask)
+  property NxGraph.Fsm.RegionMask None { get; }
+  property System.Boolean IsEmpty { get; }
+  property System.Int32 Count { get; }
+sealed class NxGraph.Fsm.RelayState : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(System.Func`1[NxGraph.Result], System.Action, System.Action)
+  ctor System.Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,NxGraph.Result], System.Action`1[NxGraph.Blackboards.BlackboardContext], System.Action`1[NxGraph.Blackboards.BlackboardContext])
+  method NxGraph.Result OnRun()
+  method System.Void OnEnter()
+  method System.Void OnExit()
+sealed class NxGraph.Fsm.RelayState`1 : State`1, IAgentSettable`1, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(System.Func`2[TAgent,NxGraph.Result], System.Action`1[TAgent], System.Action`1[TAgent])
+  ctor System.Void .ctor(System.Func`3[TAgent,NxGraph.Blackboards.BlackboardContext,NxGraph.Result], System.Action`2[TAgent,NxGraph.Blackboards.BlackboardContext], System.Action`2[TAgent,NxGraph.Blackboards.BlackboardContext])
+  method NxGraph.Result OnRun()
+  method System.Void OnEnter()
+  method System.Void OnExit()
+enum NxGraph.Fsm.RestartPolicy : System.IComparable, System.IConvertible, System.IFormattable
+  Auto = 0
+  Ignore = 2
+  Manual = 1
+struct NxGraph.Fsm.RetryPolicy
+  ctor System.Void .ctor(System.Byte, System.TimeSpan, NxGraph.Fsm.BackoffKind)
+  field static readonly NxGraph.Fsm.RetryPolicy None
+  method System.TimeSpan DelayForAttempt(System.Int32)
+  property NxGraph.Fsm.BackoffKind BackoffKind { get; }
+  property System.Byte MaxAttempts { get; }
+  property System.TimeSpan Backoff { get; }
+abstract class NxGraph.Fsm.State : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor()
+  method NxGraph.Result Execute()
+  method NxGraph.Result OnRun()
+  method System.Void Log(System.String)
+  method System.Void OnEnter()
+  method System.Void OnExit()
+  property NxGraph.Blackboards.BlackboardContext Bb { get; }
+  property System.Action`1[System.String] SyncLogReport { get; set; }
+class NxGraph.Fsm.StateMachine : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
+  field readonly NxGraph.Graphs.Graph Graph
+  method NxGraph.Fsm.StateMachineDeepSnapshot SuspendDeep()
+  method NxGraph.Fsm.StateMachineSnapshot Suspend()
+  method NxGraph.Result Execute[TEvent](TEvent)
+  method NxGraph.Result OnRun()
+  method NxGraph.Result Reset()
+  method System.Void OnEnter()
+  method System.Void OnExit()
+  method System.Void Resume(NxGraph.Fsm.StateMachineSnapshot)
+  method System.Void ResumeDeep(NxGraph.Fsm.StateMachineDeepSnapshot)
+  method System.Void SetAutoReset(System.Boolean)
+  method System.Void SetBlackboard(NxGraph.Blackboards.Blackboard)
+  method System.Void SetResetPolicy(NxGraph.Fsm.RestartPolicy)
+  method System.Void SetRestartPolicy(NxGraph.Fsm.RestartPolicy)
+  method System.Void SetStepMode(NxGraph.Fsm.ParallelStepMode)
+  property NxGraph.Fsm.ExecutionStatus Status { get; }
+  property NxGraph.Fsm.ParallelStepMode StepMode { get; }
+  property System.Int32 LastOutcome { get; }
+  property System.String LastOutcomeName { get; }
+sealed class NxGraph.Fsm.StateMachineDeepSnapshot : System.IEquatable`1[[NxGraph.Fsm.StateMachineDeepSnapshot]]
+  ctor System.Void .ctor(NxGraph.Fsm.StateMachineSnapshot, NxGraph.Fsm.CompositeSnapshot[])
+  method NxGraph.Fsm.StateMachineDeepSnapshot <Clone>$()
+  method System.Boolean Equals(NxGraph.Fsm.StateMachineDeepSnapshot)
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  method System.Void Deconstruct(NxGraph.Fsm.StateMachineSnapshot&, NxGraph.Fsm.CompositeSnapshot[]&)
+  operator System.Boolean op_Equality(NxGraph.Fsm.StateMachineDeepSnapshot, NxGraph.Fsm.StateMachineDeepSnapshot)
+  operator System.Boolean op_Inequality(NxGraph.Fsm.StateMachineDeepSnapshot, NxGraph.Fsm.StateMachineDeepSnapshot)
+  property NxGraph.Fsm.CompositeSnapshot[] Composites { get; set; }
+  property NxGraph.Fsm.StateMachineSnapshot Self { get; set; }
+sealed class NxGraph.Fsm.StateMachineSnapshot : System.IEquatable`1[[NxGraph.Fsm.StateMachineSnapshot]]
+  ctor System.Void .ctor(System.Int32, NxGraph.Fsm.ExecutionStatus, System.Int32, System.Boolean, System.Boolean, System.Int32)
+  method NxGraph.Fsm.StateMachineSnapshot <Clone>$()
+  method System.Boolean Equals(NxGraph.Fsm.StateMachineSnapshot)
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  method System.Void Deconstruct(System.Int32&, NxGraph.Fsm.ExecutionStatus&, System.Int32&, System.Boolean&, System.Boolean&, System.Int32&)
+  operator System.Boolean op_Equality(NxGraph.Fsm.StateMachineSnapshot, NxGraph.Fsm.StateMachineSnapshot)
+  operator System.Boolean op_Inequality(NxGraph.Fsm.StateMachineSnapshot, NxGraph.Fsm.StateMachineSnapshot)
+  property NxGraph.Fsm.ExecutionStatus Status { get; set; }
+  property System.Boolean MidRun { get; set; }
+  property System.Boolean NodeEntered { get; set; }
+  property System.Int32 Attempts { get; set; }
+  property System.Int32 CurrentNodeIndex { get; set; }
+  property System.Int32 LastOutcome { get; set; }
+class NxGraph.Fsm.StateMachine`1 : NxGraph.Fsm.StateMachine, IAgentSettable`1, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Fsm.ISuspendableComposite, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph, NxGraph.Fsm.IStateMachineObserver)
+  method System.Void SetAgent(TAgent)
+abstract class NxGraph.Fsm.State`1 : NxGraph.Fsm.State, IAgentSettable`1, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor()
+  field TAgent Agent
+  method System.Void SetAgent(TAgent)
+sealed class NxGraph.Fsm.SwitchState`1 : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Fsm.IDirector, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(System.Func`1[TKey], System.Collections.Generic.IReadOnlyDictionary`2[TKey,NxGraph.Graphs.NodeId], NxGraph.Graphs.NodeId)
+  ctor System.Void .ctor(System.Func`2[NxGraph.Blackboards.BlackboardContext,TKey], System.Collections.Generic.IReadOnlyDictionary`2[TKey,NxGraph.Graphs.NodeId], NxGraph.Graphs.NodeId)
+  method NxGraph.Graphs.NodeId SelectNext()
+  method NxGraph.Result Execute()
+  method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
+enum NxGraph.Fsm.TimeoutBehavior : System.IComparable, System.IConvertible, System.IFormattable
+  Fail = 0
+  Throw = 1
+sealed class NxGraph.Fsm.TimeoutState : NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(NxGraph.Graphs.ILogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
+  ctor System.Void .ctor(NxGraph.Graphs.ILogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior, System.Func`1[System.Int64])
+  method NxGraph.Result Execute()
+sealed class NxGraph.Fsm.WaitState : NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(System.TimeSpan)
+  ctor System.Void .ctor(System.TimeSpan, System.Func`1[System.Int64])
+  method NxGraph.Result Execute()
+sealed class NxGraph.Graphs.EmptyAsyncLogic : NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+sealed class NxGraph.Graphs.EmptyLogic : NxGraph.Graphs.ILogic
+  ctor System.Void .ctor()
+  method NxGraph.Result Execute()
+sealed class NxGraph.Graphs.Graph : NxGraph.Graphs.IGraph, NxGraph.Graphs.INode
+  ctor System.Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode[], NxGraph.Graphs.Transition[], NxGraph.Graphs.IAsyncLogic, NxGraph.Fsm.RetryPolicy[], System.Int32[], System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String], NxGraph.Blackboards.BlackboardSchema, NxGraph.Blackboards.BlackboardSchema, NxGraph.Blackboards.BlackboardSchema, System.Guid[])
+  method NxGraph.Graphs.INode GetNodeByIndex(System.Int32)
+  method NxGraph.Graphs.Transition GetTransitionByIndex(System.Int32)
+  method System.Boolean TryGetNode(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode&)
+  method System.Boolean TryGetNodeByIndex(System.Int32, NxGraph.Graphs.INode&)
+  method System.Boolean TryGetNodeByUid(System.Guid, NxGraph.Graphs.INode&)
+  method System.Boolean TryGetTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.Transition&)
+  method System.Void SetAgent[TAgent](TAgent)
+  method System.Void SetBlackboards(NxGraph.Blackboards.BlackboardContext&)
+  property NxGraph.Blackboards.BlackboardSchema GlobalSchema { get; }
+  property NxGraph.Blackboards.BlackboardSchema NodeSchema { get; }
+  property NxGraph.Blackboards.BlackboardSchema Schema { get; }
+  property NxGraph.Fsm.RetryPolicy[] RetryPolicies { get; }
+  property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
+  property NxGraph.Graphs.ILogic Logic { get; }
+  property NxGraph.Graphs.INode StartNode { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+  property System.Collections.Generic.IReadOnlyDictionary`2[System.Int32,System.String] OutcomeNames { get; }
+  property System.Guid[] Uids { get; }
+  property System.Int32 NodeCount { get; }
+  property System.Int32 TransitionCount { get; }
+  property System.Int32[] OutcomeCodes { get; }
+interface NxGraph.Graphs.IAsyncLogic
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+interface NxGraph.Graphs.IGraph
+  method System.Boolean TryGetNode(NxGraph.Graphs.NodeId, NxGraph.Graphs.INode&)
+  method System.Boolean TryGetTransition(NxGraph.Graphs.NodeId, NxGraph.Graphs.Transition&)
+  method System.Void SetAgent[TAgent](TAgent)
+  property NxGraph.Graphs.INode StartNode { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+  property System.Int32 NodeCount { get; }
+  property System.Int32 TransitionCount { get; }
+interface NxGraph.Graphs.ILogic
+  method NxGraph.Result Execute()
+interface NxGraph.Graphs.INode
+  property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
+  property NxGraph.Graphs.ILogic Logic { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+interface NxGraph.Graphs.ISubGraphProvider
+  property System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.Graph] SubGraphs { get; }
+class NxGraph.Graphs.LogicNode : NxGraph.Graphs.INode
+  ctor System.Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.IAsyncLogic, System.Action, System.Action)
+  field static readonly NxGraph.Graphs.LogicNode AsyncBehaviorStateMarker
+  field static readonly NxGraph.Graphs.LogicNode BehaviorStateMarker
+  field static readonly NxGraph.Graphs.LogicNode DynamicParallelStateMarker
+  field static readonly NxGraph.Graphs.LogicNode Empty
+  field static readonly NxGraph.Graphs.LogicNode EventEntryStateMarker
+  field static readonly NxGraph.Graphs.LogicNode ForkStateMarker
+  field static readonly NxGraph.Graphs.LogicNode HistoryStateMarker
+  field static readonly NxGraph.Graphs.LogicNode JoinStateMarker
+  field static readonly NxGraph.Graphs.LogicNode ParallelStateMarker
+  field static readonly NxGraph.Graphs.LogicNode StateMachineMarker
+  field static readonly NxGraph.Graphs.LogicNode SyncDynamicParallelStateMarker
+  field static readonly NxGraph.Graphs.LogicNode SyncHistoryStateMarker
+  field static readonly NxGraph.Graphs.LogicNode SyncParallelStateMarker
+  field static readonly NxGraph.Graphs.LogicNode SyncStateMachineMarker
+  property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
+  property NxGraph.Graphs.ILogic Logic { get; }
+  property NxGraph.Graphs.NodeId Id { get; }
+  property System.Action EnterAction { get; }
+  property System.Action ExitAction { get; }
+struct NxGraph.Graphs.NodeId : System.IEquatable`1[[NxGraph.Graphs.NodeId]]
+  ctor System.Void .ctor(NxGraph.Graphs.NodeId)
+  ctor System.Void .ctor(NxGraph.Graphs.NodeId, System.String)
+  ctor System.Void .ctor(System.Int32)
+  ctor System.Void .ctor(System.Int32, System.String)
+  method NxGraph.Graphs.NodeId WithName(System.String)
+  method System.Boolean Equals(NxGraph.Graphs.NodeId)
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  operator System.Boolean op_Equality(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  operator System.Boolean op_Inequality(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  property NxGraph.Graphs.NodeId AsyncBehaviorStateMarker { get; }
+  property NxGraph.Graphs.NodeId BehaviorStateMarker { get; }
+  property NxGraph.Graphs.NodeId Default { get; }
+  property NxGraph.Graphs.NodeId DynamicParallelStateMarker { get; }
+  property NxGraph.Graphs.NodeId EventEntryStateMarker { get; }
+  property NxGraph.Graphs.NodeId ForkStateMarker { get; }
+  property NxGraph.Graphs.NodeId HistoryStateMarker { get; }
+  property NxGraph.Graphs.NodeId JoinStateMarker { get; }
+  property NxGraph.Graphs.NodeId ParallelStateMarker { get; }
+  property NxGraph.Graphs.NodeId Start { get; }
+  property NxGraph.Graphs.NodeId StateMachineMarker { get; }
+  property NxGraph.Graphs.NodeId SyncDynamicParallelStateMarker { get; }
+  property NxGraph.Graphs.NodeId SyncHistoryStateMarker { get; }
+  property NxGraph.Graphs.NodeId SyncParallelStateMarker { get; }
+  property NxGraph.Graphs.NodeId SyncStateMachineMarker { get; }
+  property System.Int32 Index { get; }
+  property System.String Name { get; }
+sealed class NxGraph.Graphs.SyncLogicAdapter : NxGraph.Graphs.IAsyncLogic
+  ctor System.Void .ctor(NxGraph.Graphs.ILogic)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
+  property NxGraph.Graphs.ILogic Logic { get; }
+struct NxGraph.Graphs.Transition
+  ctor System.Void .ctor(NxGraph.Graphs.NodeId)
+  ctor System.Void .ctor(NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  field static readonly NxGraph.Graphs.Transition Empty
+  property NxGraph.Graphs.NodeId Destination { get; }
+  property NxGraph.Graphs.NodeId FailureDestination { get; }
+  property System.Boolean HasFailureDestination { get; }
+  property System.Boolean IsEmpty { get; }
+struct NxGraph.Result : System.IEquatable`1[[NxGraph.Result]]
+  field static readonly NxGraph.Result Continue
+  field static readonly NxGraph.Result Failure
+  field static readonly NxGraph.Result InProgress
+  field static readonly NxGraph.Result Success
+  method NxGraph.Result Fail(System.String)
+  method NxGraph.Result Ok(System.String)
+  method System.Boolean Equals(NxGraph.Result)
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  operator System.Boolean op_Equality(NxGraph.Result, NxGraph.Result)
+  operator System.Boolean op_Inequality(NxGraph.Result, NxGraph.Result)
+  property NxGraph.Result+StatusCode Code { get; }
+  property System.Boolean IsCompleted { get; }
+  property System.Boolean IsFailure { get; }
+  property System.Boolean IsInProgress { get; }
+  property System.Boolean IsSuccess { get; }
+  property System.String Message { get; }
+enum NxGraph.Result+StatusCode : System.IComparable, System.IConvertible, System.IFormattable
+  Continue = 2
+  Failure = 1
+  InProgress = 2
+  Success = 0
+static class NxGraph.ResultHelpers
+  field static readonly System.Threading.Tasks.ValueTask CompletedTask
+  field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result]] Continue
+  field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result]] Failure
+  field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result]] InProgress
+  field static readonly System.Threading.Tasks.ValueTask`1[[NxGraph.Result]] Success
+class NxGraph.Tokens.AsyncTokenMachine : NxGraph.Fsm.Async.AsyncState, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph, NxGraph.Tokens.IAsyncTokenMachineObserver, System.Int32)
+  field readonly NxGraph.Graphs.Graph Graph
+  method NxGraph.Tokens.TokenMachineSnapshot Suspend()
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnEnterAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnExitAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] OnRunAsync(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] Reset(System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask`1[NxGraph.Result] StepAsync(System.Threading.CancellationToken)
+  method System.Void Resume(NxGraph.Tokens.TokenMachineSnapshot)
+  method System.Void SetBlackboard(NxGraph.Blackboards.Blackboard)
+  method System.Void SetRestartPolicy(NxGraph.Fsm.RestartPolicy)
+  property NxGraph.Fsm.ExecutionStatus Status { get; }
+  property System.Int32 LiveTokenCount { get; }
+class NxGraph.Tokens.AsyncTokenMachine`1 : NxGraph.Tokens.AsyncTokenMachine, IAgentSettable`1, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph, NxGraph.Tokens.IAsyncTokenMachineObserver, System.Int32)
+  method System.Void SetAgent(TAgent)
+sealed class NxGraph.Tokens.ForkState : NxGraph.Fsm.IAsyncDirector, NxGraph.Fsm.IDirector, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(NxGraph.Graphs.NodeId[])
+  property System.Collections.Generic.IReadOnlyList`1[NxGraph.Graphs.NodeId] Branches { get; }
+interface NxGraph.Tokens.IAsyncTokenMachineObserver
+  method System.Threading.Tasks.ValueTask OnJoinFired(NxGraph.Graphs.NodeId, System.Int32, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnLogReport(System.Int32, NxGraph.Graphs.NodeId, System.String, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateEntered(System.Int32, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateExited(System.Int32, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnStateFailed(System.Int32, NxGraph.Graphs.NodeId, System.Exception, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenMachineCancelled(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenMachineReset(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenMachineStarted(NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenRetired(System.Int32, NxGraph.Graphs.NodeId, NxGraph.Tokens.TokenRetireReason, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTokenSpawned(System.Int32, System.Int32, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask OnTransition(System.Int32, NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId, System.Threading.CancellationToken)
+  method System.Threading.Tasks.ValueTask TokenMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus, System.Threading.CancellationToken)
+interface NxGraph.Tokens.ITokenMachineObserver
+  method System.Void OnJoinFired(NxGraph.Graphs.NodeId, System.Int32)
+  method System.Void OnLogReport(System.Int32, NxGraph.Graphs.NodeId, System.String)
+  method System.Void OnStateEntered(System.Int32, NxGraph.Graphs.NodeId)
+  method System.Void OnStateExited(System.Int32, NxGraph.Graphs.NodeId)
+  method System.Void OnStateFailed(System.Int32, NxGraph.Graphs.NodeId, System.Exception)
+  method System.Void OnTokenMachineCompleted(NxGraph.Graphs.NodeId, NxGraph.Result)
+  method System.Void OnTokenMachineReset(NxGraph.Graphs.NodeId)
+  method System.Void OnTokenMachineStarted(NxGraph.Graphs.NodeId)
+  method System.Void OnTokenRetired(System.Int32, NxGraph.Graphs.NodeId, NxGraph.Tokens.TokenRetireReason)
+  method System.Void OnTokenSpawned(System.Int32, System.Int32, NxGraph.Graphs.NodeId)
+  method System.Void OnTransition(System.Int32, NxGraph.Graphs.NodeId, NxGraph.Graphs.NodeId)
+  method System.Void TokenMachineStatusChanged(NxGraph.Graphs.NodeId, NxGraph.Fsm.ExecutionStatus, NxGraph.Fsm.ExecutionStatus)
+enum NxGraph.Tokens.JoinKind : System.IComparable, System.IConvertible, System.IFormattable
+  All = 0
+  Any = 1
+  Quorum = 2
+struct NxGraph.Tokens.JoinPolicy
+  method NxGraph.Tokens.JoinPolicy All(System.Int32)
+  method NxGraph.Tokens.JoinPolicy Quorum(System.Int32)
+  method System.String ToString()
+  property NxGraph.Tokens.JoinKind Kind { get; }
+  property NxGraph.Tokens.JoinPolicy Any { get; }
+  property System.Int32 Count { get; }
+  property System.Int32 RequiredCount { get; }
+sealed class NxGraph.Tokens.JoinState : NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ILogic
+  ctor System.Void .ctor(NxGraph.Tokens.JoinPolicy)
+  property NxGraph.Tokens.JoinPolicy Policy { get; }
+class NxGraph.Tokens.TokenMachine : NxGraph.Fsm.State, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph, NxGraph.Tokens.ITokenMachineObserver, System.Int32)
+  field readonly NxGraph.Graphs.Graph Graph
+  field static System.Int32 DefaultMaxTokens
+  method NxGraph.Result OnRun()
+  method NxGraph.Result Reset()
+  method NxGraph.Tokens.TokenMachineSnapshot Suspend()
+  method System.Void OnEnter()
+  method System.Void OnExit()
+  method System.Void Resume(NxGraph.Tokens.TokenMachineSnapshot)
+  method System.Void SetBlackboard(NxGraph.Blackboards.Blackboard)
+  method System.Void SetRestartPolicy(NxGraph.Fsm.RestartPolicy)
+  method System.Void SetStepMode(NxGraph.Fsm.ParallelStepMode)
+  property NxGraph.Fsm.ExecutionStatus Status { get; }
+  property NxGraph.Fsm.ParallelStepMode StepMode { get; }
+  property System.Int32 LiveTokenCount { get; }
+sealed class NxGraph.Tokens.TokenMachineSnapshot : System.IEquatable`1[[NxGraph.Tokens.TokenMachineSnapshot]]
+  ctor System.Void .ctor(NxGraph.Fsm.ExecutionStatus, System.Boolean, System.Int32, NxGraph.Tokens.TokenRecord[], System.Int32[])
+  method NxGraph.Tokens.TokenMachineSnapshot <Clone>$()
+  method System.Boolean Equals(NxGraph.Tokens.TokenMachineSnapshot)
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  method System.Void Deconstruct(NxGraph.Fsm.ExecutionStatus&, System.Boolean&, System.Int32&, NxGraph.Tokens.TokenRecord[]&, System.Int32[]&)
+  operator System.Boolean op_Equality(NxGraph.Tokens.TokenMachineSnapshot, NxGraph.Tokens.TokenMachineSnapshot)
+  operator System.Boolean op_Inequality(NxGraph.Tokens.TokenMachineSnapshot, NxGraph.Tokens.TokenMachineSnapshot)
+  property NxGraph.Fsm.ExecutionStatus Status { get; set; }
+  property NxGraph.Tokens.TokenRecord[] Tokens { get; set; }
+  property System.Boolean AnyTokenDied { get; set; }
+  property System.Boolean MidRun { get; set; }
+  property System.Boolean[] JoinsFired { get; set; }
+  property System.Int32 NextTokenId { get; set; }
+  property System.Int32[] JoinArrivals { get; set; }
+class NxGraph.Tokens.TokenMachine`1 : NxGraph.Tokens.TokenMachine, IAgentSettable`1, NxGraph.Blackboards.IBlackboardBindable, NxGraph.Blackboards.IBlackboardSettable, NxGraph.Diagnostics.Replay.ILogReporter, NxGraph.Graphs.ILogic, NxGraph.Graphs.ISubGraphProvider
+  ctor System.Void .ctor(NxGraph.Graphs.Graph, NxGraph.Tokens.ITokenMachineObserver, System.Int32)
+  method System.Void SetAgent(TAgent)
+enum NxGraph.Tokens.TokenPhase : System.IComparable, System.IConvertible, System.IFormattable
+  Parked = 1
+  Runnable = 0
+sealed class NxGraph.Tokens.TokenRecord : System.IEquatable`1[[NxGraph.Tokens.TokenRecord]]
+  ctor System.Void .ctor(System.Int32, System.Int32, System.Int32, System.Boolean, NxGraph.Tokens.TokenPhase)
+  method NxGraph.Tokens.TokenRecord <Clone>$()
+  method System.Boolean Equals(NxGraph.Tokens.TokenRecord)
+  method System.Boolean Equals(System.Object)
+  method System.Int32 GetHashCode()
+  method System.String ToString()
+  method System.Void Deconstruct(System.Int32&, System.Int32&, System.Int32&, System.Boolean&, NxGraph.Tokens.TokenPhase&)
+  operator System.Boolean op_Equality(NxGraph.Tokens.TokenRecord, NxGraph.Tokens.TokenRecord)
+  operator System.Boolean op_Inequality(NxGraph.Tokens.TokenRecord, NxGraph.Tokens.TokenRecord)
+  property NxGraph.Tokens.TokenPhase Phase { get; set; }
+  property System.Boolean NodeEntered { get; set; }
+  property System.Int32 Attempts { get; set; }
+  property System.Int32 Id { get; set; }
+  property System.Int32 NodeIndex { get; set; }
+enum NxGraph.Tokens.TokenRetireReason : System.IComparable, System.IConvertible, System.IFormattable
+  Absorbed = 4
+  Completed = 0
+  Failed = 1
+  Joined = 2
+  Starved = 3
+static class System.ArgumentNullExceptionShim
+  method System.Void ThrowIfNull(System.Object, System.String)

--- a/NxGraph.Tests/PublicApi/PublicApiSurfaceTests.cs
+++ b/NxGraph.Tests/PublicApi/PublicApiSurfaceTests.cs
@@ -14,11 +14,23 @@ namespace NxGraph.Tests.PublicApi;
 /// <para>
 /// To accept an intentional change, set the environment variable
 /// <c>NXGRAPH_UPDATE_PUBLIC_API=1</c> and re-run the tests: the baselines under
-/// <c>NxGraph.Tests/PublicApi/</c> are rewritten in place. Commit the resulting diff.
+/// <c>NxGraph.Tests/PublicApi/</c> are rewritten in place (the netstandard2.1 baseline
+/// included — it goes through the exact same mechanism). Commit the resulting diff.
 /// </para>
 /// <para>
-/// The surface is captured for net8.0 (the richest target); the netstandard2.1 surface
-/// is compiled from the same sources minus <c>NET8_0_OR_GREATER</c> members.
+/// Two flavors of capture: the loaded net8.0 assemblies are described via runtime
+/// reflection; the netstandard2.1 build of NxGraph (the Unity-facing surface, compiled
+/// with the <c>Shims/**</c> re-includes) is described via a <see cref="MetadataLoadContext"/>
+/// walk over <c>NxGraph/bin/{Configuration}/netstandard2.1/NxGraph.dll</c> resolved against
+/// the NETStandard.Library.Ref facades, and lands in <c>NxGraph.netstandard2.1.approved.txt</c>.
+/// </para>
+/// <para>
+/// Known limitation (both flavors, unchanged from the original fixture): the walk captures
+/// shape only — not nullability annotations, attributes, parameter names, or default values.
+/// The two flavors also render open-generic signatures differently (runtime reflection uses
+/// short names, MetadataLoadContext full names), so compare each baseline only with itself;
+/// the netstandard2.1 rendering is tied to the pinned System.Reflection.MetadataLoadContext
+/// package version — a bump may need a baseline regeneration via the same env var.
 /// </para>
 /// </summary>
 [TestFixture]
@@ -36,7 +48,31 @@ public class PublicApiSurfaceTests
         [Range(0, 2)] int assemblyIndex)
     {
         (string baselineFile, Assembly assembly) = Assemblies[assemblyIndex];
-        string actual = DescribePublicApi(assembly);
+        CompareOrUpdateBaseline(baselineFile, assembly.GetName().Name!, DescribePublicApi(assembly));
+    }
+
+    [Test]
+    public void Public_api_matches_approved_baseline_for_netstandard21()
+    {
+        string targetDll = NetStandardAssemblyPath();
+        if (!File.Exists(targetDll))
+        {
+            Assert.Ignore(
+                $"netstandard2.1 build output not found at '{targetDll}' — a partial build. " +
+                "Build the full solution (dotnet build) to produce it; the solution build always emits both TFMs.");
+        }
+
+        string facadeDir = NetStandardFacadeDirectory();
+        PathAssemblyResolver resolver = new(
+            Directory.EnumerateFiles(facadeDir, "*.dll").Append(targetDll));
+        using MetadataLoadContext mlc = new(resolver, coreAssemblyName: "netstandard");
+
+        string actual = DescribePublicApi(mlc.LoadFromAssemblyPath(targetDll));
+        CompareOrUpdateBaseline("NxGraph.netstandard2.1.approved.txt", "NxGraph (netstandard2.1)", actual);
+    }
+
+    private static void CompareOrUpdateBaseline(string baselineFile, string assemblyDisplayName, string actual)
+    {
         string baselinePath = Path.Combine(BaselineDirectory(), baselineFile);
 
         if (Environment.GetEnvironmentVariable("NXGRAPH_UPDATE_PUBLIC_API") == "1")
@@ -59,9 +95,41 @@ public class PublicApiSurfaceTests
         }
 
         Assert.Fail(
-            $"Public API of {assembly.GetName().Name} differs from the approved baseline.\n" +
+            $"Public API of {assemblyDisplayName} differs from the approved baseline.\n" +
             Diff(Normalize(expected), Normalize(actual)) +
             "\nIf this change is intentional, re-run with NXGRAPH_UPDATE_PUBLIC_API=1 and commit the baseline diff.");
+    }
+
+    /// <summary>NxGraph's netstandard2.1 build output for the configuration this test run was built as.</summary>
+    private static string NetStandardAssemblyPath()
+    {
+        // Test bin layout: <repo>/NxGraph.Tests/bin/<Configuration>/net8.0/ — take the live
+        // configuration from the test host's own path so a Debug test run checks the Debug
+        // netstandard build and Release checks Release.
+        string baseDir = AppContext.BaseDirectory
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string configuration = new DirectoryInfo(baseDir).Parent?.Name ?? "Release";
+
+        string repoRoot = Path.GetFullPath(Path.Combine(BaselineDirectory(), "..", ".."));
+        return Path.Combine(repoRoot, "NxGraph", "bin", configuration, "netstandard2.1", "NxGraph.dll");
+    }
+
+    /// <summary>Reference-facade directory of the restored NETStandard.Library.Ref pack.</summary>
+    private static string NetStandardFacadeDirectory()
+    {
+        string? dir = typeof(PublicApiSurfaceTests).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "NxGraph.Tests.NetStandardRefDir")?.Value;
+
+        if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+        {
+            Assert.Fail(
+                "NETStandard.Library.Ref facade directory not found (assembly metadata " +
+                $"'NxGraph.Tests.NetStandardRefDir' resolved to '{dir}'). Check the " +
+                "NETStandard.Library.Ref PackageReference in NxGraph.Tests.csproj.");
+        }
+
+        return dir!;
     }
 
     private static string Normalize(string text) => text.Replace("\r\n", "\n").TrimEnd('\n');
@@ -94,6 +162,11 @@ public class PublicApiSurfaceTests
     private static string StripAssemblyQualification(string text) =>
         Regex.Replace(text, @", [\w.]+, Version=[^,\]]+, Culture=[^,\]]+, PublicKeyToken=[^,\]]+", "");
 
+    // Everything below is deliberately MetadataLoadContext-safe: no identity comparisons
+    // against runtime typeof(...) (an MLC type never equals a runtime type) and no
+    // Enum.GetNames/Enum.Parse (which require runtime types) — name-based checks and raw
+    // field constants render identically for both reflection flavors.
+
     private static string DescribePublicApi(Assembly assembly)
     {
         StringBuilder sb = new();
@@ -118,24 +191,35 @@ public class PublicApiSurfaceTests
         if (type.IsEnum) return "enum";
         if (type.IsValueType) return "struct";
         if (type.IsInterface) return "interface";
-        if (typeof(Delegate).IsAssignableFrom(type)) return "delegate";
+        if (IsDelegate(type)) return "delegate";
         if (type is { IsAbstract: true, IsSealed: true }) return "static class";
         if (type.IsAbstract) return "abstract class";
         if (type.IsSealed) return "sealed class";
         return "class";
     }
 
+    private static bool IsDelegate(Type type)
+    {
+        for (Type? baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (baseType.FullName is "System.MulticastDelegate" or "System.Delegate")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static string TypeDisplay(Type type)
     {
         StringBuilder sb = new(type.FullName);
         List<string> bases = [];
-        if (type.BaseType is not null &&
-            type.BaseType != typeof(object) &&
-            type.BaseType != typeof(ValueType) &&
-            type.BaseType != typeof(Enum) &&
-            type.BaseType != typeof(MulticastDelegate))
+        if (type.BaseType is { } baseType &&
+            baseType.FullName is not ("System.Object" or "System.ValueType" or "System.Enum"
+                or "System.MulticastDelegate"))
         {
-            bases.Add(type.BaseType.FullName ?? type.BaseType.Name);
+            bases.Add(baseType.FullName ?? baseType.Name);
         }
 
         bases.AddRange(type.GetInterfaces()
@@ -158,9 +242,13 @@ public class PublicApiSurfaceTests
 
         if (type.IsEnum)
         {
-            foreach (string name in Enum.GetNames(type))
+            // Same ordering Enum.GetNames uses: ascending unsigned binary value.
+            foreach (FieldInfo field in type
+                         .GetFields(BindingFlags.Public | BindingFlags.Static)
+                         .OrderBy(f => unchecked((ulong)Convert.ToInt64(f.GetRawConstantValue())))
+                         .ThenBy(f => f.Name, StringComparer.Ordinal))
             {
-                yield return $"{name} = {Convert.ToInt64(Enum.Parse(type, name))}";
+                yield return $"{field.Name} = {Convert.ToInt64(field.GetRawConstantValue())}";
             }
 
             yield break;

--- a/NxGraph.Tests/PublicApi/PublicApiSurfaceTests.cs
+++ b/NxGraph.Tests/PublicApi/PublicApiSurfaceTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -245,10 +246,10 @@ public class PublicApiSurfaceTests
             // Same ordering Enum.GetNames uses: ascending unsigned binary value.
             foreach (FieldInfo field in type
                          .GetFields(BindingFlags.Public | BindingFlags.Static)
-                         .OrderBy(f => unchecked((ulong)Convert.ToInt64(f.GetRawConstantValue())))
+                         .OrderBy(f => unchecked((ulong)Convert.ToInt64(f.GetRawConstantValue(), CultureInfo.InvariantCulture)))
                          .ThenBy(f => f.Name, StringComparer.Ordinal))
             {
-                yield return $"{field.Name} = {Convert.ToInt64(field.GetRawConstantValue())}";
+                yield return $"{field.Name} = {Convert.ToInt64(field.GetRawConstantValue(), CultureInfo.InvariantCulture)}";
             }
 
             yield break;

--- a/NxGraph.Tests/ReplayTests.cs
+++ b/NxGraph.Tests/ReplayTests.cs
@@ -12,7 +12,7 @@ using System.IO;
 [Category("replay")]
 public class ReplayTests
 {
-    private class EventSequenceVerifier
+    private sealed class EventSequenceVerifier
     {
         public readonly List<string> RecordedEvents = [];
 
@@ -159,7 +159,7 @@ public class ReplayTests
         int startedIdx = verifier.RecordedEvents.IndexOf("FSM:Started");
         int entered0Idx = verifier.RecordedEvents.FindIndex(e => e == "Entered: (0)");
         int exited0Idx = verifier.RecordedEvents.FindIndex(e => e == "Exited: (0)");
-        int transitionIdx = verifier.RecordedEvents.FindIndex(e => e.StartsWith("Transitioned from"));
+        int transitionIdx = verifier.RecordedEvents.FindIndex(e => e.StartsWith("Transitioned from", StringComparison.Ordinal));
         int entered1Idx = verifier.RecordedEvents.FindIndex(e => e == "Entered: (1)");
 
         Assert.Multiple(() =>
@@ -249,7 +249,7 @@ public class ReplayTests
         newReplay.ReplayAll(verifier.ProcessEvent);
 
         // Check all expected transitions were replayed
-        Assert.That(verifier.RecordedEvents.Count(e => e.StartsWith("Transitioned")), Is.EqualTo(3));
+        Assert.That(verifier.RecordedEvents.Count(e => e.StartsWith("Transitioned", StringComparison.Ordinal)), Is.EqualTo(3));
     }
 
 
@@ -285,14 +285,14 @@ public class ReplayTests
         Assert.Multiple(() =>
         {
             // Verify log messages were captured in replay
-            Assert.That(verifier.RecordedEvents.Count(e => e.StartsWith("Log:")), Is.EqualTo(2));
+            Assert.That(verifier.RecordedEvents.Count(e => e.StartsWith("Log:", StringComparison.Ordinal)), Is.EqualTo(2));
             Assert.That(verifier.RecordedEvents, Does.Contain("Log: (0) - Test log message 1"));
             Assert.That(verifier.RecordedEvents, Does.Contain("Log: (0) - Test log message 2"));
         });
     }
 
 // Test state that logs messages
-    private class LoggingTestState(params string[] messages) : AsyncState
+    private sealed class LoggingTestState(params string[] messages) : AsyncState
     {
         protected override async ValueTask<Result> OnRunAsync(CancellationToken ct)
         {

--- a/NxGraph.Tests/RetryTests.cs
+++ b/NxGraph.Tests/RetryTests.cs
@@ -118,6 +118,62 @@ public class RetryTests
         });
     }
 
+    // The end-to-end backoff tests below stay real-time by decision: a fake-clock seam for
+    // the async retry path was considered and rejected for now — the repo keeps no
+    // InternalsVisibleTo by policy (spec 004), and a public delay-scheduler hook is API
+    // surface growth a test convenience does not justify. Elapsed-time assertions are
+    // therefore lower-bound-only (Task.Delay never completes early; overshoot on a loaded
+    // runner is unbounded, so upper bounds would be pure flake).
+
+    [Test]
+    [CancelAfter(10_000)]
+    public async Task linear_backoff_is_applied_between_async_attempts(CancellationToken ct)
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ++executions < 3 ? ResultHelpers.Failure : ResultHelpers.Success)
+            .Retry(maxAttempts: 3, backoff: TimeSpan.FromMilliseconds(40), backoffKind: BackoffKind.Linear)
+            .Build();
+
+        Stopwatch sw = Stopwatch.StartNew();
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync(ct);
+        sw.Stop();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executions, Is.EqualTo(3));
+            // Two failed attempts → linear delays of 1×40 ms and 2×40 ms = 120 ms total;
+            // assert with the same 25% timer-skew margin the fixed-backoff test uses.
+            Assert.That(sw.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(90),
+                "Linear backoff must scale the machine-level delay with the failed-attempt count.");
+        });
+    }
+
+    [Test]
+    [CancelAfter(10_000)]
+    public async Task exponential_backoff_is_applied_between_async_attempts(CancellationToken ct)
+    {
+        int executions = 0;
+        Graph graph = GraphBuilder
+            .StartWithAsync(_ => ++executions < 4 ? ResultHelpers.Failure : ResultHelpers.Success)
+            .Retry(maxAttempts: 4, backoff: TimeSpan.FromMilliseconds(20), backoffKind: BackoffKind.Exponential)
+            .Build();
+
+        Stopwatch sw = Stopwatch.StartNew();
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync(ct);
+        sw.Stop();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(executions, Is.EqualTo(4));
+            // Three failed attempts → exponential delays of 20, 40, 80 ms = 140 ms total.
+            Assert.That(sw.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(105),
+                "Exponential backoff must double the machine-level delay per failed attempt.");
+        });
+    }
+
     [Test]
     public void sync_node_failing_twice_then_succeeding_completes()
     {

--- a/NxGraph.Tests/StateObservationTests.cs
+++ b/NxGraph.Tests/StateObservationTests.cs
@@ -9,7 +9,7 @@ namespace NxGraph.Tests;
 [Category("state_observation")]
 public class StateObservationTests
 {
-    private class FsmObserver : IAsyncStateMachineObserver
+    private sealed class FsmObserver : IAsyncStateMachineObserver
     {
         public readonly List<string> ObservedStates = [];
 

--- a/NxGraph.Tests/StateObservationTests.cs
+++ b/NxGraph.Tests/StateObservationTests.cs
@@ -93,7 +93,9 @@ public class StateObservationTests
 
         await fsm.ExecuteAsync();
 
-        Assert.That(observer.ObservedStates, Is.EquivalentTo(Expected));
+        // Sequence-equal on purpose: the observer contract is the exact event order,
+        // not the event multiset.
+        Assert.That(observer.ObservedStates, Is.EqualTo(Expected));
     }
 
     [Test]

--- a/NxGraph.Tests/StatusTransitionTests.cs
+++ b/NxGraph.Tests/StatusTransitionTests.cs
@@ -26,7 +26,7 @@ public class StatusTransitionTests
     }
 
     [Test]
-    public async Task status_sets_cancelled_on_cancellation()
+    public void status_sets_cancelled_on_cancellation()
     {
         CancellationTokenSource cts = new(10);
         AsyncStateMachine fsm = GraphBuilder
@@ -34,10 +34,10 @@ public class StatusTransitionTests
             .ToAsyncStateMachine();
         fsm.SetAutoReset(false);
 
+        // The timed cts (10 ms) does the cancelling while the machine awaits; by the time
+        // the assertion completes the token has already fired.
         Assert.That(async () => await fsm.ExecuteAsync(cts.Token),
             Throws.InstanceOf<OperationCanceledException>());
-
-        await cts.CancelAsync();
 
         Assert.That(fsm.Status, Is.EqualTo(ExecutionStatus.Cancelled));
     }

--- a/NxGraph.Tests/SwitchStateTests.cs
+++ b/NxGraph.Tests/SwitchStateTests.cs
@@ -51,4 +51,71 @@ public class SwitchStateTests
         Result result = await fsm.ExecuteAsync();
         Assert.That(result, Is.EqualTo(Result.Success));
     }
+
+    // ── Sync-runtime twins: dispatch driven by StateMachine.Execute() ────
+
+    [Test]
+    public void sync_switch_state_should_follow_matching_case()
+    {
+        const Mode mode = Mode.B;
+        bool matchedCaseRan = false;
+
+        StateMachine fsm = GraphBuilder
+            .Start()
+            .Switch(() => mode)
+            .Case(Mode.A, () => Result.Failure)
+            .Case(Mode.B, () =>
+            {
+                matchedCaseRan = true;
+                return Result.Success;
+            })
+            .Case(Mode.C, () => Result.Failure)
+            .Default(() => Result.Failure)
+            .End()
+            .ToStateMachine();
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = fsm.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(matchedCaseRan, Is.True, "The sync runtime must route through the matching case body.");
+        });
+    }
+
+    [Test]
+    public void sync_switch_state_should_use_default_when_no_match()
+    {
+        const int selector = 99; // no matching case
+        bool defaultRan = false;
+
+        StateMachine fsm = GraphBuilder
+            .Start()
+            .Switch(() => selector)
+            .Case(0, () => Result.Failure)
+            .Case(1, () => Result.Failure)
+            .Default(() =>
+            {
+                defaultRan = true;
+                return Result.Success;
+            })
+            .End()
+            .ToStateMachine();
+
+        Result result = Result.InProgress;
+        while (result == Result.InProgress)
+        {
+            result = fsm.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(defaultRan, Is.True, "The sync runtime must route through the explicit default body.");
+        });
+    }
 }

--- a/NxGraph.Tests/TimeoutFaultModelTests.cs
+++ b/NxGraph.Tests/TimeoutFaultModelTests.cs
@@ -12,20 +12,25 @@ namespace NxGraph.Tests;
 [TestFixture]
 public class TimeoutFaultModelTests
 {
-    private static readonly Func<CancellationToken, ValueTask<Result>> HangForever =
+    // Hangs until cancelled, but bounded at 30 s rather than Timeout.InfiniteTimeSpan: if the
+    // timeout wrapper (or the token plumbing it relies on) regresses, the run goes red in
+    // bounded time instead of hanging the whole suite. The [CancelAfter] guards below (whose
+    // token is threaded into the machine) report the same regression much earlier.
+    private static readonly Func<CancellationToken, ValueTask<Result>> HangUntilCancelled =
         async ct =>
         {
-            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, ct);
+            await Task.Delay(TimeSpan.FromSeconds(30), ct);
             return Result.Success;
         };
 
     [Test]
-    public async Task timeout_routes_through_the_failure_edge()
+    [CancelAfter(10_000)]
+    public async Task timeout_routes_through_the_failure_edge(CancellationToken ct)
     {
         bool cleanupRan = false;
         Graph graph = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(30), HangForever, TimeoutBehavior.Fail)
+            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(30), HangUntilCancelled, TimeoutBehavior.Fail)
             .OnErrorAsync(_ =>
             {
                 cleanupRan = true;
@@ -33,7 +38,7 @@ public class TimeoutFaultModelTests
             })
             .Build();
 
-        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync(ct);
 
         Assert.Multiple(() =>
         {
@@ -43,17 +48,18 @@ public class TimeoutFaultModelTests
     }
 
     [Test]
-    public async Task timeout_is_retried_by_the_node_retry_policy()
+    [CancelAfter(10_000)]
+    public async Task timeout_is_retried_by_the_node_retry_policy(CancellationToken ct)
     {
         int executions = 0;
         Graph graph = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(30), async ct =>
+            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(30), async innerCt =>
             {
                 executions++;
                 if (executions < 2)
                 {
-                    await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, ct);
+                    await Task.Delay(TimeSpan.FromSeconds(30), innerCt); // bounded hang, see above
                 }
 
                 return Result.Success;
@@ -61,7 +67,7 @@ public class TimeoutFaultModelTests
             .Retry(maxAttempts: 2)
             .Build();
 
-        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync(ct);
 
         Assert.Multiple(() =>
         {
@@ -71,24 +77,26 @@ public class TimeoutFaultModelTests
     }
 
     [Test]
-    public async Task timeout_without_error_edge_still_fails_the_machine()
+    [CancelAfter(10_000)]
+    public async Task timeout_without_error_edge_still_fails_the_machine(CancellationToken ct)
     {
         Graph graph = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(30), HangForever, TimeoutBehavior.Fail)
+            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(30), HangUntilCancelled, TimeoutBehavior.Fail)
             .Build();
 
-        Result result = await graph.ToAsyncStateMachine().ExecuteAsync();
+        Result result = await graph.ToAsyncStateMachine().ExecuteAsync(ct);
         Assert.That(result, Is.EqualTo(Result.Failure));
     }
 
     [Test]
-    public async Task timeout_failure_carries_a_diagnostic_message()
+    [CancelAfter(10_000)]
+    public async Task timeout_failure_carries_a_diagnostic_message(CancellationToken ct)
     {
         AsyncTimeoutState state = new(
-            new AsyncRelayState(HangForever), TimeSpan.FromMilliseconds(30));
+            new AsyncRelayState(HangUntilCancelled), TimeSpan.FromMilliseconds(30));
 
-        Result result = await state.ExecuteAsync();
+        Result result = await state.ExecuteAsync(ct);
 
         Assert.Multiple(() =>
         {

--- a/NxGraph.Tests/TimeoutWrapperTests.cs
+++ b/NxGraph.Tests/TimeoutWrapperTests.cs
@@ -8,43 +8,43 @@ namespace NxGraph.Tests;
 public class TimeoutWrapperTests
 {
     [Test]
-    [Timeout(5000)]
-    public async Task returns_failure_when_inner_exceeds_timeout_by_default()
+    [CancelAfter(10_000)]
+    public async Task returns_failure_when_inner_exceeds_timeout_by_default(CancellationToken ct)
     {
         AsyncStateMachine fsm = GraphBuilder
             .Start()
             .ToWithTimeoutAsync(100.Milliseconds(), new AsyncRelayState(
-                    async ct =>
+                    async innerCt =>
                     {
-                        await Task.Delay(1000, ct);
+                        await Task.Delay(1000, innerCt);
                         return Result.Success;
                     }), TimeoutBehavior.Fail
             )
             .ToAsyncStateMachine();
 
-        Result result = await fsm.ExecuteAsync();
+        Result result = await fsm.ExecuteAsync(ct);
         Assert.That(result, Is.EqualTo(Result.Failure));
     }
 
     [Test]
-    [Timeout(5000)]
-    public void throws_timeoutexception_when_behavior_is_throw()
+    [CancelAfter(10_000)]
+    public void throws_timeoutexception_when_behavior_is_throw(CancellationToken ct)
     {
         AsyncStateMachine throwing = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(100), new AsyncRelayState(async ct =>
+            .ToWithTimeoutAsync(TimeSpan.FromMilliseconds(100), new AsyncRelayState(async innerCt =>
                 {
-                    await Task.Delay(1000, ct);
+                    await Task.Delay(1000, innerCt);
                     return Result.Success;
                 }),
                 TimeoutBehavior.Throw)
             .ToAsyncStateMachine();
 
-        Assert.ThrowsAsync<TimeoutException>(async () => await throwing.ExecuteAsync());
+        Assert.ThrowsAsync<TimeoutException>(async () => await throwing.ExecuteAsync(ct));
     }
 
     [Test]
-    [Timeout(5000)]
+    [CancelAfter(10_000)]
     public void external_cancellation_wins_over_timeout()
     {
         using CancellationTokenSource cts = new(200); // cancel sooner than timeout
@@ -58,15 +58,12 @@ public class TimeoutWrapperTests
             }, TimeoutBehavior.Fail) // timeout later than external cancel
             .ToAsyncStateMachine();
 
-        Assert.ThrowsAsync<TaskCanceledException>(async () =>
-        {
-            await fsm.ExecuteAsync(cts.Token);
-            await cts.CancelAsync();
-        });
+        // The timed cts does the cancelling mid-run; every await in here is bounded, so a
+        // cancellation regression turns into a bounded assertion failure, never a hang.
+        Assert.ThrowsAsync<TaskCanceledException>(async () => await fsm.ExecuteAsync(cts.Token));
     }
 
     [Test]
-    [Timeout(5000)]
     public void rejects_non_positive_timeout_values()
     {
         // Using StartWithTimeout should throw when timeout <= 0
@@ -82,19 +79,19 @@ public class TimeoutWrapperTests
     }
 
     [Test]
-    [Timeout(5000)]
-    public async Task completes_successfully_if_inner_finishes_before_timeout()
+    [CancelAfter(10_000)]
+    public async Task completes_successfully_if_inner_finishes_before_timeout(CancellationToken ct)
     {
         AsyncStateMachine fsm = GraphBuilder
             .Start()
-            .ToWithTimeoutAsync(1.Seconds(), async ct =>
+            .ToWithTimeoutAsync(5.Seconds(), async innerCt =>
             {
-                await Task.Delay(50, ct); // finishes well before timeout
+                await Task.Delay(50, innerCt); // finishes well before the generous timeout
                 return Result.Success;
             }, TimeoutBehavior.Fail)
             .ToAsyncStateMachine();
 
-        Result result = await fsm.ExecuteAsync();
+        Result result = await fsm.ExecuteAsync(ct);
         Assert.That(result, Is.EqualTo(Result.Success));
     }
 }

--- a/NxGraph.Tests/Tokens/AsyncTokenMachineTests.cs
+++ b/NxGraph.Tests/Tokens/AsyncTokenMachineTests.cs
@@ -195,12 +195,64 @@ public class AsyncTokenMachineTests
     }
 
     [Test]
+    public async Task token_multiplicity_same_node_active_for_each_token()
+    {
+        int sharedRuns = 0;
+        JoinState merge = new(JoinPolicy.Any);
+        Fsm.Async.AsyncRelayState shared = new(_ =>
+        {
+            sharedRuns++;
+            return ResultHelpers.Success;
+        });
+
+        Graph graph = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success)
+            .ForkTo(
+                b => b.ToAsync(shared).To(merge),
+                // Same head instance dedupes to the same node — the chain past it is already
+                // wired by the first branch.
+                b => b.ToAsync(shared))
+            .Build();
+
+        Result result = await graph.ToAsyncTokenMachine().ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(sharedRuns, Is.EqualTo(2),
+                "Both fork branches dedupe to the same node; two tokens each execute it once.");
+        });
+    }
+
+    [Test]
+    public void pool_exhaustion_throws_and_fails_the_machine()
+    {
+        Graph graph = GraphBuilder.StartWithAsync(_ => ResultHelpers.Success)
+            .ForkTo(
+                b => b.ToAsync(_ => ResultHelpers.Success),
+                b => b.ToAsync(_ => ResultHelpers.Success),
+                b => b.ToAsync(_ => ResultHelpers.Success))
+            .Build();
+
+        AsyncTokenMachine machine = graph.ToAsyncTokenMachine(maxTokens: 2);
+        machine.SetRestartPolicy(RestartPolicy.Manual);
+
+        Assert.Multiple(() =>
+        {
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await machine.ExecuteAsync());
+            Assert.That(machine.Status, Is.EqualTo(ExecutionStatus.Failed));
+        });
+    }
+
+    [Test]
     public void cancellation_flows_out_and_cancels_the_machine()
     {
         using CancellationTokenSource cts = new();
+        // Bounded wait (30 s, not Timeout.InfiniteTimeSpan) as the hang backstop: if token
+        // plumbing regresses, the node completes and the assertions go red in bounded time
+        // instead of hanging the suite.
         Graph graph = GraphBuilder.StartWithAsync(async ct =>
             {
-                await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                await Task.Delay(TimeSpan.FromSeconds(30), ct);
                 return Result.Success;
             })
             .Build();

--- a/NxGraph.Tests/WaitStateExecutionTests.cs
+++ b/NxGraph.Tests/WaitStateExecutionTests.cs
@@ -10,7 +10,8 @@ namespace NxGraph.Tests;
 public class WaitStateExecutionTests
 {
     [Test]
-    public async Task wait_state_should_complete_after_delay()
+    [CancelAfter(10_000)]
+    public async Task wait_state_should_complete_after_delay(CancellationToken ct)
     {
         const int delay = 1;
         const float errorMargin = 0.5f;
@@ -21,18 +22,22 @@ public class WaitStateExecutionTests
             .ToAsyncStateMachine();
 
         Stopwatch stopwatch = Stopwatch.StartNew();
-        Result result = await fsm.ExecuteAsync();
+        Result result = await fsm.ExecuteAsync(ct);
         stopwatch.Stop();
         Assert.Multiple(() =>
         {
             Assert.That(result, Is.EqualTo(Result.Success));
-            Assert.That(stopwatch.Elapsed.TotalSeconds, Is.GreaterThanOrEqualTo(delay - errorMargin));
-            Assert.That(stopwatch.Elapsed.TotalSeconds, Is.LessThan(delay + errorMargin));
+            Assert.That(stopwatch.Elapsed.TotalSeconds, Is.GreaterThanOrEqualTo(delay - errorMargin),
+                "The wait state must actually wait out its configured delay.");
+            // Deliberately no upper bound: on a loaded CI agent the overshoot is unbounded,
+            // so an upper bound is pure flake. The [CancelAfter] guard (threaded into the
+            // machine) replaces it as the hang stop.
         });
     }
 
     [Test]
-    public async Task wait_state_should_handle_zero_delay_immediately()
+    [CancelAfter(10_000)]
+    public async Task wait_state_should_handle_zero_delay_immediately(CancellationToken ct)
     {
         AsyncStateMachine fsm = GraphBuilder
             .Start()
@@ -41,18 +46,22 @@ public class WaitStateExecutionTests
             .ToAsyncStateMachine();
 
         Stopwatch stopwatch = Stopwatch.StartNew();
-        Result result = await fsm.ExecuteAsync();
+        Result result = await fsm.ExecuteAsync(ct);
         stopwatch.Stop();
 
         Assert.Multiple(() =>
         {
             Assert.That(result, Is.EqualTo(Result.Success));
-            Assert.That(stopwatch.Elapsed.TotalMilliseconds, Is.LessThan(10)); // should be nearly immediate
+            // Generous budget instead of the old < 10 ms bound (which flakes on a cold or
+            // loaded runner): a zero wait must not take seconds; a regression to a real or
+            // infinite wait is caught here or by the [CancelAfter] guard.
+            Assert.That(stopwatch.Elapsed.TotalSeconds, Is.LessThan(5));
         });
     }
 
     [Test]
-    public async Task wait_state_should_handle_negative_delay_immediately()
+    [CancelAfter(10_000)]
+    public async Task wait_state_should_handle_negative_delay_immediately(CancellationToken ct)
     {
         AsyncStateMachine fsm = GraphBuilder
             .Start()
@@ -61,13 +70,15 @@ public class WaitStateExecutionTests
             .ToAsyncStateMachine();
 
         Stopwatch stopwatch = Stopwatch.StartNew();
-        Result result = await fsm.ExecuteAsync();
+        Result result = await fsm.ExecuteAsync(ct);
         stopwatch.Stop();
 
         Assert.Multiple(() =>
         {
             Assert.That(result, Is.EqualTo(Result.Success));
-            Assert.That(stopwatch.Elapsed.TotalMilliseconds, Is.LessThan(10)); // should be nearly immediate
+            // Same generous budget as the zero-delay test; a raw negative TimeSpan reaching
+            // Task.Delay would throw or wait forever — both caught without a tight bound.
+            Assert.That(stopwatch.Elapsed.TotalSeconds, Is.LessThan(5));
         });
     }
 

--- a/NxGraph/Authoring/Dsl.All.cs
+++ b/NxGraph/Authoring/Dsl.All.cs
@@ -70,7 +70,7 @@ public static partial class Dsl
     /// <c>Failure</c>. Wall-clock overlap is an async-only mechanic; the join semantics are the
     /// same, including no early abort: all works always run, even after an early <c>Failure</c>,
     /// so a graph moved between runtimes sees the same board effects. The node is plain
-    /// <see cref="Fsm.ILogic"/> and also runs under the async machine via the sync-logic adapter.
+    /// <see cref="Graphs.ILogic"/> and also runs under the async machine via the sync-logic adapter.
     /// <para>
     /// The disjoint-keys contract of the async twin is not load-bearing here (works never
     /// overlap), but keeping each work on its own keys makes the graph portable to

--- a/NxGraph/Behaviors/BehaviorState.cs
+++ b/NxGraph/Behaviors/BehaviorState.cs
@@ -157,6 +157,10 @@ internal static class BehaviorComposition
         return behaviors;
     }
 
+    // CA2208 suppressed for the two cold throw-helper factories below: ParamName names the
+    // *call sites'* `behaviors` parameter (every caller validates its own `behaviors` array);
+    // the analyzer's heuristic only sees the factory's own parameter list.
+#pragma warning disable CA2208
     internal static ArgumentException AgentEntryInUntyped(object entry, int index, string typedDsl)
     {
         return new ArgumentException(
@@ -184,6 +188,7 @@ internal static class BehaviorComposition
             $"'{entryAgent?.Name ?? "<unknown>"}' but this composite binds agent type " +
             $"'{compositeAgent.Name}'.", ParamName);
     }
+#pragma warning restore CA2208
 
     internal static bool SyncHasReporter(State state) =>
         state.SyncLogReport is not null || ((ILogReporter)state).LogReport is not null;

--- a/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
+++ b/NxGraph/Diagnostics/Export/MermaidGraphExporter.cs
@@ -37,8 +37,9 @@ public sealed class MermaidGraphExporter : IGraphExporter
 
         // Header
         string title = opts.Title ?? graph.Id.ToString();
-        sb.AppendLine($"%% NxGraph → Mermaid export: {EscapeComment(title)}");
-        sb.AppendLine($"flowchart {dir}");
+        // Append chains instead of interpolation: culture-neutral by construction (CA1305).
+        sb.Append("%% NxGraph → Mermaid export: ").AppendLine(EscapeComment(title));
+        sb.Append("flowchart ").AppendLine(dir);
 
         // Nodes
         for (int i = 0; i < graph.NodeCount; i++)

--- a/NxGraph/Diagnostics/Replay/StateMachineReplay.cs
+++ b/NxGraph/Diagnostics/Replay/StateMachineReplay.cs
@@ -1,4 +1,5 @@
-﻿using NxGraph.Graphs;
+﻿using NxGraph.Compatibility;
+using NxGraph.Graphs;
 
 namespace NxGraph.Diagnostics.Replay;
 
@@ -54,7 +55,7 @@ public class StateMachineReplay(ReadOnlySpan<ReplayEvent> events)
 
     public static ReplayEvent[] Deserialize(byte[] data)
     {
-        if (data is null) throw new ArgumentNullException(nameof(data));
+        Guard.NotNull(data, nameof(data));
 
         using MemoryStream ms = new(data);
         using BinaryReader reader = new(ms);

--- a/NxGraph/Fsm/AllState.cs
+++ b/NxGraph/Fsm/AllState.cs
@@ -16,7 +16,7 @@ namespace NxGraph.Fsm;
 /// work receives the machine-bound routed <see cref="BlackboardContext"/>; the disjoint-keys
 /// contract of the async twin is not load-bearing here (works never overlap) but keeping it
 /// makes the graph portable to <c>.ToAllAsync</c>. Allocation-free per tick: the works array
-/// is construction-time state. Being <see cref="ILogic"/>, this node also runs under the
+/// is construction-time state. Being <see cref="Graphs.ILogic"/>, this node also runs under the
 /// async machine via the sync-logic adapter.
 /// </para>
 /// </summary>

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -406,7 +406,9 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                 case ExecutionStatus.Cancelled:
                     break;
                 default:
-                    throw new IndexOutOfRangeException(nameof(status));
+                    // Unreachable enum-switch guard (CA2201: IndexOutOfRangeException is
+                    // runtime-reserved, so this defensive default uses a plain invalid-op).
+                    throw new InvalidOperationException($"Unexpected execution status '{status}'.");
             }
 
             // Own the transition to Resetting from whatever terminal state we observed.
@@ -640,10 +642,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
     /// </summary>
     public void Resume(StateMachineSnapshot snapshot)
     {
-        if (snapshot is null)
-        {
-            throw new ArgumentNullException(nameof(snapshot));
-        }
+        Guard.NotNull(snapshot, nameof(snapshot));
 
         if (Interlocked.Exchange(ref _executeGate, 1) == 1)
         {
@@ -718,10 +717,7 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
     /// </summary>
     public void ResumeDeep(StateMachineDeepSnapshot snapshot)
     {
-        if (snapshot is null)
-        {
-            throw new ArgumentNullException(nameof(snapshot));
-        }
+        Guard.NotNull(snapshot, nameof(snapshot));
 
         Resume(snapshot.Self);
         DeepSnapshots.ResumeComposites(Graph, snapshot.Composites);

--- a/NxGraph/Fsm/IDirector.cs
+++ b/NxGraph/Fsm/IDirector.cs
@@ -22,7 +22,7 @@ public interface IDirector
     /// <remarks>
     /// The default returns an empty sequence so existing user implementations compile
     /// unchanged — but those custom directors will be opaque to the validator and the
-    /// exporter. Built-in <see cref="ChoiceState"/> and <see cref="SwitchState"/>
+    /// exporter. Built-in <see cref="ChoiceState"/> and <see cref="SwitchState{TKey}"/>
     /// override this to surface their known targets.
     /// </remarks>
     IEnumerable<NodeId> EnumerateStaticTargets() => System.Array.Empty<NodeId>();

--- a/NxGraph/Fsm/RetryPolicy.cs
+++ b/NxGraph/Fsm/RetryPolicy.cs
@@ -54,8 +54,8 @@ public readonly struct RetryPolicy
 
     public BackoffKind BackoffKind { get; }
 
-    /// <summary>No retry policy — a failing node fails on its first attempt.</summary>
-    public static readonly RetryPolicy None = default;
+    /// <summary>No retry policy — a failing node fails on its first attempt (the zero-initialized default).</summary>
+    public static readonly RetryPolicy None;
 
     /// <summary>
     /// The delay to wait before the next attempt, given how many attempts have already failed.

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -397,7 +397,9 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
             case ExecutionStatus.Resetting:
                 break;
             default:
-                throw new IndexOutOfRangeException(nameof(status));
+                // Unreachable enum-switch guard (CA2201: IndexOutOfRangeException is
+                // runtime-reserved, so this defensive default uses a plain invalid-op).
+                throw new InvalidOperationException($"Unexpected execution status '{status}'.");
         }
 
         TransitionTo(ExecutionStatus.Resetting);
@@ -442,10 +444,7 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
     /// </summary>
     public void Resume(StateMachineSnapshot snapshot)
     {
-        if (snapshot is null)
-        {
-            throw new ArgumentNullException(nameof(snapshot));
-        }
+        Guard.NotNull(snapshot, nameof(snapshot));
 
         if (_reentranceGuard)
         {
@@ -517,10 +516,7 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
     /// </summary>
     public void ResumeDeep(StateMachineDeepSnapshot snapshot)
     {
-        if (snapshot is null)
-        {
-            throw new ArgumentNullException(nameof(snapshot));
-        }
+        Guard.NotNull(snapshot, nameof(snapshot));
 
         Resume(snapshot.Self);
         DeepSnapshots.ResumeComposites(Graph, snapshot.Composites);

--- a/NxGraph/Graphs/Graph.cs
+++ b/NxGraph/Graphs/Graph.cs
@@ -56,6 +56,12 @@ public sealed class Graph : INode, IGraph
     /// <param name="nodes">The array of nodes in the graph. Must be non-empty and start with the start node at index 0.</param>
     /// <param name="edges">The array of transitions (edges) in the graph. Must be non-empty and have the same length as the nodes array.</param>
     /// <param name="logic">The logic associated with the graph. If null, an empty logic is used.</param>
+    /// <param name="retryPolicies">Optional per-node retry policies indexed by <see cref="NodeId.Index"/>. Must match the nodes array length when provided; null when no node has a policy.</param>
+    /// <param name="outcomeCodes">Optional per-node terminal outcome codes indexed by <see cref="NodeId.Index"/>. Must match the nodes array length when provided; null when no node declares an outcome.</param>
+    /// <param name="outcomeNames">Optional display names for declared outcome codes, keyed by code.</param>
+    /// <param name="schema">Optional Graph-scoped blackboard schema declared for this graph (validated against machine-bound boards).</param>
+    /// <param name="globalSchema">Optional Global-scoped blackboard schema this graph requires from its host machine.</param>
+    /// <param name="nodeSchema">Optional Node-scoped blackboard schema for transient per-visit scratch (each machine owns its own board instance).</param>
     /// <param name="uids">Optional per-node stable UIDs indexed by <see cref="NodeId.Index"/> (<see cref="Guid.Empty"/> = unassigned). Must match the nodes array length when provided.</param>
     /// <exception cref="ArgumentException">Thrown when the nodes or edges arrays are empty, have unequal lengths, or the first node is not the start node.</exception>
     public Graph(NodeId id, INode[] nodes, Transition[] edges, IAsyncLogic? logic = null,

--- a/NxGraph/NxGraph.csproj
+++ b/NxGraph/NxGraph.csproj
@@ -1,20 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <!-- Common properties (LangVersion/Nullable/analyzers/package metadata) come from the
+         repo-root Directory.Build.props. -->
     <PropertyGroup>
         <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
-        <LangVersion>latest</LangVersion>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <!-- CS1591: XML docs are required only where they add value; missing-doc coverage is
+             tracked editorially, not as a build gate.
+             CA1000: static factories on generic types (SetValue&lt;T&gt;.Unbound,
+             BlackboardValue&lt;T&gt;.Bound, Repeat/AsyncRepeat&lt;TAgent&gt;.Unbound) are the
+             documented deserialization-rebind surface (specs 014/015); the type argument is
+             intrinsic to each factory, and the pattern recurs for every serializable behavior.
+             CA1051: the visible fields (machines' readonly Graph, generic state bases'
+             protected Agent) are deliberate hot-path surface guarded by the public-API
+             baseline; converting to properties is a breaking API change with no gain.
+             CA1716: observer interfaces use the domain-correct parameter names to/next
+             (OnTransition(from, to), StateMachineStatusChanged(..., next)); renaming would
+             break named-argument callers and the API baseline for a VB/F#-keyword concern
+             this library does not serve. -->
+        <NoWarn>$(NoWarn);CS1591;CA1000;CA1051;CA1716</NoWarn>
         <Title>NxGraph</Title>
-        <Authors>Moe Iraji</Authors>
         <Description>A lean, high-performance finite state machine (FSM) / stateflow library for .NET with a clean authoring DSL, strong validation, first-class observability, and export tools (Mermaid, tracing, replay). Designed for correctness on hot paths (allocation-free), production diagnostics, and pleasant authoring.</Description>
-        <PackageProjectUrl>https://github.com/Enzx/NxGraph</PackageProjectUrl>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/Enzx/NxGraph</RepositoryUrl>
         <PackageTags>statemachine fsm stateflow graph performance zero-allocation unity</PackageTags>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>Docs/readme.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>
@@ -25,7 +32,6 @@
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
         <Compile Include="Shims\**\*.cs" />
-        
     </ItemGroup>
     <ItemGroup>
         <None Include="Docs\readme.md" Pack="true" PackagePath="Docs\" />

--- a/NxGraph/Result.cs
+++ b/NxGraph/Result.cs
@@ -40,8 +40,10 @@ public readonly struct Result : IEquatable<Result>
         InProgress = 2,
 
         /// <inheritdoc cref="InProgress"/>
+#pragma warning disable CA1069 // Deliberate duplicate value: obsolete back-compat alias for InProgress.
         [Obsolete("Renamed to StatusCode.InProgress — 'Continue' read like a command rather than a status.")]
         Continue = 2,
+#pragma warning restore CA1069
     }
 
     // ── Static singletons ───────────────────────────────────────────────

--- a/NxGraph/ResultHelpers.cs
+++ b/NxGraph/ResultHelpers.cs
@@ -16,8 +16,9 @@ public static class ResultHelpers
     public static readonly ValueTask<Result> Failure = new(Result.Failure);
     /// <summary>
     /// Represents a completed operation with no meaningful result (e.g. for lifecycle events).
+    /// A zero-initialized <see cref="ValueTask"/> is already the completed task.
     /// </summary>
-    public static readonly ValueTask CompletedTask = default;
+    public static readonly ValueTask CompletedTask;
 
     /// <summary>
     /// Represents an in-progress (not yet finished) result.

--- a/NxGraph/Tokens/AsyncTokenMachine.cs
+++ b/NxGraph/Tokens/AsyncTokenMachine.cs
@@ -276,7 +276,9 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                 case ExecutionStatus.Cancelled:
                     break;
                 default:
-                    throw new IndexOutOfRangeException(nameof(status));
+                    // Unreachable enum-switch guard (CA2201: IndexOutOfRangeException is
+                    // runtime-reserved, so this defensive default uses a plain invalid-op).
+                    throw new InvalidOperationException($"Unexpected execution status '{status}'.");
             }
 
             if (!TryTransition(status, ExecutionStatus.Resetting, out ExecutionStatus previous))

--- a/NxGraph/Tokens/TokenMachine.cs
+++ b/NxGraph/Tokens/TokenMachine.cs
@@ -304,7 +304,9 @@ public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
             case ExecutionStatus.Resetting:
                 break;
             default:
-                throw new IndexOutOfRangeException(nameof(status));
+                // Unreachable enum-switch guard (CA2201: IndexOutOfRangeException is
+                // runtime-reserved, so this defensive default uses a plain invalid-op).
+                throw new InvalidOperationException($"Unexpected execution status '{status}'.");
         }
 
         TransitionTo(ExecutionStatus.Resetting);

--- a/README.md
+++ b/README.md
@@ -1186,7 +1186,7 @@ dotnet run --project NxGraph.Benchmarks -c Release
 
 ### Results
 
-> Runtime: .NET 8.0.26 (RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI) · BenchmarkDotNet v0.13.12 · ShortRun job · 2026-04-27
+> Runtime: .NET 8.0.27 (RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI) · BenchmarkDotNet v0.13.12 · ShortRun job · 2026-07-19. Indicative numbers from a dev machine — compare rows within this table, not across README revisions.
 
 ![Benchmark chart](docs/benchmarks.svg)
 
@@ -1194,32 +1194,34 @@ dotnet run --project NxGraph.Benchmarks -c Release
 
 | Scenario | Mean | Alloc |
 |---|---:|---:|
-| Single node (`RelayState.Success`) ★ | 199 ns | 0 B |
-| Single node + `NoopObserver` | 239 ns | 0 B |
-| Timeout wrapper (immediate success) | 330 ns | 0 B |
-| Chain × 10 nodes | 802 ns | 0 B |
-| Director-driven × 10 nodes | 856 ns | 0 B |
-| Chain × 50 nodes | 3,344 ns | 0 B |
+| Single node (`RelayState.Success`) ★ | 246 ns | 0 B |
+| Single node + `NoopObserver` | 301 ns | 0 B |
+| Timeout wrapper (immediate success) | 382 ns | 0 B |
+| Chain × 10 nodes | 1,107 ns | 0 B |
+| Director-driven × 10 nodes | 1,225 ns | 0 B |
+| Chain × 50 nodes | 4,851 ns | 0 B |
 
 **Sync `StateMachine`:**
 
 | Scenario | Mean | Alloc |
 |---|---:|---:|
-| Single node ★ | 24 ns | 0 B |
-| Single node + `SyncNoopObserver` | 27 ns | 0 B |
-| Chain × 10 nodes | 194 ns | 0 B |
-| Chain × 50 nodes | 979 ns | 0 B |
+| Single node ★ | 56 ns | 0 B |
+| Single node + `SyncNoopObserver` | 62 ns | 0 B |
+| Timeout wrapper (immediate success) | 69 ns | 0 B |
+| Chain × 10 nodes | 385 ns | 0 B |
+| Director-driven × 10 nodes | 467 ns | 0 B |
+| Chain × 50 nodes | 1,480 ns | 0 B |
 
 ★ baseline
 
 Key observations:
 
 - **Zero allocations**: both runtimes are fully alloc-free after graph construction.
-- **Sync is ~8× faster on a single node**: 24 ns vs 199 ns, reflecting the absence of async machinery and `Interlocked` operations.
-- **Observer overhead is constant** and runtime-dependent: +3 ns for sync, +40 ns for async, independent of chain length.
-- **Per-node cost falls with chain length**: async 199 ns for 1 node → 80 ns/node for 10 → 67 ns/node for 50.
-- **Sync per-node cost is consistent**: ~19 ns/node for both chain × 10 and chain × 50.
-- **Director nodes** add ~54 ns over a plain 10-node async chain.
+- **Sync is ~4× faster on a single node**: 56 ns vs 246 ns, reflecting the absence of async machinery and `Interlocked` operations.
+- **Observer overhead is constant** and runtime-dependent: +6 ns for sync, +55 ns for async, independent of chain length.
+- **Timeout wrapper overhead** mirrors the same split: +13 ns sync, +136 ns async over the bare single node.
+- **Per-node cost falls with chain length**: async 246 ns for 1 node → 111 ns/node for 10 → 97 ns/node for 50; sync 56 ns → 39 ns/node → 30 ns/node.
+- **Director nodes** add ~118 ns (async) / ~82 ns (sync) over the plain 10-node chain of the same runtime.
 
 ---
 

--- a/docs/benchmarks.svg
+++ b/docs/benchmarks.svg
@@ -1,9 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="490"
-     viewBox="0 0 820 490"
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="550"
+     viewBox="0 0 820 550"
      font-family="ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace">
 
   <!-- background -->
-  <rect width="820" height="490" fill="#fafafa" rx="4"/>
+  <rect width="820" height="550" fill="#fafafa" rx="4"/>
 
   <!-- title -->
   <text x="410" y="26" text-anchor="middle" font-size="13" font-weight="700" fill="#0f172a">
@@ -11,113 +11,119 @@
   </text>
 
   <!--
-    Chart area: x=260..790 (530px), log₂ scale from 4 (16 ns) to 12 (4096 ns)
-    scale = 530 / 8 = 66.25 px per log₂ unit
+    Chart area: x=260..790 (530px), log₂ scale from 4 (16 ns) to 13 (8192 ns)
+    scale = 530 / 9 = 58.889 px per log₂ unit
     Tick x positions:
-      16 ns=260  32=326  64=393  128=459  256=525  512=591  1024=658  2048=724  4096=790
-    Bar widths  (x = 260 + (log2(ns) - 4) * 66.25):
-      Sync  23.9 ns  w=38   x_end=298
-      Sync  27.4 ns  w=51   x_end=311
-      Sync  194 ns   w=239  x_end=499
-      Sync  979 ns   w=393  x_end=653
-      Async 199 ns   w=241  x_end=501
-      Async 239 ns   w=258  x_end=518
-      Async 330 ns   w=289  x_end=549
-      Async 802 ns   w=374  x_end=634
-      Async 856 ns   w=381  x_end=641
-      Async 3344 ns  w=511  x_end=771
+      16 ns=260  32=319  64=378  128=437  256=496  512=554  1024=613  2048=672  4096=731  8192=790
+    Bar widths  (w = (log2(ns) - 4) * 58.889):
+      Sync  56 ns    w=106   Async 246 ns    w=232
+      Sync  62 ns    w=115   Async 301 ns    w=249
+      Sync  69 ns    w=124   Async 382 ns    w=270
+      Sync  385 ns   w=270   Async 1107 ns   w=360
+      Sync  467 ns   w=287   Async 1225 ns   w=369
+      Sync  1480 ns  w=385   Async 4851 ns   w=485  x_end=745
   -->
 
   <!-- grid lines (dashed, one per power-of-2) -->
-  <line x1="260" y1="46" x2="260" y2="378" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="3,3"/>
-  <line x1="326" y1="46" x2="326" y2="378" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
-  <line x1="393" y1="46" x2="393" y2="378" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
-  <line x1="459" y1="46" x2="459" y2="378" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
-  <line x1="525" y1="46" x2="525" y2="378" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
-  <line x1="591" y1="46" x2="591" y2="378" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
-  <line x1="658" y1="46" x2="658" y2="378" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
-  <line x1="724" y1="46" x2="724" y2="378" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
-  <line x1="790" y1="46" x2="790" y2="378" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="260" y1="46" x2="260" y2="448" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="319" y1="46" x2="319" y2="448" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="378" y1="46" x2="378" y2="448" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="437" y1="46" x2="437" y2="448" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="496" y1="46" x2="496" y2="448" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="554" y1="46" x2="554" y2="448" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="613" y1="46" x2="613" y2="448" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="672" y1="46" x2="672" y2="448" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="731" y1="46" x2="731" y2="448" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="790" y1="46" x2="790" y2="448" stroke="#e2e8f0" stroke-width="1" stroke-dasharray="3,3"/>
 
   <!-- ═══ Group 1: Single Node ═══ -->
   <text x="258" y="46" text-anchor="end" font-size="9" fill="#94a3b8" font-style="italic">single node</text>
-  <rect x="260" y="50" width="38"  height="22" fill="#34d399" rx="2"/>
+  <rect x="260" y="50" width="106" height="22" fill="#34d399" rx="2"/>
   <text x="258" y="65" text-anchor="end" font-size="10" fill="#374151">Sync</text>
-  <text x="302" y="65" font-size="10" fill="#15803d" font-weight="600">24 ns</text>
-  <rect x="260" y="76" width="241" height="22" fill="#60a5fa" rx="2"/>
+  <text x="370" y="65" font-size="10" fill="#15803d" font-weight="600">56 ns</text>
+  <rect x="260" y="76" width="232" height="22" fill="#60a5fa" rx="2"/>
   <text x="258" y="91" text-anchor="end" font-size="10" fill="#374151">Async</text>
-  <text x="505" y="91" font-size="10" fill="#1d4ed8" font-weight="600">199 ns</text>
+  <text x="496" y="91" font-size="10" fill="#1d4ed8" font-weight="600">246 ns</text>
 
   <!-- ═══ Group 2: Single + Observer ═══ -->
   <text x="258" y="116" text-anchor="end" font-size="9" fill="#94a3b8" font-style="italic">single + observer</text>
-  <rect x="260" y="120" width="51"  height="22" fill="#34d399" rx="2"/>
+  <rect x="260" y="120" width="115" height="22" fill="#34d399" rx="2"/>
   <text x="258" y="135" text-anchor="end" font-size="10" fill="#374151">Sync</text>
-  <text x="315" y="135" font-size="10" fill="#15803d" font-weight="600">27 ns</text>
-  <rect x="260" y="146" width="258" height="22" fill="#60a5fa" rx="2"/>
+  <text x="379" y="135" font-size="10" fill="#15803d" font-weight="600">62 ns</text>
+  <rect x="260" y="146" width="249" height="22" fill="#60a5fa" rx="2"/>
   <text x="258" y="161" text-anchor="end" font-size="10" fill="#374151">Async</text>
-  <text x="522" y="161" font-size="10" fill="#1d4ed8" font-weight="600">239 ns</text>
+  <text x="513" y="161" font-size="10" fill="#1d4ed8" font-weight="600">301 ns</text>
 
-  <!-- ═══ Group 3: Chain × 10 ═══ -->
-  <text x="258" y="186" text-anchor="end" font-size="9" fill="#94a3b8" font-style="italic">chain × 10</text>
-  <rect x="260" y="190" width="239" height="22" fill="#34d399" rx="2"/>
+  <!-- ═══ Group 3: Timeout Wrapper (immediate success) ═══ -->
+  <text x="258" y="186" text-anchor="end" font-size="9" fill="#94a3b8" font-style="italic">timeout wrapper</text>
+  <rect x="260" y="190" width="124" height="22" fill="#34d399" rx="2"/>
   <text x="258" y="205" text-anchor="end" font-size="10" fill="#374151">Sync</text>
-  <text x="503" y="205" font-size="10" fill="#15803d" font-weight="600">194 ns</text>
-  <rect x="260" y="216" width="374" height="22" fill="#60a5fa" rx="2"/>
+  <text x="388" y="205" font-size="10" fill="#15803d" font-weight="600">69 ns</text>
+  <rect x="260" y="216" width="270" height="22" fill="#60a5fa" rx="2"/>
   <text x="258" y="231" text-anchor="end" font-size="10" fill="#374151">Async</text>
-  <text x="638" y="231" font-size="10" fill="#1d4ed8" font-weight="600">802 ns</text>
+  <text x="534" y="231" font-size="10" fill="#1d4ed8" font-weight="600">382 ns</text>
 
-  <!-- ═══ Group 4: Chain × 50 ═══ -->
-  <text x="258" y="256" text-anchor="end" font-size="9" fill="#94a3b8" font-style="italic">chain × 50</text>
-  <rect x="260" y="260" width="393" height="22" fill="#34d399" rx="2"/>
+  <!-- ═══ Group 4: Chain × 10 ═══ -->
+  <text x="258" y="256" text-anchor="end" font-size="9" fill="#94a3b8" font-style="italic">chain × 10</text>
+  <rect x="260" y="260" width="270" height="22" fill="#34d399" rx="2"/>
   <text x="258" y="275" text-anchor="end" font-size="10" fill="#374151">Sync</text>
-  <text x="657" y="275" font-size="10" fill="#15803d" font-weight="600">979 ns</text>
-  <!-- label inside bar: bar spans 260→771, near chart edge -->
-  <rect x="260" y="286" width="511" height="22" fill="#60a5fa" rx="2"/>
+  <text x="534" y="275" font-size="10" fill="#15803d" font-weight="600">385 ns</text>
+  <rect x="260" y="286" width="360" height="22" fill="#60a5fa" rx="2"/>
   <text x="258" y="301" text-anchor="end" font-size="10" fill="#374151">Async</text>
-  <text x="767" y="301" text-anchor="end" font-size="10" fill="#ffffff" font-weight="600">3,344 ns</text>
+  <text x="624" y="301" font-size="10" fill="#1d4ed8" font-weight="600">1,107 ns</text>
 
-  <!-- ═══ Group 5: Async-only ═══ -->
-  <text x="258" y="326" text-anchor="end" font-size="9" fill="#94a3b8" font-style="italic">async only</text>
-  <rect x="260" y="330" width="289" height="22" fill="#a78bfa" rx="2"/>
-  <text x="258" y="345" text-anchor="end" font-size="10" fill="#374151">Timeout</text>
-  <text x="553" y="345" font-size="10" fill="#6d28d9" font-weight="600">330 ns</text>
-  <rect x="260" y="356" width="381" height="22" fill="#a78bfa" rx="2"/>
-  <text x="258" y="371" text-anchor="end" font-size="10" fill="#374151">Director×10</text>
-  <text x="645" y="371" font-size="10" fill="#6d28d9" font-weight="600">856 ns</text>
+  <!-- ═══ Group 5: Director × 10 ═══ -->
+  <text x="258" y="326" text-anchor="end" font-size="9" fill="#94a3b8" font-style="italic">director × 10</text>
+  <rect x="260" y="330" width="287" height="22" fill="#34d399" rx="2"/>
+  <text x="258" y="345" text-anchor="end" font-size="10" fill="#374151">Sync</text>
+  <text x="551" y="345" font-size="10" fill="#15803d" font-weight="600">467 ns</text>
+  <rect x="260" y="356" width="369" height="22" fill="#60a5fa" rx="2"/>
+  <text x="258" y="371" text-anchor="end" font-size="10" fill="#374151">Async</text>
+  <text x="633" y="371" font-size="10" fill="#1d4ed8" font-weight="600">1,225 ns</text>
+
+  <!-- ═══ Group 6: Chain × 50 ═══ -->
+  <text x="258" y="396" text-anchor="end" font-size="9" fill="#94a3b8" font-style="italic">chain × 50</text>
+  <rect x="260" y="400" width="385" height="22" fill="#34d399" rx="2"/>
+  <text x="258" y="415" text-anchor="end" font-size="10" fill="#374151">Sync</text>
+  <text x="649" y="415" font-size="10" fill="#15803d" font-weight="600">1,480 ns</text>
+  <!-- label inside bar: widest bar, keep the value clear of the axis edge -->
+  <rect x="260" y="426" width="485" height="22" fill="#60a5fa" rx="2"/>
+  <text x="258" y="441" text-anchor="end" font-size="10" fill="#374151">Async</text>
+  <text x="741" y="441" text-anchor="end" font-size="10" fill="#ffffff" font-weight="600">4,851 ns</text>
 
   <!-- axis line -->
-  <line x1="260" y1="382" x2="790" y2="382" stroke="#64748b" stroke-width="1.5"/>
+  <line x1="260" y1="452" x2="790" y2="452" stroke="#64748b" stroke-width="1.5"/>
 
   <!-- axis ticks + labels -->
-  <line x1="260" y1="382" x2="260" y2="388" stroke="#64748b" stroke-width="1.5"/>
-  <text x="260" y="400" text-anchor="middle" font-size="10" fill="#64748b">16 ns</text>
-  <line x1="326" y1="382" x2="326" y2="388" stroke="#94a3b8" stroke-width="1"/>
-  <text x="326" y="400" text-anchor="middle" font-size="10" fill="#94a3b8">32</text>
-  <line x1="393" y1="382" x2="393" y2="388" stroke="#94a3b8" stroke-width="1"/>
-  <text x="393" y="400" text-anchor="middle" font-size="10" fill="#94a3b8">64</text>
-  <line x1="459" y1="382" x2="459" y2="388" stroke="#94a3b8" stroke-width="1"/>
-  <text x="459" y="400" text-anchor="middle" font-size="10" fill="#94a3b8">128</text>
-  <line x1="525" y1="382" x2="525" y2="388" stroke="#94a3b8" stroke-width="1"/>
-  <text x="525" y="400" text-anchor="middle" font-size="10" fill="#94a3b8">256</text>
-  <line x1="591" y1="382" x2="591" y2="388" stroke="#94a3b8" stroke-width="1"/>
-  <text x="591" y="400" text-anchor="middle" font-size="10" fill="#94a3b8">512</text>
-  <line x1="658" y1="382" x2="658" y2="388" stroke="#94a3b8" stroke-width="1"/>
-  <text x="658" y="400" text-anchor="middle" font-size="10" fill="#64748b">1 µs</text>
-  <line x1="724" y1="382" x2="724" y2="388" stroke="#94a3b8" stroke-width="1"/>
-  <text x="724" y="400" text-anchor="middle" font-size="10" fill="#94a3b8">2 µs</text>
-  <line x1="790" y1="382" x2="790" y2="388" stroke="#94a3b8" stroke-width="1"/>
-  <text x="790" y="400" text-anchor="middle" font-size="10" fill="#94a3b8">4 µs</text>
+  <line x1="260" y1="452" x2="260" y2="458" stroke="#64748b" stroke-width="1.5"/>
+  <text x="260" y="470" text-anchor="middle" font-size="10" fill="#64748b">16 ns</text>
+  <line x1="319" y1="452" x2="319" y2="458" stroke="#94a3b8" stroke-width="1"/>
+  <text x="319" y="470" text-anchor="middle" font-size="10" fill="#94a3b8">32</text>
+  <line x1="378" y1="452" x2="378" y2="458" stroke="#94a3b8" stroke-width="1"/>
+  <text x="378" y="470" text-anchor="middle" font-size="10" fill="#94a3b8">64</text>
+  <line x1="437" y1="452" x2="437" y2="458" stroke="#94a3b8" stroke-width="1"/>
+  <text x="437" y="470" text-anchor="middle" font-size="10" fill="#94a3b8">128</text>
+  <line x1="496" y1="452" x2="496" y2="458" stroke="#94a3b8" stroke-width="1"/>
+  <text x="496" y="470" text-anchor="middle" font-size="10" fill="#94a3b8">256</text>
+  <line x1="554" y1="452" x2="554" y2="458" stroke="#94a3b8" stroke-width="1"/>
+  <text x="554" y="470" text-anchor="middle" font-size="10" fill="#94a3b8">512</text>
+  <line x1="613" y1="452" x2="613" y2="458" stroke="#94a3b8" stroke-width="1"/>
+  <text x="613" y="470" text-anchor="middle" font-size="10" fill="#64748b">1 µs</text>
+  <line x1="672" y1="452" x2="672" y2="458" stroke="#94a3b8" stroke-width="1"/>
+  <text x="672" y="470" text-anchor="middle" font-size="10" fill="#94a3b8">2 µs</text>
+  <line x1="731" y1="452" x2="731" y2="458" stroke="#94a3b8" stroke-width="1"/>
+  <text x="731" y="470" text-anchor="middle" font-size="10" fill="#94a3b8">4 µs</text>
+  <line x1="790" y1="452" x2="790" y2="458" stroke="#94a3b8" stroke-width="1"/>
+  <text x="790" y="470" text-anchor="middle" font-size="10" fill="#94a3b8">8 µs</text>
 
   <!-- legend -->
-  <rect x="215" y="418" width="13" height="12" fill="#34d399" rx="2"/>
-  <text x="232" y="429" font-size="11" fill="#374151">Sync StateMachine (0 B)</text>
-  <rect x="430" y="418" width="13" height="12" fill="#60a5fa" rx="2"/>
-  <text x="447" y="429" font-size="11" fill="#374151">Async StateMachine (0 B)</text>
-  <rect x="650" y="418" width="13" height="12" fill="#a78bfa" rx="2"/>
-  <text x="667" y="429" font-size="11" fill="#374151">Async extras</text>
+  <rect x="250" y="488" width="13" height="12" fill="#34d399" rx="2"/>
+  <text x="267" y="499" font-size="11" fill="#374151">Sync StateMachine (0 B)</text>
+  <rect x="470" y="488" width="13" height="12" fill="#60a5fa" rx="2"/>
+  <text x="487" y="499" font-size="11" fill="#374151">Async StateMachine (0 B)</text>
 
   <!-- footer -->
-  <text x="410" y="462" text-anchor="middle" font-size="10" fill="#94a3b8">
-    Runtime: .NET 8.0.26 · RyuJIT AVX-512 · 2026-04-27
+  <text x="410" y="530" text-anchor="middle" font-size="10" fill="#94a3b8">
+    Runtime: .NET 8.0.27 · RyuJIT AVX-512 · 2026-07-19
   </text>
 </svg>

--- a/upm/com.enzx.nxgraph/CHANGELOG.md
+++ b/upm/com.enzx.nxgraph/CHANGELOG.md
@@ -18,7 +18,8 @@ All notable changes to this package will be documented in this file.
 - Source staging now includes the `Tokens` folder (the source-mode package could not compile without it after the token runtime landed).
 - Staging documentation now describes the actual mechanism (`dotnet run --project NxGraph.Build -- stage-source|stage-binary`); the previously referenced `scripts/build-upm.ps1` no longer exists.
 - Source staging now includes the `Blackboards` and `Shims` folders (the source-mode package could not compile without them).
-- Refreshed the staged binary (`Runtime/Plugins/NxGraph.dll`) — the previously committed DLL was a stale 1.0.0 build predating failure edges, suspend/resume, parallel composites, and blackboards.
+- Staged binaries are no longer committed to `main` (`Runtime/**` build outputs are git-ignored); each release rebuilds and stages `Runtime/Plugins/NxGraph.dll` in CI, retiring the previously committed stale 1.0.0 build that predated failure edges, suspend/resume, parallel composites, and blackboards.
+- Versioning policy: the committed `package.json` always carries the **last released** version; the release workflow (`upm-patch-version`) stamps the same value at release time. Bumping the manifest is part of the release checklist (see `NxGraph.Build/README.md`).
 - Aligned the assembly definition name (`NxGraph.Unity.Runtime`) with its file name.
 - Install instructions now point at the released `upm` branch/tags instead of the main-branch package folder.
 

--- a/upm/com.enzx.nxgraph/package.json
+++ b/upm/com.enzx.nxgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.enzx.nxgraph",
   "displayName": "NxGraph",
-  "version": "2.0.1-alpha",
+  "version": "2.1.0-alpha",
   "description": "A lean, high-performance finite state machine / stateflow library for Unity with a fluent authoring DSL, validation, replay, and Mermaid export.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## What this does

**Test-suite hardening.** The three order-insensitive assertions on observer traces are now sequence-exact (all stayed green — the traces were already correct, the assertions were weaker than the contract). Wall-clock upper bounds are removed or widened with lower bounds kept, every unbounded-delay await gained a `[CancelAfter]` hang guard or a bounded delay, dead unreachable `CancelAsync` calls are gone, and Linear/Exponential retry backoff is now exercised end-to-end (lower-bound-only asserts; a fake-clock seam was considered and rejected — recorded in the fixture). The AllocationGate pins JIT tiering for determinism, folds four inline measure loops into the shared helpers, and gains nine cases (Switch dispatch, non-blackboard Choice, async token any-merge/retry/scratch, sync token observer, async timeout wrapper). `NxGraph.Serialization.Tests` converges on the NUnit 4 line, the last shared mutable static in the suite is gone, and sync Switch and async token pool/multiplicity coverage twins are added.

**A netstandard2.1 public-API baseline** (MetadataLoadContext walk over the built dll against the NETStandard.Library.Ref facades, `NxGraph.netstandard2.1.approved.txt`, same `NXGRAPH_UPDATE_PUBLIC_API=1` mechanism, skip-with-message on partial builds). It immediately caught a real finding: the `System.ArgumentNullExceptionShim` polyfill ships **public** in the netstandard2.1 (Unity-facing) build — now pinned by the baseline; internalizing it is a deliberate follow-up surface change.

**Delivery hardening.** A root `Directory.Build.props` centralizes language/analyzer/metadata props with .NET analyzers at `latest-recommended` and `TreatWarningsAsErrors=true` across all eight projects (all pre-existing warnings fixed; every `NoWarn` carries an in-file justification; `NxGraph.Build`'s props import the root so its `.tools/` isolation is preserved; SourceLink/determinism gate on CI env vars). The coverage gate runs on the single coverlet.msbuild driver — proven live: `COVERAGE_THRESHOLD=99` fails ci with the threshold error, default 70 passes with NxGraph at 80.93% line coverage; the CI artifact now uploads the same driver's lcov output. `NUGET_API_KEY` is no longer echoed on local publishes (redacted command line, including in failure text). Workflow actions are SHA-pinned with tag comments (checkout v4.3.1, setup-dotnet v4.3.1, upload-artifact v4.6.2, action-gh-release v2.6.2), the dispatch help lists all targets, and `REPO_BRANCH` is correct on tag builds. The committed UPM manifest now carries the last released version (2.1.0-alpha) with the policy recorded in the release checklist.

**Benchmark refresh.** Fairness fixes in the Stateless comparison (no `IterationSetup` on ns-scale ops, honest timeout analog, CSV exporter parity), sync Timeout/Director twins, and 14 new feature benchmarks (parallel round, dynamic selection, blackboard typed-key vs dictionary, token diamond, port relay, suspend/resume, Switch). The README table and chart are re-measured (ShortRun, 2026-07-19) on the combined tree of the open hardening PRs, so the published numbers describe main after they all land; a higher-precision A/B of the sync single node against pre-change main measured +2.4 ns (51.5 vs 49.1 ns), the expected cost of the per-visit report-slot hygiene introduced by the log-bridge PR, with longer chains inside noise.

## Verification

`dotnet build -c Release` fully clean under warnings-as-errors; 653 + 193 tests green at the branch tip; `dotnet run --project NxGraph.Build -- ci` green end-to-end at the default threshold and with `CI=true` (determinism props + baselines healthy together).

## Merge notes

**Land this PR last.** After the other three hardening PRs merge, update this branch from main — the combination was validated locally (full suite and ci green under warnings-as-errors on the merged tree; expected clean auto-merge, no conflicting regions).
