### PR TITLE
Observe director targets by their built ids and forward machine wiring through the timeout wrappers

### DIFF
--- a/NxGraph.Tests/DirectorTargetObservationTests.cs
+++ b/NxGraph.Tests/DirectorTargetObservationTests.cs
@@ -1,0 +1,276 @@
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// Observers must see the graph's <b>built</b> node ids — display names included — for every
+/// node a run enters, no matter how the machine got there. Ordinary edge destinations get
+/// their names applied at <c>Build()</c>, but director-selected targets (event dispatch,
+/// the plain-run <c>Otherwise</c> chain, choice/switch branches) are captured at authoring
+/// time, before names exist; the machines canonicalize them against the graph so
+/// <c>OnTransition</c>/<c>OnStateEntered</c>/<c>OnStateExited</c> report the same id an edge
+/// hop would.
+/// </summary>
+[TestFixture]
+public class DirectorTargetObservationTests
+{
+    private sealed record Ping(string Payload);
+
+    private static (Graph Graph, BlackboardSchema Schema, BlackboardKey<Ping> Key) EventGraph(
+        bool singleStepChain = false)
+    {
+        BlackboardSchema schema = new("events");
+        BlackboardKey<Ping> ping = schema.Register<Ping>("ping");
+
+        EventsToken token = GraphBuilder.StartWithEvents();
+        token = singleStepChain
+            ? token.On(ping, e => e.ToAsync(_ => ResultHelpers.Success).SetName("handle-ping"))
+            : token.On(ping, e => e
+                .ToAsync(_ => ResultHelpers.Success).SetName("handle-ping")
+                .ToAsync(_ => ResultHelpers.Success).SetName("after-ping"));
+
+        Graph graph = token
+            .Otherwise(e => e.ToAsync(_ => ResultHelpers.Success).SetName("manual"))
+            .WithSchema(schema)
+            .Build();
+        return (graph, schema, ping);
+    }
+
+    private static (Graph Graph, BlackboardSchema Schema, BlackboardKey<Ping> Key) SyncEventGraph()
+    {
+        BlackboardSchema schema = new("events");
+        BlackboardKey<Ping> ping = schema.Register<Ping>("ping");
+
+        Graph graph = GraphBuilder.StartWithEvents()
+            .On(ping, e => e
+                .To(() => Result.Success).SetName("handle-ping")
+                .To(() => Result.Success).SetName("after-ping"))
+            .Otherwise(e => e.To(() => Result.Success).SetName("manual"))
+            .WithSchema(schema)
+            .Build();
+        return (graph, schema, ping);
+    }
+
+    // ── Event dispatch (async) ───────────────────────────────────────────
+
+    [Test]
+    public async Task async_event_dispatch_target_is_observed_by_its_built_id()
+    {
+        (Graph graph, BlackboardSchema schema, BlackboardKey<Ping> ping) = EventGraph();
+        RecordingObserver observer = new();
+        AsyncStateMachine fsm = graph.ToAsyncStateMachine(observer).WithBlackboard(new Blackboard(schema));
+
+        await fsm.ExecuteAsync(new Ping("p-1"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observer.EnteredNames, Does.Contain("handle-ping"),
+                "The node the dispatch jumps to must be entered under its built id.");
+            Assert.That(observer.ExitedNames, Does.Contain("handle-ping"),
+                "The node the dispatch jumps to must be exited under its built id.");
+            Assert.That(observer.TransitionTargets, Does.Contain("handle-ping"),
+                "The dispatch transition must name the built target id.");
+            Assert.That(observer.EnteredNames, Does.Contain("after-ping"),
+                "Nodes after the dispatch target observe via the ordinary edge path.");
+        });
+    }
+
+    [Test]
+    public async Task async_single_step_entry_chain_observes_its_one_node()
+    {
+        (Graph graph, BlackboardSchema schema, BlackboardKey<Ping> ping) = EventGraph(singleStepChain: true);
+        RecordingObserver observer = new();
+        AsyncStateMachine fsm = graph.ToAsyncStateMachine(observer).WithBlackboard(new Blackboard(schema));
+
+        await fsm.ExecuteAsync(new Ping("p-1"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observer.EnteredNames, Does.Contain("handle-ping"));
+            Assert.That(observer.ExitedNames, Does.Contain("handle-ping"));
+        });
+    }
+
+    [Test]
+    public async Task async_plain_start_otherwise_target_is_observed_by_its_built_id()
+    {
+        (Graph graph, BlackboardSchema schema, _) = EventGraph();
+        RecordingObserver observer = new();
+        AsyncStateMachine fsm = graph.ToAsyncStateMachine(observer).WithBlackboard(new Blackboard(schema));
+
+        await fsm.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observer.EnteredNames, Does.Contain("manual"));
+            Assert.That(observer.ExitedNames, Does.Contain("manual"));
+        });
+    }
+
+    [Test]
+    public async Task async_stepped_event_dispatch_target_is_observed_by_its_built_id()
+    {
+        (Graph graph, BlackboardSchema schema, BlackboardKey<Ping> ping) = EventGraph();
+        RecordingObserver observer = new();
+        AsyncStateMachine fsm = graph.ToAsyncStateMachine(observer).WithBlackboard(new Blackboard(schema));
+
+        Result result = await fsm.StepAsync(new Ping("p-1"));
+        while (result == Result.InProgress)
+        {
+            result = await fsm.StepAsync();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observer.EnteredNames, Does.Contain("handle-ping"));
+            Assert.That(observer.ExitedNames, Does.Contain("handle-ping"));
+        });
+    }
+
+    // ── Event dispatch (sync twin) ───────────────────────────────────────
+
+    [Test]
+    public void sync_event_dispatch_target_is_observed_by_its_built_id()
+    {
+        (Graph graph, BlackboardSchema schema, BlackboardKey<Ping> ping) = SyncEventGraph();
+        SyncRecordingObserver observer = new();
+        StateMachine fsm = graph.ToStateMachine(observer);
+        fsm.SetBlackboard(new Blackboard(schema));
+
+        Result result = fsm.Execute(new Ping("p-1"));
+        while (result == Result.InProgress)
+        {
+            result = fsm.Execute();
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observer.EnteredNames, Does.Contain("handle-ping"));
+            Assert.That(observer.ExitedNames, Does.Contain("handle-ping"));
+            Assert.That(observer.TransitionTargets, Does.Contain("handle-ping"));
+        });
+    }
+
+    [Test]
+    public void sync_plain_start_otherwise_target_is_observed_by_its_built_id()
+    {
+        (Graph graph, BlackboardSchema schema, _) = SyncEventGraph();
+        SyncRecordingObserver observer = new();
+        StateMachine fsm = graph.ToStateMachine(observer);
+        fsm.SetBlackboard(new Blackboard(schema));
+        fsm.SetStepMode(ParallelStepMode.RunToJoin);
+
+        fsm.Execute();
+
+        Assert.That(observer.EnteredNames, Does.Contain("manual"));
+    }
+
+    // ── Ordinary directors (choice) share the same contract ─────────────
+
+    [Test]
+    public async Task async_choice_branch_target_is_observed_by_its_built_id()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("ask")
+            .If(() => true)
+            .Then(() => Result.Success).SetName("yes")
+            .Else(() => Result.Success).SetName("no")
+            .Build();
+        RecordingObserver observer = new();
+        AsyncStateMachine fsm = graph.ToAsyncStateMachine(observer);
+
+        await fsm.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observer.EnteredNames, Does.Contain("yes"));
+            Assert.That(observer.ExitedNames, Does.Contain("yes"));
+        });
+    }
+
+    [Test]
+    public void sync_choice_branch_target_is_observed_by_its_built_id()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("ask")
+            .If(() => true)
+            .Then(() => Result.Success).SetName("yes")
+            .Else(() => Result.Success).SetName("no")
+            .Build();
+        SyncRecordingObserver observer = new();
+        StateMachine fsm = graph.ToStateMachine(observer);
+        fsm.SetStepMode(ParallelStepMode.RunToJoin);
+
+        fsm.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observer.EnteredNames, Does.Contain("yes"));
+            Assert.That(observer.ExitedNames, Does.Contain("yes"));
+        });
+    }
+
+    // ── Plain single-node graph (spec pin: entry observation on a plain start) ──
+
+    [Test]
+    public async Task async_single_node_graph_observes_its_one_node()
+    {
+        Graph graph = GraphBuilder
+            .StartWith(() => Result.Success).SetName("only")
+            .Build();
+        RecordingObserver observer = new();
+        AsyncStateMachine fsm = graph.ToAsyncStateMachine(observer);
+
+        await fsm.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(observer.EnteredNames, Is.EqualTo(new[] { "only" }));
+            Assert.That(observer.ExitedNames, Is.EqualTo(new[] { "only" }));
+        });
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private sealed class RecordingObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> EnteredNames = [];
+        public readonly List<string> ExitedNames = [];
+        public readonly List<string> TransitionTargets = [];
+
+        public ValueTask OnStateEntered(NodeId id, CancellationToken ct = default)
+        {
+            EnteredNames.Add(id.Name);
+            return default;
+        }
+
+        public ValueTask OnStateExited(NodeId id, CancellationToken ct = default)
+        {
+            ExitedNames.Add(id.Name);
+            return default;
+        }
+
+        public ValueTask OnTransition(NodeId from, NodeId to, CancellationToken ct = default)
+        {
+            TransitionTargets.Add(to.Name);
+            return default;
+        }
+    }
+
+    private sealed class SyncRecordingObserver : IStateMachineObserver
+    {
+        public readonly List<string> EnteredNames = [];
+        public readonly List<string> ExitedNames = [];
+        public readonly List<string> TransitionTargets = [];
+
+        void IStateMachineObserver.OnStateEntered(NodeId id) => EnteredNames.Add(id.Name);
+
+        void IStateMachineObserver.OnStateExited(NodeId id) => ExitedNames.Add(id.Name);
+
+        void IStateMachineObserver.OnTransition(NodeId from, NodeId to) => TransitionTargets.Add(to.Name);
+    }
+}

