### PR TITLE
Release prep for 2.2.0-alpha: bump UPM manifest, changelog, and install pin

### DIFF
--- a/NxGraph.Build/Program.cs
+++ b/NxGraph.Build/Program.cs
@@ -11,11 +11,17 @@ public static class Program
     // different SDK mid-run if the environment changes.
     private static DotNetLocator.Result? _dotnet;
 
+    // Source staging is an explicit allowlist: a folder that is not named here is silently
+    // absent from the staged package, and source mode then fails to compile at the consumer.
+    // Keep it in step with the core project's folders — every folder under NxGraph/ that holds
+    // compiled code belongs here (Docs holds markdown only).
     private static readonly string[] DirectoriesToCopy =
     [
         Path.Combine("Authoring"),
+        Path.Combine("Behaviors"),
         Path.Combine("Blackboards"),
         Path.Combine("Compatibility"),
+        Path.Combine("Conditions"),
         Path.Combine("Diagnostics", "Export"),
         Path.Combine("Diagnostics", "Replay"),
         Path.Combine("Diagnostics", "Validations"),
@@ -29,6 +35,8 @@ public static class Program
     [
         "Result.cs",
         "ResultHelpers.cs",
+        // The sync/async report bridge State.Log and the behavior composites both call.
+        "ValueTaskSync.cs",
     ];
 
     private static readonly string[] ExcludedFiles =

--- a/upm/com.enzx.nxgraph/CHANGELOG.md
+++ b/upm/com.enzx.nxgraph/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this package will be documented in this file.
 - Serialization payload versions 7–10: event entry sections, behavior sections, nested behavior entries, and the choice/switch branch sections ride the graph payload — the last with an `ISerializableCondition` / `ConditionRegistry` pair mirroring the behavior registry, so branch graphs round-trip with zero serializer options. Read paths are hardened and the blackboard `Skip` restore policy never resets a board without restoring at least one value. Each version reads its predecessors unchanged.
 
 ### Package
+- Source staging now includes the `Behaviors` and `Conditions` folders and `ValueTaskSync.cs`. The staging list is an explicit allowlist and unlisted files are dropped silently, so a source-mode package built before this fix was missing the behavior composites, the condition set, and the sync/async report bridge they and `State.Log` call.
 - The netstandard2.1 (Unity-facing) public API surface now has its own approved baseline, so Unity-visible API changes are caught explicitly.
 - Analyzer warnings are errors across the build; the staged runtime compiles warning-free under the stricter regime.
 

--- a/upm/com.enzx.nxgraph/CHANGELOG.md
+++ b/upm/com.enzx.nxgraph/CHANGELOG.md
@@ -2,15 +2,25 @@
 
 All notable changes to this package will be documented in this file.
 
-## [Unreleased]
-
-### Runtime (staged NxGraph core)
-- **Data-built branching**: `ChoiceState(conditions, ConditionMatch.All|Any, trueTarget, falseTarget)` and `SwitchState<T>(key, literal cases, defaultTarget)` decide from data instead of a closure, so a branching graph rides the serialization payload with zero serializer options and survives suspend/resume. Conditions live in `NxGraph.Conditions` (`ICondition`, `KeyEquals<T>`, `IsTrue`, `Not`), reuse the behavior model's `BehaviorContext`, and reuse none of the fault model — a false condition is a decision, never a node failure. Author with `.If(condition)`, `.If(ConditionMatch.Any, …)`, and `.Switch(blackboardKey).Case(value, …).Default(…).End()`.
-- Mermaid export labels data-built arms (`true` / `false`, the case literal, `otherwise`), and the validator warns on a choice whose arms are the same node and on a switch with no default target.
-- Serialization payload version 10: sparse choice and switch sections, with an `ISerializableCondition` / `ConditionRegistry` pair mirroring the behavior registry. Version 9 payloads read branch-free.
+## [2.2.0-alpha]
 
 ### Breaking
-- The delegate-backed director states were renamed: `ChoiceState` → `RelayChoiceState`, `SwitchState<TKey>` → `RelaySwitchState<TKey>`, `AsyncChoiceState` → `AsyncRelayChoiceState`, `AsyncSwitchState<TKey>` → `AsyncRelaySwitchState<TKey>`. Behavior and constructors are unchanged, and the `.If(predicate)` / `.Switch(selector)` DSL paths still build them. **No obsolete forwarding aliases exist**: the old names are reused in the same release for the new data-built states, so an alias would silently compile old code into a state that means something else. Update the type names; the compiler error is the migration instruction.
+- The delegate-backed director states were renamed: `ChoiceState` → `RelayChoiceState`, `SwitchState<TKey>` → `RelaySwitchState<TKey>`, `AsyncChoiceState` → `AsyncRelayChoiceState`, `AsyncSwitchState<TKey>` → `AsyncRelaySwitchState<TKey>`. Behavior and constructors are unchanged, and the `.If(predicate)` / `.Switch(selector)` DSL paths still build them. **No obsolete forwarding aliases exist**: the old names are reused in this same release for the new data-built states, so an alias would silently compile old code into a state that means something else. Update the type names; the compiler error is the migration instruction.
+
+### Runtime (staged NxGraph core)
+- **Data-built branching**: `ChoiceState(conditions, ConditionMatch.All|Any, trueTarget, falseTarget)` and `SwitchState<T>(key, literal cases, defaultTarget)` decide from data instead of a closure, so a branching graph rides the serialization payload with zero serializer options and survives suspend/resume. Conditions live in `NxGraph.Conditions` (`ICondition`, `KeyEquals<T>`, `IsTrue`, `Not`), reuse the behavior model's `BehaviorContext`, and reuse none of the fault model — a false condition is a decision, never a node failure. Author with `.If(condition)`, `.If(ConditionMatch.Any, …)`, and `.Switch(blackboardKey).Case(value, …).Default(…).End()`; a switch is a lookup (literal cases, duplicates rejected at build time) and ordered first-match-wins rules lower to a chain of choices.
+- Typed event entry points: `GraphBuilder.StartWithEvents()` builds one graph with N externally-raised entry chains (`.On(key, e => chain)`, `.Otherwise(...)`); raise with `Execute<TEvent>(evt)` / `ExecuteAsync<TEvent>(evt, ct)` / `StepAsync<TEvent>(evt, ct)`. Event payloads deliver through Graph-scoped blackboard keys, so payload durability falls out of the existing blackboard artifacts.
+- Declarative behaviors: author a node as an ordered, fail-fast list of small data-shaped behaviors (`.ToBehaviors(...)` / `.ToBehaviorsAsync(...)`, plus typed-agent variants). `BlackboardValue<T>` binds each field to a literal or a blackboard key; the standard set ships `Log` and `SetValue<T>`, and `Repeat` adds bounded sub-node iteration in both runtimes.
+- Machine lifecycle hardening: run-start initialization is throw-hardened on all four machines (a throwing observer or context stamp repairs status back to Ready and releases the execute gate), sync `Reset()` is idempotent from every status, and every `Resume` rejects snapshots with undefined execution statuses.
+- `State.Log` now delivers to the attached observer under both runtimes, and machines sharing a graph each attribute log reports to their own observer. The report channel is a capability rather than a base-class membership, so a node that is not a `State` subclass — a data-built branch, for instance — reaches the observer too, and a condition can report the decision it just made.
+- Director-selected next nodes (choice/switch) are reported to observers under their built ids, and timeout wrappers forward machine wiring to the logic they wrap.
+- Cross-runtime behavior is pinned by a parity conformance suite comparing sync/async × full-run/stepped runs as order-exact traces.
+- Validation is self-sufficient (the node set derives from the graph itself); the Mermaid exporter escapes director labels correctly and labels data-built branch arms (`true` / `false`, the case literal, `otherwise`). The validator warns on a choice whose arms are the same node and on a switch with no default target.
+- Serialization payload versions 7–10: event entry sections, behavior sections, nested behavior entries, and the choice/switch branch sections ride the graph payload — the last with an `ISerializableCondition` / `ConditionRegistry` pair mirroring the behavior registry, so branch graphs round-trip with zero serializer options. Read paths are hardened and the blackboard `Skip` restore policy never resets a board without restoring at least one value. Each version reads its predecessors unchanged.
+
+### Package
+- The netstandard2.1 (Unity-facing) public API surface now has its own approved baseline, so Unity-visible API changes are caught explicitly.
+- Analyzer warnings are errors across the build; the staged runtime compiles warning-free under the stricter regime.
 
 ## [2.1.0-alpha]
 

--- a/upm/com.enzx.nxgraph/README.md
+++ b/upm/com.enzx.nxgraph/README.md
@@ -31,7 +31,7 @@ Or pin a specific release tag:
 ```json
 {
   "dependencies": {
-    "com.enzx.nxgraph": "https://github.com/Enzx/NxGraph.git#upm/v2.1.0-alpha"
+    "com.enzx.nxgraph": "https://github.com/Enzx/NxGraph.git#upm/v2.2.0-alpha"
   }
 }
 ```

--- a/upm/com.enzx.nxgraph/package.json
+++ b/upm/com.enzx.nxgraph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.enzx.nxgraph",
   "displayName": "NxGraph",
-  "version": "2.1.0-alpha",
+  "version": "2.2.0-alpha",
   "description": "A lean, high-performance finite state machine / stateflow library for Unity with a fluent authoring DSL, validation, replay, and Mermaid export.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Release prep for **2.2.0-alpha**, per the UPM release checklist (three artifacts, one version):

- `package.json` version → `2.2.0-alpha`
- `CHANGELOG.md` → new `[2.2.0-alpha]` entry covering everything merged since the 2.1.0-alpha tag
- UPM `README.md` install pin → `upm/v2.2.0-alpha`

Rebased onto `main` after #67 (data-built branching) merged, so the entry now covers that too.

## What the release contains

**Breaking** — the delegate-backed director states were renamed (`ChoiceState` → `RelayChoiceState`, `SwitchState<TKey>` → `RelaySwitchState<TKey>`, and both async twins), with **no forwarding aliases**, because the old names are reused in this same release for the new data-built states. Consumer code fails to compile until the type names are updated; that is deliberate, and the changelog leads with it. The version stays `2.2.0-alpha` rather than taking a major bump — this is a pre-stable alpha line.

**Runtime** — data-built branching (serializable `ChoiceState` / `SwitchState<T>` deciding from `ICondition` lists or literal cases), typed event entry points, declarative behaviors with bounded repetition, machine lifecycle hardening, the cross-runtime log-report bridge (now a capability, so non-`State` nodes such as branches reach the observer too), director target observation under built ids, timeout wrapper wiring forwarding, self-sufficient validation plus labelled Mermaid branch arms, and serialization payload versions 7–10 with hardened read paths.

**Package** — the netstandard2.1 API baseline, analyzers-as-errors, and the source-staging fix below.

## Release blocker found while preparing this

`NxGraph.Build`'s source-staging list is an explicit allowlist, and anything unlisted is dropped **silently** — the copy loop only reports folders it was asked for and could not find. It was missing the `Behaviors` and `Conditions` folders and `ValueTaskSync.cs`, so a **source-mode** package built from this release would not have compiled at the consumer: the behavior composites, the condition set, and the sync/async report bridge that `State.Log` and the composites both call were all absent. Binary mode is the release default, which is why this went unnoticed since the behaviors feature landed.

Fixed in this PR, with a comment on the list recording that it is an allowlist that must track the core project's folders. Verified by running `stage-source` and confirming all three appear in the staged output.

## Verification

`dotnet run --project NxGraph.Build -- ci` on this branch: green, 0 warnings, 840 core + 235 serialization tests, 83% line coverage.

## After merge

Tag `v2.2.0-alpha` (publishes all three NuGet packages) and `upm/v2.2.0-alpha` (UPM release, binary mode) on the merge commit.