--- a/NxGraph.Tests/PublicApi/NxGraph.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.approved.txt
@@ -639,7 +639,7 @@ sealed class NxGraph.Fsm.Async.AsyncSwitchState`1 : NxGraph.Blackboards.IBlackbo
   method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
   method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
-class NxGraph.Fsm.Async.AsyncTimeoutState : NxGraph.Graphs.IAsyncLogic
+class NxGraph.Fsm.Async.AsyncTimeoutState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ILogicWrapper
   ctor Void .ctor(NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
 static class NxGraph.Fsm.Async.AsyncWait
@@ -884,7 +884,7 @@ sealed class NxGraph.Fsm.SwitchState`1 : NxGraph.Blackboards.IBlackboardSettable
 enum NxGraph.Fsm.TimeoutBehavior : System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
   Fail = 0
   Throw = 1
-sealed class NxGraph.Fsm.TimeoutState : NxGraph.Graphs.ILogic
+sealed class NxGraph.Fsm.TimeoutState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.ILogic, NxGraph.Graphs.ILogicWrapper
   ctor Void .ctor(NxGraph.Graphs.ILogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
   ctor Void .ctor(NxGraph.Graphs.ILogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior, System.Func`1[System.Int64])
   method NxGraph.Result Execute()
@@ -944,6 +944,8 @@ interface NxGraph.Graphs.IGraph
   property NxGraph.Graphs.NodeId Id { get; }
 interface NxGraph.Graphs.ILogic
   method NxGraph.Result Execute()
+interface NxGraph.Graphs.ILogicWrapper
+  property System.Object WrappedLogic { get; }
 interface NxGraph.Graphs.INode
   property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
   property NxGraph.Graphs.ILogic Logic { get; }

--- a/NxGraph.Tests/PublicApi/NxGraph.netstandard2.1.approved.txt
+++ b/NxGraph.Tests/PublicApi/NxGraph.netstandard2.1.approved.txt
@@ -639,7 +639,7 @@ sealed class NxGraph.Fsm.Async.AsyncSwitchState`1 : NxGraph.Blackboards.IBlackbo
   method System.Collections.Generic.IEnumerable`1[NxGraph.Graphs.NodeId] EnumerateStaticTargets()
   method System.Threading.Tasks.ValueTask`1[NxGraph.Graphs.NodeId] SelectNextAsync(System.Threading.CancellationToken)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
-class NxGraph.Fsm.Async.AsyncTimeoutState : NxGraph.Graphs.IAsyncLogic
+class NxGraph.Fsm.Async.AsyncTimeoutState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.IAsyncLogic, NxGraph.Graphs.ILogicWrapper
   ctor System.Void .ctor(NxGraph.Graphs.IAsyncLogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
   method System.Threading.Tasks.ValueTask`1[NxGraph.Result] ExecuteAsync(System.Threading.CancellationToken)
 static class NxGraph.Fsm.Async.AsyncWait
@@ -884,7 +884,7 @@ sealed class NxGraph.Fsm.SwitchState`1 : NxGraph.Blackboards.IBlackboardSettable
 enum NxGraph.Fsm.TimeoutBehavior : System.IComparable, System.IConvertible, System.IFormattable
   Fail = 0
   Throw = 1
-sealed class NxGraph.Fsm.TimeoutState : NxGraph.Graphs.ILogic
+sealed class NxGraph.Fsm.TimeoutState : NxGraph.Blackboards.IBlackboardSettable, NxGraph.Graphs.ILogic, NxGraph.Graphs.ILogicWrapper
   ctor System.Void .ctor(NxGraph.Graphs.ILogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior)
   ctor System.Void .ctor(NxGraph.Graphs.ILogic, System.TimeSpan, NxGraph.Fsm.TimeoutBehavior, System.Func`1[System.Int64])
   method NxGraph.Result Execute()
@@ -933,6 +933,8 @@ interface NxGraph.Graphs.IGraph
   property System.Int32 TransitionCount { get; }
 interface NxGraph.Graphs.ILogic
   method NxGraph.Result Execute()
+interface NxGraph.Graphs.ILogicWrapper
+  property System.Object WrappedLogic { get; }
 interface NxGraph.Graphs.INode
   property NxGraph.Graphs.IAsyncLogic AsyncLogic { get; }
   property NxGraph.Graphs.ILogic Logic { get; }

--- a/NxGraph.Tests/TimeoutWiringForwardingTests.cs
+++ b/NxGraph.Tests/TimeoutWiringForwardingTests.cs
@@ -1,0 +1,253 @@
+using NxGraph.Authoring;
+using NxGraph.Blackboards;
+using NxGraph.Fsm;
+using NxGraph.Fsm.Async;
+using NxGraph.Graphs;
+
+namespace NxGraph.Tests;
+
+/// <summary>
+/// The timeout wrappers are transparent to machine wiring: the blackboard context, the
+/// log-report channel, and the agent stamped by the machine must reach the state inside
+/// <see cref="AsyncTimeoutState"/>/<see cref="TimeoutState"/> exactly as they reach a bare
+/// state. Before this contract, the wiring stopped at the wrapper — a blackboard-using state
+/// inside a timeout silently lost its board and report context, and an agent-taking state
+/// made <c>SetAgent</c> throw "no nodes implement IAgentSettable".
+/// </summary>
+[TestFixture]
+public class TimeoutWiringForwardingTests
+{
+    private sealed class TestAgent
+    {
+        public string Name = "";
+    }
+
+    // ── Async wrapper ────────────────────────────────────────────────────
+
+    [Test]
+    public async Task board_reaches_state_wrapped_in_async_timeout()
+    {
+        BlackboardSchema schema = new("wiring");
+        BlackboardKey<string> key = schema.Register<string>("value", "");
+        BoardReadingAsyncState inner = new(key);
+
+        Graph graph = GraphBuilder.Start()
+            .ToWithTimeoutAsync(TimeSpan.FromSeconds(5), inner)
+            .WithSchema(schema)
+            .Build();
+
+        Blackboard board = new(schema);
+        board.Set(key, "board-reached");
+        AsyncStateMachine fsm = graph.ToAsyncStateMachine().WithBlackboard(board);
+
+        Result result = await fsm.ExecuteAsync();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(inner.Seen, Is.EqualTo("board-reached"),
+                "The machine-bound board must reach the state inside the timeout wrapper.");
+        });
+    }
+
+    [Test]
+    public async Task log_report_from_state_wrapped_in_async_timeout_reaches_observer()
+    {
+        LoggingAsyncState inner = new("from-inside-timeout");
+        Graph graph = GraphBuilder.Start()
+            .ToWithTimeoutAsync(TimeSpan.FromSeconds(5), inner)
+            .Build();
+
+        LogRecordingObserver observer = new();
+        AsyncStateMachine fsm = graph.ToAsyncStateMachine(observer);
+
+        await fsm.ExecuteAsync();
+
+        Assert.That(observer.Messages, Is.EqualTo(new[] { "from-inside-timeout" }),
+            "A log report from inside the timeout wrapper must reach the machine's observer.");
+    }
+
+    [Test]
+    public async Task agent_reaches_state_wrapped_in_async_timeout()
+    {
+        AgentReadingAsyncState inner = new();
+        Graph graph = GraphBuilder.Start()
+            .ToWithTimeoutAsync(TimeSpan.FromSeconds(5), inner)
+            .Build();
+
+        AsyncStateMachine<TestAgent> fsm = graph.ToAsyncStateMachine<TestAgent>();
+        TestAgent agent = new() { Name = "agent-reached" };
+
+        Assert.DoesNotThrow(() => fsm.SetAgent(agent),
+            "An agent-taking state inside a timeout wrapper must count as an agent acceptor.");
+        await fsm.ExecuteAsync();
+
+        Assert.That(inner.Seen, Is.SameAs(agent));
+    }
+
+    // ── Sync twin ────────────────────────────────────────────────────────
+
+    [Test]
+    public void board_reaches_state_wrapped_in_sync_timeout()
+    {
+        BlackboardSchema schema = new("wiring");
+        BlackboardKey<string> key = schema.Register<string>("value", "");
+        BoardReadingState inner = new(key);
+
+        Graph graph = GraphBuilder.Start()
+            .ToWithTimeout(TimeSpan.FromSeconds(5), inner)
+            .WithSchema(schema)
+            .Build();
+
+        Blackboard board = new(schema);
+        board.Set(key, "board-reached");
+        StateMachine fsm = graph.ToStateMachine();
+        fsm.SetBlackboard(board);
+        fsm.SetStepMode(ParallelStepMode.RunToJoin);
+
+        Result result = fsm.Execute();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo(Result.Success));
+            Assert.That(inner.Seen, Is.EqualTo("board-reached"));
+        });
+    }
+
+    [Test]
+    public void log_report_from_state_wrapped_in_sync_timeout_reaches_observer()
+    {
+        LoggingState inner = new("from-inside-timeout");
+        Graph graph = GraphBuilder.Start()
+            .ToWithTimeout(TimeSpan.FromSeconds(5), inner)
+            .Build();
+
+        LogRecordingSyncObserver observer = new();
+        StateMachine fsm = graph.ToStateMachine(observer);
+        fsm.SetStepMode(ParallelStepMode.RunToJoin);
+
+        fsm.Execute();
+
+        Assert.That(observer.Messages, Is.EqualTo(new[] { "from-inside-timeout" }));
+    }
+
+    [Test]
+    public void agent_reaches_state_wrapped_in_sync_timeout()
+    {
+        AgentReadingState inner = new();
+        Graph graph = GraphBuilder.Start()
+            .ToWithTimeout(TimeSpan.FromSeconds(5), inner)
+            .Build();
+
+        StateMachine<TestAgent> fsm = graph.ToStateMachine<TestAgent>();
+        fsm.SetStepMode(ParallelStepMode.RunToJoin);
+        TestAgent agent = new() { Name = "agent-reached" };
+
+        Assert.DoesNotThrow(() => fsm.SetAgent(agent));
+        fsm.Execute();
+
+        Assert.That(inner.Seen, Is.SameAs(agent));
+    }
+
+    // ── The wrapped state keeps behaving like a bare one under the async machine ──
+
+    [Test]
+    public async Task sync_state_wrapped_in_sync_timeout_reports_under_the_async_machine()
+    {
+        // The bridge case: a sync State inside the sync TimeoutState, run by the async
+        // machine behind the sync-logic adapter — State.Log must still reach the observer.
+        LoggingState inner = new("bridged-report");
+        Graph graph = GraphBuilder.Start()
+            .ToWithTimeout(TimeSpan.FromSeconds(5), inner)
+            .Build();
+
+        LogRecordingObserver observer = new();
+        AsyncStateMachine fsm = graph.ToAsyncStateMachine(observer);
+
+        await fsm.ExecuteAsync();
+
+        Assert.That(observer.Messages, Is.EqualTo(new[] { "bridged-report" }));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private sealed class BoardReadingAsyncState(BlackboardKey<string> key) : AsyncState
+    {
+        public string? Seen;
+
+        protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+        {
+            Seen = Bb.Get(key);
+            return ResultHelpers.Success;
+        }
+    }
+
+    private sealed class LoggingAsyncState(string message) : AsyncState
+    {
+        protected override async ValueTask<Result> OnRunAsync(CancellationToken ct)
+        {
+            await LogAsync(message, ct);
+            return Result.Success;
+        }
+    }
+
+    private sealed class AgentReadingAsyncState : AsyncState<TestAgent>
+    {
+        public TestAgent? Seen;
+
+        protected override ValueTask<Result> OnRunAsync(CancellationToken ct)
+        {
+            Seen = Agent;
+            return ResultHelpers.Success;
+        }
+    }
+
+    private sealed class BoardReadingState(BlackboardKey<string> key) : State
+    {
+        public string? Seen;
+
+        protected override Result OnRun()
+        {
+            Seen = Bb.Get(key);
+            return Result.Success;
+        }
+    }
+
+    private sealed class LoggingState(string message) : State
+    {
+        protected override Result OnRun()
+        {
+            Log(message);
+            return Result.Success;
+        }
+    }
+
+    private sealed class AgentReadingState : State<TestAgent>
+    {
+        public TestAgent? Seen;
+
+        protected override Result OnRun()
+        {
+            Seen = Agent;
+            return Result.Success;
+        }
+    }
+
+    private sealed class LogRecordingObserver : IAsyncStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+
+        public ValueTask OnLogReport(NodeId nodeId, string message, CancellationToken ct = default)
+        {
+            Messages.Add(message);
+            return default;
+        }
+    }
+
+    private sealed class LogRecordingSyncObserver : IStateMachineObserver
+    {
+        public readonly List<string> Messages = [];
+
+        void IStateMachineObserver.OnLogReport(NodeId nodeId, string message) => Messages.Add(message);
+    }
+}

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -333,7 +333,12 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
         {
             if (graph.TryGetNodeByIndex(i, out INode? node) && node is LogicNode logicNode)
             {
-                table[i] = logicNode.AsyncLogic as ILogReporter ?? logicNode.Logic as ILogReporter;
+                // Decorator logic (timeout wrappers) hides the reporter it wraps — resolve
+                // through the seam so the machine wires (and clears) the wrapped state's own
+                // report slots, exactly as it would for the bare state.
+                table[i] = logicNode.AsyncLogic as ILogReporter
+                           ?? logicNode.Logic as ILogReporter
+                           ?? LogicWrappers.ResolveThroughWrappers<ILogReporter>(logicNode);
             }
         }
 

--- a/NxGraph/Fsm/Async/AsyncStateMachine.cs
+++ b/NxGraph/Fsm/Async/AsyncStateMachine.cs
@@ -932,6 +932,8 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                             LastOutcome = OutcomeOf(_current);
                             return Result.Success;
                         }
+
+                        next = CanonicalId(next);
                     }
                     // Sync directors (ChoiceState/SwitchState behind a SyncLogicAdapter) route
                     // here too — mirroring the sync runtime's `Logic is IDirector` check, and
@@ -944,6 +946,8 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                             LastOutcome = OutcomeOf(_current);
                             return Result.Success;
                         }
+
+                        next = CanonicalId(next);
                     }
                     else
                     {
@@ -1056,6 +1060,17 @@ public class AsyncStateMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             }
         }
     }
+
+    /// <summary>
+    /// Replaces a director-selected id with the graph's own id for that index. Directors
+    /// (choice/switch/event dispatch) hold targets captured at authoring time, before
+    /// <c>Build()</c> applied display names, so routing on them directly would hand observers
+    /// a nameless id for the node the director jumps to — while ordinary edge destinations
+    /// (renamed at <c>Build()</c>) observe under their built ids. Identity is the index, so
+    /// this changes nothing about routing. An index the graph does not know passes through
+    /// untouched and fails on the next step with the existing "node not found" error.
+    /// </summary>
+    private NodeId CanonicalId(NodeId id) => Graph.TryGetNode(id, out INode? node) ? node!.Id : id;
 
     private async ValueTask LogReportCallback(string message, CancellationToken ct)
     {

--- a/NxGraph/Fsm/Async/AsyncTimeoutState.cs
+++ b/NxGraph/Fsm/Async/AsyncTimeoutState.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using NxGraph.Blackboards;
 using NxGraph.Graphs;
 
 namespace NxGraph.Fsm.Async;
@@ -8,6 +9,12 @@ namespace NxGraph.Fsm.Async;
 /// If the inner node does not complete within the timeout, the wrapper either
 /// returns <see cref="Result.Failure"/> or throws <see cref="TimeoutException"/>,
 /// depending on <see cref="TimeoutBehavior"/>.
+/// <para>
+/// The wrapper is transparent to machine wiring: the blackboard context stamped on it is
+/// forwarded to the wrapped state (<see cref="IBlackboardSettable"/>), and agent stamping and
+/// log-report wiring resolve through it via <see cref="ILogicWrapper"/> — a timeout around a
+/// blackboard-using, logging, or agent-taking state behaves exactly like the bare state.
+/// </para>
 /// </summary>
 /// <remarks>
 /// Pooling characteristic: timeout executions rent their <see cref="CancellationTokenSource"/>
@@ -17,7 +24,7 @@ namespace NxGraph.Fsm.Async;
 /// a burst leaves behind at most burst-width retained instances rather than churn. Processes
 /// with rare, very wide bursts pay that retained memory for the process lifetime.
 /// </remarks>
-public class AsyncTimeoutState : IAsyncLogic
+public class AsyncTimeoutState : IAsyncLogic, IBlackboardSettable, ILogicWrapper
 {
     private readonly IAsyncLogic _inner;
     private readonly TimeSpan _timeout;
@@ -36,6 +43,20 @@ public class AsyncTimeoutState : IAsyncLogic
         _timeout = timeout;
         _behavior = behavior;
         _timeoutMessage = $"Node timed out after {timeout}.";
+    }
+
+    object ILogicWrapper.WrappedLogic => _inner;
+
+    /// <summary>
+    /// Forwards the machine-stamped blackboard context to the wrapped state, so a
+    /// blackboard-using state keeps its board context when decorated with a timeout.
+    /// Forward-only: the wrapper holds no board state of its own.
+    /// </summary>
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        IBlackboardSettable? settable =
+            _inner as IBlackboardSettable ?? (_inner as SyncLogicAdapter)?.Logic as IBlackboardSettable;
+        settable?.SetBlackboards(in context);
     }
 
     public async ValueTask<Result> ExecuteAsync(CancellationToken ct = default)

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -778,6 +778,8 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
                         LastOutcome = OutcomeOf(_current);
                         return Result.Success;
                     }
+
+                    next = CanonicalId(next);
                 }
                 else
                 {
@@ -865,6 +867,16 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
                 throw new InvalidOperationException("Unknown node result.");
         }
     }
+
+    /// <summary>
+    /// Replaces a director-selected id with the graph's own id for that index — the sync twin
+    /// of <see cref="AsyncStateMachine"/>'s canonicalization. Directors hold targets captured
+    /// at authoring time, before <c>Build()</c> applied display names, so routing on them
+    /// directly would hand observers a nameless id for the node the director jumps to.
+    /// Identity is the index; unknown indexes pass through and fail on the next tick with the
+    /// existing "node not found" error.
+    /// </summary>
+    private NodeId CanonicalId(NodeId id) => Graph.TryGetNode(id, out INode? node) ? node!.Id : id;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void LogReportCallback(string message)

--- a/NxGraph/Fsm/StateMachine.cs
+++ b/NxGraph/Fsm/StateMachine.cs
@@ -328,7 +328,11 @@ public class StateMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
         {
             if (graph.TryGetNodeByIndex(i, out INode? node) && node is LogicNode logicNode)
             {
-                table[i] = logicNode.Logic as State;
+                // Decorator logic (timeout wrappers) hides the state it wraps — resolve
+                // through the seam so the machine wires (and clears) the wrapped state's own
+                // report slots, exactly as it would for the bare state.
+                table[i] = logicNode.Logic as State
+                           ?? LogicWrappers.ResolveThroughWrappers<State>(logicNode);
             }
         }
 

--- a/NxGraph/Fsm/TimeoutState.cs
+++ b/NxGraph/Fsm/TimeoutState.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using NxGraph.Blackboards;
 using NxGraph.Compatibility;
 using NxGraph.Graphs;
 
@@ -19,8 +20,13 @@ namespace NxGraph.Fsm;
 /// the deadline cannot interrupt a node mid-execution — it is detected <b>between</b> ticks,
 /// after the inner logic returns. No CTS, no timers, no allocation on the happy path.
 /// </para>
+/// <para>
+/// Like the async twin, the wrapper is transparent to machine wiring: the blackboard context
+/// stamped on it is forwarded to the wrapped state (<see cref="IBlackboardSettable"/>), and
+/// agent stamping and log-report wiring resolve through it via <see cref="ILogicWrapper"/>.
+/// </para>
 /// </summary>
-public sealed class TimeoutState : ILogic
+public sealed class TimeoutState : ILogic, IBlackboardSettable, ILogicWrapper
 {
     private readonly ILogic _inner;
     private readonly TimeoutBehavior _behavior;
@@ -53,6 +59,21 @@ public sealed class TimeoutState : ILogic
         _timeoutTimestampTicks = (long)(timeout.TotalSeconds * Stopwatch.Frequency);
         _clock = clock;
         _timeoutMessage = $"Node timed out after {timeout}.";
+    }
+
+    object ILogicWrapper.WrappedLogic => _inner;
+
+    /// <summary>
+    /// Forwards the machine-stamped blackboard context to the wrapped state, so a
+    /// blackboard-using state keeps its board context when decorated with a timeout.
+    /// Forward-only: the wrapper holds no board state of its own.
+    /// </summary>
+    void IBlackboardSettable.SetBlackboards(in BlackboardContext context)
+    {
+        if (_inner is IBlackboardSettable settable)
+        {
+            settable.SetBlackboards(in context);
+        }
     }
 
     public Result Execute()

--- a/NxGraph/Graphs/Graph.cs
+++ b/NxGraph/Graphs/Graph.cs
@@ -336,7 +336,24 @@ public sealed class Graph : INode, IGraph
                 ?? logicNode.Logic as ISubGraphProvider;
             if (provider is null)
             {
-                continue;
+                // Decorator logic (ILogicWrapper — e.g. the timeout wrappers) hides what it
+                // wraps from this walk. Agent stamping is generic in the agent type, so a
+                // non-generic wrapper cannot forward it itself — reach through the layers so
+                // an agent-taking state keeps its agent when decorated, and a decorated
+                // composite still surfaces its children.
+                if (LogicWrappers.ResolveThroughWrappers<IAgentSettable<TAgent>>(logicNode)
+                    is { } wrappedSettable)
+                {
+                    wrappedSettable.SetAgent(agent);
+                    found = true;
+                    continue;
+                }
+
+                provider = LogicWrappers.ResolveThroughWrappers<ISubGraphProvider>(logicNode);
+                if (provider is null)
+                {
+                    continue;
+                }
             }
 
             foreach (Graph nested in provider.SubGraphs)

--- a/NxGraph/Graphs/ILogicWrapper.cs
+++ b/NxGraph/Graphs/ILogicWrapper.cs
@@ -1,0 +1,59 @@
+namespace NxGraph.Graphs;
+
+/// <summary>
+/// The wiring seam for decorator nodes: a node logic that wraps another logic instance
+/// (e.g. the timeout wrappers) exposes the wrapped instance so machine wiring that cannot be
+/// forwarded interface-to-interface reaches through the decorator — agent stamping (generic
+/// in the agent type, so a non-generic wrapper cannot implement it) and the log-report
+/// resolution the machines perform at construction (the sync slot lives on the
+/// <c>State</c> base class, not on an interface). Blackboard stamping is forwarded by the
+/// wrapper itself via <see cref="NxGraph.Blackboards.IBlackboardSettable"/> — a decorator
+/// holds no wiring state of its own, it only passes the machine's wiring through.
+/// </summary>
+public interface ILogicWrapper
+{
+    /// <summary>The logic instance this decorator wraps.</summary>
+    object WrappedLogic { get; }
+}
+
+/// <summary>
+/// Resolution through decorator layers, shared by the wiring walks and the machines'
+/// construction-time report tables. Cold path by contract (construction / run-start walks);
+/// the per-layer step is two type tests, no allocation.
+/// </summary>
+internal static class LogicWrappers
+{
+    /// <summary>
+    /// Finds the first <typeparamref name="T"/> reachable from the node's logic slots by
+    /// stepping through decorator (<see cref="ILogicWrapper"/>) and
+    /// <see cref="SyncLogicAdapter"/> layers. The node's own top-level logic is deliberately
+    /// not probed — callers keep their existing direct probes; this helper only reaches
+    /// <i>through</i> wrappers. Wrapper chains are acyclic by construction (the wrapped
+    /// instance is a constructor argument), so the walk terminates.
+    /// </summary>
+    internal static T? ResolveThroughWrappers<T>(LogicNode node) where T : class
+    {
+        return FromChain(node.AsyncLogic) ?? (node.Logic is { } logic ? FromChain(logic) : null);
+
+        static T? FromChain(object outer)
+        {
+            object? current = (outer as ILogicWrapper)?.WrappedLogic;
+            while (current is not null)
+            {
+                if (current is T match)
+                {
+                    return match;
+                }
+
+                current = current switch
+                {
+                    ILogicWrapper wrapper => wrapper.WrappedLogic,
+                    SyncLogicAdapter adapter => adapter.Logic,
+                    _ => null,
+                };
+            }
+
+            return null;
+        }
+    }
+}

--- a/NxGraph/Tokens/AsyncTokenMachine.cs
+++ b/NxGraph/Tokens/AsyncTokenMachine.cs
@@ -887,6 +887,11 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                             .ConfigureAwait(false);
                         return;
                     }
+
+                    // Director targets are captured at authoring time, before Build() applied
+                    // display names — canonicalize so OnTransition reports the built id, like
+                    // edge destinations do. Arrival events already resolve via IdOf.
+                    next = CanonicalId(next);
                 }
                 else if (logicNode.Logic is IDirector syncDirector)
                 {
@@ -897,6 +902,8 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
                             .ConfigureAwait(false);
                         return;
                     }
+
+                    next = CanonicalId(next);
                 }
                 else
                 {
@@ -1185,6 +1192,13 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
     }
 
     private NodeId IdOf(int index) => Graph.GetNodeByIndex(index).Id;
+
+    /// <summary>
+    /// Replaces a director-selected id with the graph's own id for that index (see the FSM
+    /// machines' twin). Unknown indexes pass through untouched and fail at arrival exactly
+    /// as they do today.
+    /// </summary>
+    private NodeId CanonicalId(NodeId id) => Graph.TryGetNode(id, out INode? node) ? node!.Id : id;
 
     private async ValueTask LogReportCallback(string message, CancellationToken ct)
     {

--- a/NxGraph/Tokens/AsyncTokenMachine.cs
+++ b/NxGraph/Tokens/AsyncTokenMachine.cs
@@ -132,7 +132,11 @@ public class AsyncTokenMachine : AsyncState, ISubGraphProvider, IBlackboardBinda
             _joins[i] = logicNode.Logic as JoinState ?? logicNode.AsyncLogic as JoinState;
             anyJoin |= _joins[i] is not null;
             _settables[i] = logicNode.AsyncLogic as IBlackboardSettable ?? logicNode.Logic as IBlackboardSettable;
-            _reporters[i] = logicNode.AsyncLogic as ILogReporter ?? logicNode.Logic as ILogReporter;
+            // Decorator logic (timeout wrappers) hides the reporter it wraps — resolve
+            // through the seam so the machine wires the wrapped state's own report slots.
+            _reporters[i] = logicNode.AsyncLogic as ILogReporter
+                            ?? logicNode.Logic as ILogReporter
+                            ?? LogicWrappers.ResolveThroughWrappers<ILogReporter>(logicNode);
         }
 
         _joinArrivals = anyJoin ? new int[graph.NodeCount] : null;

--- a/NxGraph/Tokens/TokenMachine.cs
+++ b/NxGraph/Tokens/TokenMachine.cs
@@ -765,6 +765,11 @@ public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
                         RetireToken(t, logicNode.Id, TokenRetireReason.Completed);
                         return;
                     }
+
+                    // Director targets are captured at authoring time, before Build() applied
+                    // display names — canonicalize so OnTransition reports the built id, like
+                    // edge destinations do. Arrival events already resolve via IdOf.
+                    next = CanonicalId(next);
                 }
                 else
                 {
@@ -987,6 +992,13 @@ public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
     }
 
     private NodeId IdOf(int index) => Graph.GetNodeByIndex(index).Id;
+
+    /// <summary>
+    /// Replaces a director-selected id with the graph's own id for that index (see the FSM
+    /// machines' twin). Unknown indexes pass through untouched and fail at arrival exactly
+    /// as they do today.
+    /// </summary>
+    private NodeId CanonicalId(NodeId id) => Graph.TryGetNode(id, out INode? node) ? node!.Id : id;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void LogReportCallback(string message)

--- a/NxGraph/Tokens/TokenMachine.cs
+++ b/NxGraph/Tokens/TokenMachine.cs
@@ -163,7 +163,10 @@ public class TokenMachine : State, ISubGraphProvider, IBlackboardBindable, IBlac
             _joins[i] = logicNode.Logic as JoinState ?? logicNode.AsyncLogic as JoinState;
             anyJoin |= _joins[i] is not null;
             _settables[i] = logicNode.AsyncLogic as IBlackboardSettable ?? logicNode.Logic as IBlackboardSettable;
-            _logReportStates[i] = logicNode.Logic as State;
+            // Decorator logic (timeout wrappers) hides the state it wraps — resolve through
+            // the seam so the machine wires the wrapped state's own report slots.
+            _logReportStates[i] = logicNode.Logic as State
+                                  ?? LogicWrappers.ResolveThroughWrappers<State>(logicNode);
         }
 
         _joinArrivals = anyJoin ? new int[graph.NodeCount] : null;


### PR DESCRIPTION
Two wiring gaps, both found by a downstream consumer that observes runs and wraps steps in timeouts.

## What was broken

**1. Observers saw a nameless id for the node a dispatch or plain start jumps to.** Directors — the event-entry dispatcher (`StartWithEvents`), the plain-run `Otherwise` route, `ChoiceState`/`SwitchState`, and any user director — hold target `NodeId`s captured at authoring time, before `Build()` applies display names. The run loops routed on those raw ids, so `OnTransition`/`OnStateEntered`/`OnStateExited` for the first node of every entry chain carried an empty `Name` (a single-step chain never surfaced a named event at all), while every ordinary edge hop reported the built, named id. Any observer that keys on `NodeId.Name` — progress publishers, trace tooling — silently dropped the first authored step of every chain.

**2. The timeout wrappers swallowed machine wiring.** `AsyncTimeoutState`/`TimeoutState` implemented only the logic interface, so the blackboard stamping walk, agent stamping, and the machines' log-report resolution all stopped at the wrapper: a blackboard-using state inside a timeout lost its board context, its `Log` calls went nowhere, and a graph whose only agent acceptor sat inside a timeout made `SetAgent` throw "no nodes implement IAgentSettable".

## What changed

- All four run loops (sync/async FSM, sync/async token) canonicalize a director-selected id against the graph before routing, so observers see the built id exactly as they do for edge destinations. Identity is the index, so routing is unchanged; an unknown index still fails with the existing node-not-found error.
- Both timeout wrappers forward the stamped blackboard context to the wrapped state (`IBlackboardSettable`, forward-only — the wrapper holds no board state, so nothing is duplicated).
- A new `ILogicWrapper` seam (`WrappedLogic`) exposes the wrapped instance for the wiring that cannot be forwarded interface-to-interface: agent stamping is generic in the agent type, and the sync report slot lives on the `State` base class. The graph's agent walk and all four machines' report tables resolve through decorator layers, so the wrapped state's own slots are wired and cleared exactly as if it were bare. A decorated composite still surfaces its children to the agent walk.
- Public API baselines record the new surface (`ILogicWrapper`, the wrappers' interface lists).

## Other wrappers checked

`SyncLogicAdapter` was already unwrapped at the `LogicNode` level; `AllState`/`AsyncAllState` hold delegates that receive the routed context as a parameter; the machine-wrapping composites already implement `IBlackboardSettable`/`ISubGraphProvider`. The two timeout states were the only decorators with the hole.

## Resume semantics

Untouched. `Resume`/`ResumeDeep` already restore the current node from the graph's own node table (built ids), and restore deliberately replays no observer events — both fixes only affect the live routing/wiring paths.

## Tests

- `DirectorTargetObservationTests` (9): entered/exited/transition ids carry the built name for an event dispatch target (full-run and stepped), the plain-start `Otherwise` target, a single-step entry chain, and choice branch targets — sync and async; plus a single-node-graph pin. All fail before the fix.
- `TimeoutWiringForwardingTests` (7): board, log report, and agent reach a state inside the async and sync timeout wrappers, including the sync-state-under-async-machine bridge case. All fail before the fix.
- Full suite green: 721 + 203 (was 705 + 203 at baseline).

## Downstream note

The Aitomata consumer (project reference against this checkout) was smoke-checked with its full acceptance harness after both fixes: everything green — 222 backend tests plus the frontend phase, no test there asserted the old missing-first-step behavior. Its run-progress publisher now correctly emits step-started/step-finished for the first authored step of every chain, and its `StepTimeoutState` forwarding-subclass workaround (which forwards `IBlackboardSettable`/`ILogReporter` itself) keeps working unchanged and can be retired at the consumer's leisure.
